### PR TITLE
Refine state-machine input routing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@mariozechner/pi-agent-core": "^0.70.6",
         "@mariozechner/pi-ai": "^0.70.6",
         "@mariozechner/pi-coding-agent": "^0.70.6",
+        "ajv": "^8.20.0",
         "dedent": "^1.7.2",
         "dotenv": "^17.4.2",
         "eventemitter3": "^5.0.0",
@@ -380,6 +381,8 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -452,6 +455,10 @@
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
     "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
@@ -511,6 +518,8 @@
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "jstoxml": ["jstoxml@7.1.0", "", {}, "sha512-IUETuZk3Gza+5xcG85DA00UuBXjpvyDsHXuSgj/wk6WtLSRDBSYNFNG/bGvUR8jzC0cyk2Xe9uL6qi4tTAOaGg=="],
 
@@ -585,6 +594,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 

--- a/evals/outreach-lifecycle.eval.ts
+++ b/evals/outreach-lifecycle.eval.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { TurnRunner } from "../src/turn-runner/turn-runner.js";
+import type { TurnTerminalEvent } from "../src/types/protocol.js";
+import type { StateMachineDefinition } from "../src/types/state-machine.js";
+
+const model = process.env.EVAL_MODEL ?? "vercel-ai-gateway:anthropic/claude-opus-4.7";
+
+describe("outreach lifecycle state machine", () => {
+  test("runs research, outreach, wait, reply classification, and terminal completion", async () => {
+    const runner = new TurnRunner({
+      model,
+      mode: outreachDefinition,
+      skillDiscovery: { includeDefaults: false },
+      systemInstructions: [
+        "This is an eval. Use the state-machine tools for the durable outreach workflow.",
+        "Select states in this order: research_prospect, send_outreach, wait_for_reply, fetch_reply, classify_reply, meeting_scheduled.",
+        "When selecting a state with inputSchema, provide the required input object.",
+        "Do not ask the user questions.",
+      ].join("\n"),
+    });
+
+    const first = await runner.turn({
+      type: "start",
+      mode: outreachDefinition,
+      prompt:
+        "Run the outreach lifecycle for Ada Lovelace at ada@example.com. The fake reply says she is interested in a meeting.",
+    });
+
+    expect(first.type).toBe("sleep");
+    expect(first.state.stateMachine?.currentState).toBe("wait_for_reply");
+
+    await delay(10_100);
+
+    const terminal = await runner.turn({ type: "wake", state: first.state });
+
+    expect(terminal.type).toBe("complete");
+    expect(terminal.type === "complete" ? terminal.status : undefined).toBe("completed");
+    expect(terminal.state.stateMachine?.terminal).toMatchObject({
+      state: "meeting_scheduled",
+      status: "completed",
+    });
+    expect(completedStates(terminal)).toEqual([
+      "research_prospect",
+      "send_outreach",
+      "wait_for_reply",
+      "fetch_reply",
+      "classify_reply",
+    ]);
+  }, 120_000);
+});
+
+const outreachDefinition: StateMachineDefinition = {
+  name: "outreach_eval",
+  prompt:
+    "Use this state machine for the eval outreach lifecycle: research a prospect, send outreach, wait briefly, fetch a fake reply, classify it, and finish when a meeting should be scheduled.",
+  states: [
+    {
+      kind: "agent",
+      name: "research_prospect",
+      inputSchema: {
+        type: "object",
+        properties: {
+          prospectName: { type: "string" },
+          company: { type: "string" },
+        },
+        required: ["prospectName", "company"],
+      },
+      prompt:
+        "Do not call tools. Write one concise research note for {{ input.prospectName }} from {{ input.company }}.",
+    },
+    {
+      kind: "script",
+      name: "send_outreach",
+      inputSchema: {
+        type: "object",
+        properties: {
+          email: { type: "string" },
+          prospectName: { type: "string" },
+        },
+        required: ["email", "prospectName"],
+      },
+      command:
+        'printf \'{"sent":true,"email":"{{ input.email }}","messageId":"eval-message-1","prospectName":"{{ input.prospectName }}"}\'',
+    },
+    {
+      kind: "poll",
+      name: "wait_for_reply",
+      intervalMs: 10_000,
+      timeoutMs: 30_000,
+      poll: { kind: "timer" },
+    },
+    {
+      kind: "script",
+      name: "fetch_reply",
+      inputSchema: {
+        type: "object",
+        properties: {
+          messageId: { type: "string" },
+        },
+        required: ["messageId"],
+      },
+      command:
+        'printf \'{"reply":"Thanks for reaching out. I am interested in scheduling a meeting next week.","messageId":"{{ input.messageId }}"}\'',
+    },
+    {
+      kind: "agent",
+      name: "classify_reply",
+      inputSchema: {
+        type: "object",
+        properties: {
+          reply: { type: "string" },
+        },
+        required: ["reply"],
+      },
+      prompt:
+        "Do not call tools. Classify this outreach reply as interested, negative, question, neutral, or unclear. Reply with one sentence. Reply: {{ input.reply }}",
+    },
+    {
+      kind: "terminal",
+      name: "meeting_scheduled",
+      status: "completed",
+      reason: "The fake reply was classified as interested.",
+    },
+  ],
+};
+
+function completedStates(terminal: TurnTerminalEvent): string[] {
+  return (
+    terminal.state.stateMachine?.history
+      .filter((event) => event.type === "state_completed")
+      .map((event) => event.state) ?? []
+  );
+}

--- a/evals/state-template.eval.ts
+++ b/evals/state-template.eval.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import {
+  TurnRunner,
+  type AgentWorkerInput,
+  type AgentWorkerResult,
+} from "../src/turn-runner/turn-runner.js";
+import type { TurnRunnerControlResult } from "../src/turn-runner/tools.js";
+import type { StateMachineDefinition } from "../src/types/state-machine.js";
+
+describe("state template strings", () => {
+  test("renders transition input into agent state prompts", async () => {
+    const runner = new EvalTurnRunner();
+    runner.controlResults.push(
+      {
+        type: "select_state_machine_state",
+        decision: {
+          kind: "run_state",
+          state: "write_note",
+          input: { topic: "feature flags", audience: "release managers" },
+        },
+      },
+      {
+        type: "select_state_machine_state",
+        decision: { kind: "terminal", state: "done" },
+      },
+    );
+
+    const terminal = await runner.turn({
+      type: "start",
+      mode: templateDefinition,
+      prompt: "Write the note.",
+    });
+
+    expect(terminal.type).toBe("complete");
+    expect(runner.workerInputs[1]?.prompt).toBe("Write about feature flags for release managers.");
+  });
+
+  test("renders transition input into script state commands", async () => {
+    const runner = new EvalTurnRunner();
+    runner.controlResults.push(
+      {
+        type: "select_state_machine_state",
+        decision: {
+          kind: "run_state",
+          state: "echo_values",
+          input: { topic: "feature flags", audience: "release managers" },
+        },
+      },
+      {
+        type: "select_state_machine_state",
+        decision: { kind: "terminal", state: "done" },
+      },
+    );
+
+    const terminal = await runner.turn({
+      type: "start",
+      mode: templateDefinition,
+      prompt: "Echo the values.",
+    });
+
+    expect(terminal.type).toBe("complete");
+    const completed = terminal.state.stateMachine?.history.find(
+      (event) => event.type === "state_completed" && event.state === "echo_values",
+    );
+    expect(completed?.type === "state_completed" ? completed.output : undefined).toMatchObject({
+      parsed: { topic: "feature flags", audience: "release managers" },
+    });
+  });
+});
+
+const templateDefinition: StateMachineDefinition = {
+  name: "template_eval",
+  prompt: "Use this state machine for template rendering evals.",
+  states: [
+    {
+      kind: "agent",
+      name: "write_note",
+      inputSchema: {
+        type: "object",
+        properties: {
+          topic: { type: "string" },
+          audience: { type: "string" },
+        },
+        required: ["topic", "audience"],
+      },
+      prompt: "Write about {{ input.topic }} for {{ input.audience }}.",
+    },
+    {
+      kind: "script",
+      name: "echo_values",
+      inputSchema: {
+        type: "object",
+        properties: {
+          topic: { type: "string" },
+          audience: { type: "string" },
+        },
+        required: ["topic", "audience"],
+      },
+      command: 'printf \'{"topic":"{{ input.topic }}","audience":"{{ input.audience }}"}\'',
+    },
+    { kind: "terminal", name: "done", status: "completed" },
+  ],
+};
+
+class EvalTurnRunner extends TurnRunner {
+  readonly workerInputs: AgentWorkerInput[] = [];
+  readonly controlResults: TurnRunnerControlResult[] = [];
+
+  constructor() {
+    super({
+      model: "anthropic:claude-opus-4-7",
+      skillDiscovery: { includeDefaults: false },
+    });
+  }
+
+  protected override async runAgentWorker(input: AgentWorkerInput): Promise<AgentWorkerResult> {
+    this.workerInputs.push(input);
+    const control = this.controlResults.shift() ?? { type: "none" };
+    const resultText = `Completed: ${input.prompt}`;
+    const assistantMessage: AssistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: resultText }],
+      api: "unknown",
+      provider: "unknown",
+      model: "eval",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+    const state = {
+      ...input.state,
+      status: "completed" as const,
+      agent: {
+        status: "completed" as const,
+        messages: [...input.state.agent.messages, assistantMessage],
+      },
+    };
+
+    return {
+      control,
+      terminal: {
+        type: "complete",
+        status: "completed",
+        result: resultText,
+        state,
+      },
+    };
+  }
+}

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -26,11 +26,11 @@ async function main() {
   });
 
   console.log("\n--- Session Summary ---");
-  console.log(`Status: ${terminal.session.status}`);
+  console.log(`Status: ${terminal.state.status}`);
   if (terminal.type === "complete" && terminal.error) {
     console.error(`Error: ${terminal.error}`);
   }
-  console.log(terminal.session.stateMachine ? "State machine session" : "Agent session");
+  console.log(terminal.state.stateMachine ? "State machine session" : "Agent session");
 }
 
 main().catch(console.error);

--- a/examples/state-machine.ts
+++ b/examples/state-machine.ts
@@ -18,7 +18,6 @@ const definition: StateMachineDefinition = {
       when: "The user needs the brief written.",
       prompt:
         "Write a concise brief for the user's request. Keep it under 120 words and do not edit files.",
-      contextScope: "state_machine",
     },
     {
       kind: "terminal",
@@ -52,8 +51,8 @@ async function main() {
   });
 
   console.log("\n--- State Machine Summary ---");
-  console.log(`Status: ${terminal.session.status}`);
-  console.log(`Current state: ${terminal.session.stateMachine?.currentState ?? "none"}`);
+  console.log(`Status: ${terminal.state.status}`);
+  console.log(`Current state: ${terminal.state.stateMachine?.currentState ?? "none"}`);
   if (terminal.type === "complete" && terminal.error) {
     console.error(`Error: ${terminal.error}`);
   }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@mariozechner/pi-agent-core": "^0.70.6",
     "@mariozechner/pi-ai": "^0.70.6",
     "@mariozechner/pi-coding-agent": "^0.70.6",
+    "ajv": "^8.20.0",
     "dedent": "^1.7.2",
     "dotenv": "^17.4.2",
     "eventemitter3": "^5.0.0",

--- a/src/turn-runner/prompts.ts
+++ b/src/turn-runner/prompts.ts
@@ -3,10 +3,7 @@ import dedent from "dedent";
 import { toXML } from "../lib/xml.js";
 import type { TurnRunnerConfig } from "../types/config.js";
 import type { TurnMode, TurnState } from "../types/protocol.js";
-import type { StateMachineAgentState, StateMachineSession } from "../types/state-machine.js";
 import { readSkillInstructions } from "./skills.js";
-
-const STATE_AGENT_HISTORY_CHAR_LIMIT = 12_000;
 
 export function createSystemPromptWithAppendedLayers(input: {
   config: TurnRunnerConfig;
@@ -41,53 +38,13 @@ export function createStateMachineSystemPromptLayer(input: {
   return [
     "Route durable business-process work through state-machine tools whenever possible.",
     "If the request is simple or unrelated, answer normally without calling a turn-runner control tool.",
+    "State prompts and script commands may use template strings like {{ input.email }}. Add inputSchema to states that need template input, and pass matching input when selecting that state.",
+    "Use allowedSkills on agent states only when that sub-agent should receive a restricted skill set.",
     constraint,
     definitionPrompt,
   ]
     .filter(Boolean)
     .join("\n\n");
-}
-
-export function createStateAgentSystemPromptLayer(input: {
-  session: TurnState;
-  state: StateMachineAgentState;
-}): string | undefined {
-  const stateMachine = input.session.stateMachine;
-  if (!stateMachine) return undefined;
-
-  return dedent`
-    You are executing the "${input.state.name}" state in a state machine.
-
-    State prompt:
-    ${input.state.prompt}
-
-    State-machine context:
-    ${JSON.stringify(
-      {
-        originalPrompt: stateMachine.prompt,
-        state: stateMachine.state,
-        definition:
-          input.state.contextScope === "state_machine" ? stateMachine.definition : undefined,
-      },
-      null,
-      2,
-    )}
-  `;
-}
-
-export function createStateAgentPrompt(input: {
-  session: TurnState;
-  state: StateMachineAgentState;
-}): string {
-  const stateMachine = input.session.stateMachine;
-  if (!stateMachine) return input.state.prompt;
-
-  const history = createBoundedStateMachineHistory(stateMachine.history);
-  return [
-    input.state.prompt,
-    "Use this bounded state-machine history as recent context for this state:",
-    JSON.stringify(history, null, 2),
-  ].join("\n\n");
 }
 
 function createBaseSystemPrompt(config: TurnRunnerConfig, skills: readonly Skill[]): string {
@@ -111,24 +68,4 @@ function createSkillsSystemPrompt(skills: readonly Skill[]): string | undefined 
       })),
     })}
   `;
-}
-
-function createBoundedStateMachineHistory(history: StateMachineSession["history"]): {
-  omitted: number;
-  events: StateMachineSession["history"];
-} {
-  const events: StateMachineSession["history"] = [];
-  let size = 0;
-
-  for (let index = history.length - 1; index >= 0; index--) {
-    const event = history[index];
-    const eventSize = JSON.stringify(event).length;
-    if (events.length > 0 && size + eventSize > STATE_AGENT_HISTORY_CHAR_LIMIT) {
-      return { omitted: index + 1, events };
-    }
-    events.unshift(event);
-    size += eventSize;
-  }
-
-  return { omitted: 0, events };
 }

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -1,5 +1,6 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { createCodingTools } from "@mariozechner/pi-coding-agent";
+import { Ajv } from "ajv";
 import { Type, type Static } from "typebox";
 import { Value } from "typebox/value";
 import type { TurnMode, TurnQuestion } from "../types/protocol.js";
@@ -10,6 +11,8 @@ import type {
   StateMachineScriptState,
   StateMachineState,
 } from "../types/state-machine.js";
+
+const jsonSchemaValidator = new Ajv({ strictSchema: false });
 
 const questionOptionSchema = Type.Object({
   label: Type.String({ description: "Answer text shown to the user." }),
@@ -348,6 +351,7 @@ function createStateMachineDefinitionTool(): AgentTool<typeof createDefinitionSc
       "Create a state-machine definition for durable business-process work. State prompts and script commands may use template strings such as {{ input.email }}; define inputSchema on those states and pass matching input when selecting them. Agent states may set allowedSkills to restrict which skills are injected into that sub-agent. Use this only when no state machine is active or the previous state machine has reached a terminal state; otherwise use select_state_machine_state.",
     parameters: createDefinitionSchema,
     async execute(_toolCallId, params) {
+      assertValidDefinitionInputSchemas(params.definition);
       const result: TurnRunnerControlResult = {
         type: "create_state_machine_definition",
         definition: params.definition,
@@ -423,6 +427,7 @@ function assertValidSelectedState(
   if (decision.kind !== "run_state") return;
 
   const effectiveState = applyStateOverride(selectedState, decision.override);
+  assertValidStateInputSchema(effectiveState);
   assertValidStateInput(effectiveState, decision.input);
 }
 
@@ -462,4 +467,21 @@ function assertValidStateInput(state: StateMachineState, input: unknown): void {
   const path = first?.path ?? "/";
   const message = first?.message ?? "does not match schema";
   throw new Error(`Invalid input for state "${state.name}" at ${path}: ${message}`);
+}
+
+function assertValidDefinitionInputSchemas(definition: StateMachineDefinition): void {
+  for (const state of definition.states) {
+    assertValidStateInputSchema(state);
+  }
+}
+
+function assertValidStateInputSchema(state: StateMachineState): void {
+  if (!state.inputSchema) return;
+
+  if (jsonSchemaValidator.validateSchema(state.inputSchema)) return;
+
+  const message = jsonSchemaValidator.errorsText(jsonSchemaValidator.errors, {
+    dataVar: `inputSchema for state "${state.name}"`,
+  });
+  throw new Error(`Invalid inputSchema for state "${state.name}": ${message}`);
 }

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -1,6 +1,7 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { createCodingTools } from "@mariozechner/pi-coding-agent";
 import { Type, type Static } from "typebox";
+import { Value } from "typebox/value";
 import type { TurnMode, TurnQuestion } from "../types/protocol.js";
 import type {
   StateMachineAgentState,
@@ -11,65 +12,92 @@ import type {
 } from "../types/state-machine.js";
 
 const questionOptionSchema = Type.Object({
-  label: Type.String(),
-  description: Type.Optional(Type.String()),
+  label: Type.String({ description: "Answer text shown to the user." }),
+  description: Type.Optional(
+    Type.String({ description: "Optional context explaining this choice." }),
+  ),
 });
 
 const questionSchema = Type.Object({
-  question: Type.String(),
-  header: Type.Optional(Type.String()),
-  options: Type.Array(questionOptionSchema),
-  multiSelect: Type.Optional(Type.Boolean()),
+  question: Type.String({ description: "Question to ask the user." }),
+  header: Type.Optional(
+    Type.String({ description: "Optional section heading for this question." }),
+  ),
+  options: Type.Array(questionOptionSchema, {
+    description: "Answer options the user can choose from.",
+  }),
+  multiSelect: Type.Optional(
+    Type.Boolean({ description: "Whether the user may select more than one option." }),
+  ),
 });
 
 const askUserQuestionSchema = Type.Object({
-  questions: Type.Array(questionSchema),
+  questions: Type.Array(questionSchema, {
+    description: "Structured multiple-choice questions that must be answered before continuing.",
+  }),
 });
 
 type AskUserQuestionParams = Static<typeof askUserQuestionSchema>;
 
 const agentOverrideSchema = Type.Partial(
   Type.Object({
-    prompt: Type.String(),
-    contextScope: Type.Union([
-      Type.Literal("state"),
-      Type.Literal("dependencies"),
-      Type.Literal("state_machine"),
-    ]),
-    allowedSkills: Type.Array(Type.String()),
-    maxTurns: Type.Number(),
-    outputSchema: Type.Record(Type.String(), Type.Any()),
+    prompt: Type.String({ description: "Replacement user prompt for this agent state." }),
+    systemPrompt: Type.String({
+      description: "Replacement system prompt appended for this sub-agent only.",
+    }),
+    allowedSkills: Type.Array(Type.String(), {
+      description:
+        "Skill names to inject into this sub-agent. Omit to inject all available skills.",
+    }),
+    inputSchema: Type.Record(Type.String(), Type.Any(), {
+      description: "Replacement JSON Schema for transition input accepted by this state.",
+    }),
   }),
 );
 
 const scriptOverrideSchema = Type.Partial(
   Type.Object({
-    command: Type.String(),
-    cwd: Type.String(),
-    timeoutMs: Type.Number(),
-    successCodes: Type.Array(Type.Number()),
+    command: Type.String({ description: "Replacement shell command for this script state." }),
+    cwd: Type.String({ description: "Replacement working directory for the command." }),
+    timeoutMs: Type.Number({ description: "Replacement command timeout in milliseconds." }),
+    successCodes: Type.Array(Type.Number(), {
+      description: "Replacement exit codes treated as successful completion.",
+    }),
+    inputSchema: Type.Record(Type.String(), Type.Any(), {
+      description: "Replacement JSON Schema for transition input accepted by this state.",
+    }),
   }),
 );
 
 const pollAttemptSchema = Type.Union([
   Type.Object({
-    kind: Type.Literal("script"),
-    command: Type.String(),
-    cwd: Type.Optional(Type.String()),
-    successCodes: Type.Optional(Type.Array(Type.Number())),
+    kind: Type.Literal("script", { description: "Run one shell command per poll attempt." }),
+    command: Type.String({
+      description:
+        "Shell command for one poll attempt. Return non-empty JSON only when polling found a result.",
+    }),
+    cwd: Type.Optional(Type.String({ description: "Working directory for the poll command." })),
+    successCodes: Type.Optional(
+      Type.Array(Type.Number(), {
+        description: "Exit codes that mean this poll attempt found a result.",
+      }),
+    ),
   }),
   Type.Object({
-    kind: Type.Literal("prompt"),
-    prompt: Type.String(),
-    outputSchema: Type.Optional(Type.Record(Type.String(), Type.Any())),
+    kind: Type.Literal("timer", {
+      description: "Sleep once for intervalMs, then resume with elapsedMs output.",
+    }),
   }),
 ]);
 
 const pollOverrideSchema = Type.Partial(
   Type.Object({
-    intervalMs: Type.Number(),
-    timeoutMs: Type.Number(),
+    intervalMs: Type.Number({ description: "Replacement delay between poll wake attempts." }),
+    timeoutMs: Type.Number({ description: "Replacement maximum poll-state runtime." }),
     poll: pollAttemptSchema,
+    inputSchema: Type.Record(Type.String(), Type.Any(), {
+      description: "Replacement JSON Schema for transition input accepted by this state.",
+    }),
   }),
 );
 
@@ -80,52 +108,69 @@ const stateOverrideSchema = Type.Union([
 ]);
 
 const baseStateSchema = {
-  name: Type.String(),
-  when: Type.Optional(Type.String()),
+  name: Type.String({ description: "State name used by select_state_machine_state." }),
+  when: Type.Optional(
+    Type.String({ description: "Guidance for when the parent runner should select this state." }),
+  ),
+  inputSchema: Type.Optional(
+    Type.Record(Type.String(), Type.Any(), {
+      description:
+        "JSON Schema for the input object the parent must pass when selecting this state. Template strings read values from this object.",
+    }),
+  ),
 };
 
 const agentStateSchema = Type.Object({
   ...baseStateSchema,
-  kind: Type.Literal("agent"),
-  prompt: Type.String(),
-  contextScope: Type.Optional(
-    Type.Union([
-      Type.Literal("state"),
-      Type.Literal("dependencies"),
-      Type.Literal("state_machine"),
-    ]),
+  kind: Type.Literal("agent", { description: "Run a sub-agent for this state." }),
+  prompt: Type.String({
+    description: "User prompt sent to the sub-agent. May use templates like {{ input.email }}.",
+  }),
+  systemPrompt: Type.Optional(
+    Type.String({ description: "Optional system prompt appended for this sub-agent only." }),
   ),
-  allowedSkills: Type.Optional(Type.Array(Type.String())),
-  maxTurns: Type.Optional(Type.Number()),
-  outputSchema: Type.Optional(Type.Record(Type.String(), Type.Any())),
+  allowedSkills: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        "Skill names to inject into this sub-agent. Omit to inject all available skills.",
+    }),
+  ),
 });
 
 const scriptStateSchema = Type.Object({
   ...baseStateSchema,
-  kind: Type.Literal("script"),
-  command: Type.String(),
-  cwd: Type.Optional(Type.String()),
-  timeoutMs: Type.Optional(Type.Number()),
-  successCodes: Type.Optional(Type.Array(Type.Number())),
+  kind: Type.Literal("script", { description: "Run a shell command for this state." }),
+  command: Type.String({
+    description: "Shell command to execute. May use templates like {{ input.email }}.",
+  }),
+  cwd: Type.Optional(Type.String({ description: "Working directory for the command." })),
+  timeoutMs: Type.Optional(Type.Number({ description: "Command timeout in milliseconds." })),
+  successCodes: Type.Optional(
+    Type.Array(Type.Number(), {
+      description: "Exit codes treated as successful completion. Defaults to [0].",
+    }),
+  ),
 });
 
 const pollStateSchema = Type.Object({
   ...baseStateSchema,
-  kind: Type.Literal("poll"),
-  intervalMs: Type.Number(),
-  timeoutMs: Type.Optional(Type.Number()),
+  kind: Type.Literal("poll", { description: "Perform one external wait/check attempt." }),
+  intervalMs: Type.Number({ description: "Delay before the next scheduled wake attempt." }),
+  timeoutMs: Type.Optional(
+    Type.Number({ description: "Maximum time this state may remain polling." }),
+  ),
   poll: pollAttemptSchema,
 });
 
 const terminalStateSchema = Type.Object({
   ...baseStateSchema,
-  kind: Type.Literal("terminal"),
+  kind: Type.Literal("terminal", { description: "Finalize the state-machine session." }),
   status: Type.Union([
-    Type.Literal("completed"),
-    Type.Literal("failed"),
-    Type.Literal("cancelled"),
+    Type.Literal("completed", { description: "The state machine completed successfully." }),
+    Type.Literal("failed", { description: "The state machine failed." }),
+    Type.Literal("cancelled", { description: "The state machine was cancelled." }),
   ]),
-  reason: Type.Optional(Type.String()),
+  reason: Type.Optional(Type.String({ description: "Optional final explanation for the user." })),
 });
 
 const stateMachineStateSchema = Type.Union([
@@ -136,18 +181,15 @@ const stateMachineStateSchema = Type.Union([
 ]);
 
 export type StateMachineAgentStateOverride = Partial<
-  Pick<
-    StateMachineAgentState,
-    "prompt" | "contextScope" | "allowedSkills" | "options" | "maxTurns" | "outputSchema"
-  >
+  Pick<StateMachineAgentState, "prompt" | "systemPrompt" | "allowedSkills" | "inputSchema">
 >;
 
 export type StateMachineScriptStateOverride = Partial<
-  Pick<StateMachineScriptState, "command" | "cwd" | "timeoutMs" | "successCodes">
+  Pick<StateMachineScriptState, "command" | "cwd" | "timeoutMs" | "successCodes" | "inputSchema">
 >;
 
 export type StateMachinePollStateOverride = Partial<
-  Pick<StateMachinePollState, "intervalMs" | "timeoutMs" | "poll">
+  Pick<StateMachinePollState, "intervalMs" | "timeoutMs" | "poll" | "inputSchema">
 >;
 
 export type StateMachineStateOverride =
@@ -155,34 +197,62 @@ export type StateMachineStateOverride =
   | { kind: "script"; state: StateMachineScriptStateOverride }
   | { kind: "poll"; state: StateMachinePollStateOverride };
 
-const stateMachineDefinitionSchema = Type.Object({
-  name: Type.String(),
-  prompt: Type.String(),
-  states: Type.Array(stateMachineStateSchema),
-});
+const stateMachineDefinitionSchema = Type.Object(
+  {
+    name: Type.String({ description: "Human-readable state-machine name." }),
+    prompt: Type.String({
+      description: "Routing guidance explaining when this state-machine definition applies.",
+    }),
+    states: Type.Array(stateMachineStateSchema, {
+      description: "Available states the parent runner may select.",
+    }),
+  },
+  {
+    description:
+      "State-machine definition. Use inputSchema plus {{ input.foo }} templates for state prompts and commands that need transition input.",
+  },
+);
 
 const createDefinitionSchema = Type.Object({
   definition: stateMachineDefinitionSchema,
-  firstState: Type.Optional(Type.String()),
+  firstState: Type.Optional(
+    Type.String({ description: "Optional state name to run first after creating the definition." }),
+  ),
 });
 
 type CreateDefinitionParams = Static<typeof createDefinitionSchema>;
 type ToolStateMachineDefinition = CreateDefinitionParams["definition"];
 
 const selectStateSchema = Type.Object({
-  decision: Type.Object({
-    kind: Type.Union([Type.Literal("run_state"), Type.Literal("terminal"), Type.Literal("fail")]),
-    state: Type.Optional(Type.String()),
-    reason: Type.Optional(Type.String()),
-    override: Type.Optional(stateOverrideSchema),
-  }),
+  decision: Type.Object(
+    {
+      kind: Type.Union([Type.Literal("run_state"), Type.Literal("terminal"), Type.Literal("fail")]),
+      state: Type.Optional(Type.String({ description: "State name to run or finalize." })),
+      reason: Type.Optional(
+        Type.String({ description: "Reason for a terminal or failure decision." }),
+      ),
+      override: Type.Optional(stateOverrideSchema),
+      input: Type.Optional(
+        Type.Record(Type.String(), Type.Any(), {
+          description:
+            "Input object for the selected state. Required when the state inputSchema requires fields; templates read values as {{ input.field }}.",
+        }),
+      ),
+    },
+    {
+      description:
+        "State transition decision. Use input when selecting states with inputSchema or {{ input.foo }} templates.",
+    },
+  ),
 });
 
 type SelectStateParams = Static<typeof selectStateSchema>;
 type ToolRunnerDecision = SelectStateParams["decision"];
 
 const promptStateMachineAgentSchema = Type.Object({
-  prompt: Type.String(),
+  prompt: Type.String({
+    description: "Follow-up user prompt to send to the current state-machine agent state.",
+  }),
 });
 
 type PromptStateMachineAgentParams = Static<typeof promptStateMachineAgentSchema>;
@@ -192,6 +262,7 @@ export type StateMachineRunnerDecision =
       kind: "run_state";
       state: string;
       override?: StateMachineStateOverride;
+      input?: Record<string, unknown>;
     })
   | (ToolRunnerDecision & { kind: "terminal"; state: string })
   | (ToolRunnerDecision & { kind: "fail"; reason: string });
@@ -274,7 +345,7 @@ function createStateMachineDefinitionTool(): AgentTool<typeof createDefinitionSc
     name: "create_state_machine_definition",
     label: "Create state machine definition",
     description:
-      "Create a state-machine definition for durable business-process work. Use this only when no state machine is active or the previous state machine has reached a terminal state; otherwise use select_state_machine_state.",
+      "Create a state-machine definition for durable business-process work. State prompts and script commands may use template strings such as {{ input.email }}; define inputSchema on those states and pass matching input when selecting them. Agent states may set allowedSkills to restrict which skills are injected into that sub-agent. Use this only when no state machine is active or the previous state machine has reached a terminal state; otherwise use select_state_machine_state.",
     parameters: createDefinitionSchema,
     async execute(_toolCallId, params) {
       const result: TurnRunnerControlResult = {
@@ -297,7 +368,8 @@ function createSelectStateTool(
   return {
     name: "select_state_machine_state",
     label: "Select state machine state",
-    description: "Select the next state-machine state, terminal state, or failure outcome.",
+    description:
+      "Select the next state-machine state, terminal state, or failure outcome. When the selected state has inputSchema or template strings like {{ input.email }}, pass the matching input object here.",
     parameters: selectStateSchema,
     async execute(_toolCallId, params) {
       const decision = normalizeRunnerDecision(params.decision);
@@ -343,9 +415,15 @@ function assertValidSelectedState(
   }
 
   const validStates = definition.states.map((state) => state.name);
-  if (!validStates.includes(decision.state)) {
+  const selectedState = definition.states.find((state) => state.name === decision.state);
+  if (!selectedState) {
     throw new Error(`Unknown state: ${decision.state}. Valid states: ${validStates.join(", ")}`);
   }
+
+  if (decision.kind !== "run_state") return;
+
+  const effectiveState = applyStateOverride(selectedState, decision.override);
+  assertValidStateInput(effectiveState, decision.input);
 }
 
 function normalizeRunnerDecision(decision: ToolRunnerDecision): StateMachineRunnerDecision {
@@ -369,5 +447,19 @@ function normalizeRunnerDecision(decision: ToolRunnerDecision): StateMachineRunn
     state: decision.state ?? "",
     reason: decision.reason,
     override: decision.override as StateMachineStateOverride | undefined,
+    input: decision.input,
   };
+}
+
+function assertValidStateInput(state: StateMachineState, input: unknown): void {
+  if (!state.inputSchema) return;
+
+  const candidate = input ?? {};
+  if (Value.Check(state.inputSchema as never, candidate)) return;
+
+  const errors = [...Value.Errors(state.inputSchema as never, candidate)];
+  const first = errors[0] as { path?: string; message?: string } | undefined;
+  const path = first?.path ?? "/";
+  const message = first?.message ?? "does not match schema";
+  throw new Error(`Invalid input for state "${state.name}" at ${path}: ${message}`);
 }

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -53,7 +53,8 @@ const agentOverrideSchema = Type.Partial(
         "Skill names to inject into this sub-agent. Omit to inject all available skills.",
     }),
     inputSchema: Type.Record(Type.String(), Type.Any(), {
-      description: "Replacement JSON Schema for transition input accepted by this state.",
+      description:
+        'Replacement valid JSON Schema object for transition input accepted by this state, such as { "type": "object", "properties": { "email": { "type": "string" }, "followUpCount": { "type": "integer" } }, "required": ["email"] }. Fields omitted from required are optional.',
     }),
   }),
 );
@@ -67,7 +68,8 @@ const scriptOverrideSchema = Type.Partial(
       description: "Replacement exit codes treated as successful completion.",
     }),
     inputSchema: Type.Record(Type.String(), Type.Any(), {
-      description: "Replacement JSON Schema for transition input accepted by this state.",
+      description:
+        'Replacement valid JSON Schema object for transition input accepted by this state, such as { "type": "object", "properties": { "email": { "type": "string" }, "followUpCount": { "type": "integer" } }, "required": ["email"] }. Fields omitted from required are optional.',
     }),
   }),
 );
@@ -99,7 +101,8 @@ const pollOverrideSchema = Type.Partial(
     timeoutMs: Type.Number({ description: "Replacement maximum poll-state runtime." }),
     poll: pollAttemptSchema,
     inputSchema: Type.Record(Type.String(), Type.Any(), {
-      description: "Replacement JSON Schema for transition input accepted by this state.",
+      description:
+        'Replacement valid JSON Schema object for transition input accepted by this state, such as { "type": "object", "properties": { "messageId": { "type": "string" } }, "required": ["messageId"] }. Fields omitted from required are optional.',
     }),
   }),
 );
@@ -118,7 +121,7 @@ const baseStateSchema = {
   inputSchema: Type.Optional(
     Type.Record(Type.String(), Type.Any(), {
       description:
-        "JSON Schema for the input object the parent must pass when selecting this state. Template strings read values from this object.",
+        'Valid JSON Schema object for the input the parent must pass when selecting this state, such as { "type": "object", "properties": { "email": { "type": "string" }, "followUpCount": { "type": "integer" } }, "required": ["email"] }. Fields omitted from required are optional. Template strings read values from this object.',
     }),
   ),
 };

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -2,7 +2,7 @@ import { Agent, type AgentEvent, type AgentTool } from "@mariozechner/pi-agent-c
 import { getEnvApiKey, getModel, type Model } from "@mariozechner/pi-ai";
 import type { Skill } from "@mariozechner/pi-coding-agent";
 import dedent from "dedent";
-import { execFile } from "node:child_process";
+import { execFile, type ExecException } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -37,8 +37,6 @@ import type {
 } from "../types/state-machine.js";
 import {
   createSystemPromptWithAppendedLayers,
-  createStateAgentPrompt,
-  createStateAgentSystemPromptLayer,
   createStateMachineSystemPromptLayer,
 } from "./prompts.js";
 import {
@@ -64,6 +62,7 @@ export interface AgentWorkerInput {
   prompt: string;
   options?: TurnOptions;
   appendSystemPrompt?: string;
+  skills?: Skill[];
   tools: AgentTool[];
 }
 
@@ -242,7 +241,7 @@ export class TurnRunner {
       : undefined;
 
     if (command.state.status === "sleeping" && currentState?.kind === "poll") {
-      return this.runStateMachinePollState(state, currentState);
+      return this.runStateMachinePollState(state, currentState, { woke: true });
     }
 
     return {
@@ -419,7 +418,10 @@ export class TurnRunner {
       initialState: {
         model,
         thinkingLevel: input.options?.thinkingLevel ?? "medium",
-        systemPrompt: this.createBaseSystemPromptWithAppendedLayers(input.appendSystemPrompt),
+        systemPrompt: this.createBaseSystemPromptWithAppendedLayers({
+          append: [input.appendSystemPrompt],
+          skills: input.skills,
+        }),
         messages: input.state.agent.messages,
         tools: input.tools,
       },
@@ -450,6 +452,18 @@ export class TurnRunner {
   getSkillInstructions(skillId: string): string {
     const skill = this.skills.find((s) => s.name === skillId);
     return skill ? readSkillInstructions(skill) : "";
+  }
+
+  private resolveStateAgentSkills(state: StateMachineAgentState): Skill[] | undefined {
+    if (!state.allowedSkills) return undefined;
+
+    const skillsByName = new Map(this.skills.map((skill) => [skill.name, skill]));
+    const missing = state.allowedSkills.filter((name) => !skillsByName.has(name));
+    if (missing.length > 0) {
+      throw new Error(`Unknown allowedSkills for state "${state.name}": ${missing.join(", ")}`);
+    }
+
+    return state.allowedSkills.map((name) => skillsByName.get(name)!);
   }
 
   private resolveSlashSkillPrompt(prompt: string): string {
@@ -501,11 +515,14 @@ export class TurnRunner {
     );
   }
 
-  protected createBaseSystemPromptWithAppendedLayers(...append: Array<string | undefined>): string {
+  protected createBaseSystemPromptWithAppendedLayers(input?: {
+    append?: Array<string | undefined>;
+    skills?: readonly Skill[];
+  }): string {
     return createSystemPromptWithAppendedLayers({
       config: this.config,
-      skills: this.skills,
-      append: [...this.readSystemPromptFileLayers(), ...append],
+      skills: input?.skills ?? this.skills,
+      append: [...this.readSystemPromptFileLayers(), ...(input?.append ?? [])],
     });
   }
 
@@ -581,7 +598,11 @@ export class TurnRunner {
       decision.kind === "run_state"
         ? applyStateOverride(selectedState, decision.override)
         : selectedState;
-    const nextSession = this.recordStateStarted(session, effectiveState);
+    const nextSession = this.recordStateStarted(
+      session,
+      effectiveState,
+      decision.kind === "run_state" ? decision.input : undefined,
+    );
 
     this.emit({ type: "state_machine", currentState: effectiveState.name });
 
@@ -601,8 +622,8 @@ export class TurnRunner {
     session: TurnState,
     state: StateMachineAgentState,
   ): Promise<TurnTerminalEvent> {
-    const childPrompt = createStateAgentPrompt({ session, state });
-    return this.runStateMachineAgentStatePrompt(session, state, childPrompt, state.options);
+    const childPrompt = this.renderTemplate(state.prompt, session.stateMachine?.currentInput ?? {});
+    return this.runStateMachineAgentStatePrompt(session, state, childPrompt);
   }
 
   protected async promptStateMachineAgent(
@@ -628,7 +649,6 @@ export class TurnRunner {
     session: TurnState,
     state: StateMachineAgentState,
     prompt: string,
-    options?: TurnOptions,
   ): Promise<TurnTerminalEvent> {
     const childState: TurnState = {
       ...session,
@@ -641,16 +661,18 @@ export class TurnRunner {
       await this.runAgentWorker({
         state: childState,
         prompt,
-        options: options ?? state.options,
-        appendSystemPrompt: createStateAgentSystemPromptLayer({ session, state }),
+        appendSystemPrompt: state.systemPrompt,
+        skills: this.resolveStateAgentSkills(state),
         ...this.createTools("agent"),
       })
     ).terminal;
     const parentSession = { ...session, agent: childResult.state.agent };
-    const updatedSession = this.recordStateCompleted(parentSession, state.name, {
+    const rawOutput = {
       result: childResult.type === "complete" ? childResult.result : undefined,
       childStatus: childResult.state.status,
-    });
+      terminal: childResult,
+    };
+    const updatedSession = this.recordStateCompleted(parentSession, state.name, rawOutput);
 
     if (childResult.type === "ask") {
       return { ...childResult, state: { ...updatedSession, status: "waiting_for_human" } };
@@ -665,7 +687,7 @@ export class TurnRunner {
     return this.continueStateMachineAfterStateCompleted(
       { ...updatedSession, status: "running" },
       state.name,
-      childResult.result,
+      rawOutput,
     );
   }
 
@@ -676,16 +698,25 @@ export class TurnRunner {
     const abortController = new AbortController();
     this.activeAbortController = abortController;
     try {
-      const { stdout } = await execFileAsync("sh", ["-lc", state.command], {
+      const command = this.renderTemplate(state.command, session.stateMachine?.currentInput ?? {});
+      const shellOutput = await this.runShellCommand(command, {
         cwd: state.cwd ?? this.config.cwd ?? process.cwd(),
-        timeout: state.timeoutMs,
+        timeoutMs: state.timeoutMs,
         signal: abortController.signal,
+        successCodes: state.successCodes,
       });
+      const { stdout } = shellOutput;
       const output = this.parseStructuredOutput(stdout);
+      const rawOutput = {
+        ...shellOutput,
+        stdout: stdout.trim(),
+        stderr: shellOutput.stderr.trim(),
+        parsed: output,
+      };
       return this.continueStateMachineAfterStateCompleted(
-        this.recordStateCompleted(session, state.name, output),
+        this.recordStateCompleted(session, state.name, rawOutput),
         state.name,
-        stdout.trim(),
+        rawOutput,
       );
     } catch (error) {
       if (this.interruptedTerminal) {
@@ -710,33 +741,55 @@ export class TurnRunner {
   protected async runStateMachinePollState(
     session: TurnState,
     state: StateMachinePollState,
+    options?: { woke?: boolean },
   ): Promise<TurnTerminalEvent> {
-    if (state.poll.kind === "prompt") {
-      const result = await this.runAgentMode(this.createInitialState("agent"), state.poll.prompt);
-      const output =
-        result.type === "complete" && result.result ? this.parseJsonObject(result.result) : {};
-      if (Object.keys(output).length > 0) {
-        return this.continueStateMachineAfterStateCompleted(
-          this.recordStateCompleted(session, state.name, output),
-          state.name,
-          result.type === "complete" ? result.result : undefined,
-        );
+    const elapsedMs = this.elapsedSinceStateStarted(session, state.name);
+    if (state.timeoutMs !== undefined && elapsedMs >= state.timeoutMs) {
+      const message = `Poll state "${state.name}" timed out after ${elapsedMs}ms.`;
+      return this.complete(
+        this.recordStateFailed(session, state.name, message),
+        "failed",
+        undefined,
+        message,
+      );
+    }
+
+    if (state.poll.kind === "timer") {
+      if (!options?.woke) {
+        return this.sleep(session, state);
       }
+      const output = { elapsedMs };
+      return this.continueStateMachineAfterStateCompleted(
+        this.recordStateCompleted(session, state.name, output),
+        state.name,
+        output,
+      );
     } else {
       const abortController = new AbortController();
       this.activeAbortController = abortController;
       try {
-        const { stdout } = await execFileAsync("sh", ["-lc", state.poll.command], {
+        const command = this.renderTemplate(
+          state.poll.command,
+          session.stateMachine?.currentInput ?? {},
+        );
+        const shellOutput = await this.runShellCommand(command, {
           cwd: state.poll.cwd ?? this.config.cwd ?? process.cwd(),
-          timeout: state.timeoutMs,
           signal: abortController.signal,
+          successCodes: state.poll.successCodes,
         });
+        const { stdout } = shellOutput;
         const output = this.parseJsonObject(stdout);
         if (Object.keys(output).length > 0) {
+          const rawOutput = {
+            ...shellOutput,
+            stdout: stdout.trim(),
+            stderr: shellOutput.stderr.trim(),
+            parsed: output,
+          };
           return this.continueStateMachineAfterStateCompleted(
-            this.recordStateCompleted(session, state.name, output),
+            this.recordStateCompleted(session, state.name, rawOutput),
             state.name,
-            stdout.trim(),
+            rawOutput,
           );
         }
       } catch {
@@ -753,6 +806,10 @@ export class TurnRunner {
       }
     }
 
+    return this.sleep(session, state);
+  }
+
+  private sleep(session: TurnState, state: StateMachinePollState): TurnTerminalEvent {
     return {
       type: "sleep",
       wakeAt: Date.now() + state.intervalMs,
@@ -782,10 +839,10 @@ export class TurnRunner {
   protected async continueStateMachineAfterStateCompleted(
     session: TurnState,
     state: string,
-    result?: string,
+    output?: unknown,
   ): Promise<TurnTerminalEvent> {
     if (session.mode === "agent") {
-      return this.complete(session, "completed", result);
+      return this.complete(session, "completed", typeof output === "string" ? output : undefined);
     }
 
     let nextSession = session;
@@ -800,7 +857,11 @@ export class TurnRunner {
         prompt: dedent`
           The state "${state}" finished.
 
-          ${toXML({ result: result ?? "" })}
+          ${toXML({
+            state_completed: {
+              output: output ?? null,
+            },
+          })}
 
           ${retryInstruction}
 
@@ -863,7 +924,6 @@ export class TurnRunner {
         definition,
         prompt,
         currentState,
-        state: {},
         history: [{ type: "session_started", timestamp: now }],
         createdAt: now,
         updatedAt: now,
@@ -952,7 +1012,11 @@ export class TurnRunner {
     };
   }
 
-  private recordStateStarted(session: TurnState, state: StateMachineState): TurnState {
+  private recordStateStarted(
+    session: TurnState,
+    state: StateMachineState,
+    input?: Record<string, unknown>,
+  ): TurnState {
     const stateMachine = session.stateMachine;
     if (!stateMachine) return session;
     return {
@@ -960,13 +1024,14 @@ export class TurnRunner {
       stateMachine: {
         ...stateMachine,
         currentState: state.name,
+        currentInput: input,
         history: [
           ...stateMachine.history,
           {
             type: "state_started",
             timestamp: Date.now(),
             state: state.name,
-            effectiveState: state,
+            input,
           },
         ],
         updatedAt: Date.now(),
@@ -981,10 +1046,6 @@ export class TurnRunner {
       ...session,
       stateMachine: {
         ...stateMachine,
-        state: {
-          ...stateMachine.state,
-          ...(typeof output === "object" && output !== null ? output : { result: output }),
-        },
         history: [
           ...stateMachine.history,
           { type: "state_completed", timestamp: Date.now(), state, output },
@@ -992,6 +1053,17 @@ export class TurnRunner {
         updatedAt: Date.now(),
       },
     };
+  }
+
+  private elapsedSinceStateStarted(session: TurnState, state: string): number {
+    const history = session.stateMachine?.history ?? [];
+    for (let index = history.length - 1; index >= 0; index--) {
+      const event = history[index];
+      if (event.type === "state_started" && event.state === state) {
+        return Math.max(0, Date.now() - event.timestamp);
+      }
+    }
+    return 0;
   }
 
   private recordStateFailed(session: TurnState, state: string, error: string): TurnState {
@@ -1028,6 +1100,45 @@ export class TurnRunner {
     };
   }
 
+  private async runShellCommand(
+    command: string,
+    options: {
+      cwd: string;
+      timeoutMs?: number;
+      signal: AbortSignal;
+      successCodes?: number[];
+    },
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    try {
+      const result = await execFileAsync("sh", ["-lc", command], {
+        cwd: options.cwd,
+        timeout: options.timeoutMs,
+        signal: options.signal,
+      });
+      return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+    } catch (error) {
+      const execError = error as ExecException & {
+        stdout?: string;
+        stderr?: string;
+        code?: number | string;
+      };
+      const code =
+        typeof execError.code === "number"
+          ? execError.code
+          : typeof execError.code === "string"
+            ? Number(execError.code)
+            : undefined;
+      if (code !== undefined && (options.successCodes ?? [0]).includes(code)) {
+        return {
+          stdout: execError.stdout ?? "",
+          stderr: execError.stderr ?? "",
+          exitCode: code,
+        };
+      }
+      throw error;
+    }
+  }
+
   private parseStructuredOutput(stdout: string): Record<string, unknown> {
     const trimmed = stdout.trim();
     if (!trimmed) return {};
@@ -1052,5 +1163,22 @@ export class TurnRunner {
     } catch {
       return {};
     }
+  }
+
+  private renderTemplate(template: string, input: Record<string, unknown>): string {
+    return template.replace(/\{\{\s*input\.([A-Za-z0-9_.-]+)\s*\}\}/g, (_match, path: string) => {
+      const value = this.readPath(input, path);
+      if (value === undefined || value === null) return "";
+      return typeof value === "string" ? value : JSON.stringify(value);
+    });
+  }
+
+  private readPath(input: Record<string, unknown>, path: string): unknown {
+    let value: unknown = input;
+    for (const part of path.split(".")) {
+      if (!value || typeof value !== "object") return undefined;
+      value = (value as Record<string, unknown>)[part];
+    }
+    return value;
   }
 }

--- a/src/types/state-machine.ts
+++ b/src/types/state-machine.ts
@@ -1,11 +1,9 @@
-import type { TurnOptions } from "./protocol.js";
-
 /**
  * Durable state-machine definitions and runtime state.
  *
  * A state machine models the high-level business process, not task execution.
  * There is one current business state at a time. The state-machine runner agent
- * sees the original prompt, state-machine state, state history, and state
+ * sees the original prompt, current transition input, state history, and state
  * definitions, then decides which state should run next, whether the session should
  * wait, or whether a terminal state should finalize the state machine.
  *
@@ -25,8 +23,7 @@ import type { TurnOptions } from "./protocol.js";
  *
  * The runner should:
  *
- * 1. Start a StateMachineSession from a StateMachineDefinition and initialize durable domain
- *    state.
+ * 1. Start a StateMachineSession from a StateMachineDefinition.
  * 2. Enter an agent state for enrichment/research and record the output in the
  *    session history so the state machine can resume without repeating research.
  * 3. Enter a send-email script state and record the sent message details.
@@ -58,10 +55,10 @@ import type { TurnOptions } from "./protocol.js";
  *
  * The state-machine types should support this by representing:
  *
- * - durable domain state
+ * - durable session history
  * - agent/tool/script states whose outputs are available through state-machine history
  * - poll states, plus explicit waits for human input
- * - runner-agent decisions driven by full prompt, state, and history
+ * - runner-agent decisions driven by full prompt, transition input, and history
  * - named terminal states richer than generic "completed" or "failed"
  *
  * Case 2: development state machine
@@ -74,7 +71,7 @@ import type { TurnOptions } from "./protocol.js";
  *
  * 1. Start a StateMachineSession from the user's prompt.
  * 2. Execute a script/tool state that creates a worktree and records its path in
- *    state-machine state/history.
+ *    state-machine history.
  * 3. Execute an agent state that implements the requested code change inside the
  *    worktree.
  * 4. Execute a review agent state. The review can either approve, request fixes,
@@ -118,20 +115,24 @@ import type { TurnOptions } from "./protocol.js";
  *
  * Example of templated script commands:
  *
- * A setup state can emit structured output such as { "worktreePath": "..." }.
- * The runner records that output in history and merges the structured
- * fields into state:
+ * The parent runner can pass transition input when selecting a state:
  *
  *   {
  *     kind: "script",
- *     command: "scripts/create-worktree.sh '{{ state.branchName }}'"
+ *     inputSchema: {
+ *       type: "object",
+ *       properties: { branchName: { type: "string" } },
+ *       required: ["branchName"]
+ *     },
+ *     command: "scripts/create-worktree.sh '{{ input.branchName }}'"
  *   }
  *
- * A later dev state or cleanup state can reference that state:
+ * A later dev state or cleanup state can receive fresh input selected from
+ * prior completion output:
  *
  *   {
  *     kind: "script",
- *     command: "rm -rf '{{ state.worktreePath }}'"
+ *     command: "rm -rf '{{ input.worktreePath }}'"
  *   }
  *
  * A PR poll state can check through any CLI/API wrapper without the state
@@ -141,13 +142,11 @@ import type { TurnOptions } from "./protocol.js";
  *     kind: "poll",
  *     poll: {
  *       kind: "script",
- *       command: "scripts/check-pr-finished.sh '{{ state.prUrl }}'"
+ *       command: "scripts/check-pr-finished.sh '{{ input.prUrl }}'"
  *     },
  *     intervalMs: 300000
  *   }
  */
-
-export type StateMachineAgentContextScope = "state" | "dependencies" | "state_machine";
 
 /** User-authored state machine template. Runtime progress lives in StateMachineSession. */
 export interface StateMachineDefinition {
@@ -174,8 +173,11 @@ export interface StateMachineSession {
   prompt: string;
   /** Current business state, selected by the runner agent. */
   currentState?: string;
-  /** Mutable state machine memory shared across runner decisions and state templates. */
-  state: Record<string, unknown>;
+  /**
+   * Input supplied by the parent runner when it selected the current state.
+   * Persisted so sleeping poll states can resume with the same template values.
+   */
+  currentInput?: Record<string, unknown>;
   /** Append-only audit log used for debugging, replay, and persistence. */
   history: StateMachineSessionEvent[];
   /** Present only after a session reaches a named terminal state. */
@@ -195,34 +197,35 @@ export interface StateMachineBaseState {
   name: string;
   /** Helps the runner agent understand when this state is appropriate. */
   when?: string;
+  /**
+   * Optional JSON Schema for the input the parent runner must provide when
+   * selecting this state. The runner validates transition input before executing
+   * the state and exposes it to prompt/script templates as `input`.
+   */
+  inputSchema?: Record<string, unknown>;
 }
 
 /** Runs an agent. The runner injects original prompt/history outside this state config. */
 export interface StateMachineAgentState extends StateMachineBaseState {
   kind: "agent";
   /**
-   * Prompt for the agent. The runner renders this as a template before
-   * execution using session.state only. The original user prompt and
-   * broader history are added separately when the final agent prompt is
-   * constructed.
+   * User prompt sent to the sub-agent. The runner renders this as a template
+   * using the transition input provided when the parent runner selected this
+   * state.
    */
   prompt: string;
   /**
-   * Controls how much state machine context the agent receives.
-   *
-   * - "state": rendered prompt and current state.
-   * - "dependencies": state context plus runner-selected prerequisite history.
-   * - "state_machine": state context plus full state-machine definition and full state history.
+   * Optional system prompt appended to the runner's base system prompt for this
+   * sub-agent only. Use this for durable role or behavior instructions; dynamic
+   * state input belongs in `prompt`.
    */
-  contextScope?: StateMachineAgentContextScope;
-  /** Optional skill allowlist injected into this agent state. Omitted means use state machine/turn-runner defaults. */
+  systemPrompt?: string;
+  /**
+   * Optional skill allowlist for this sub-agent. When set, only these discovered
+   * or explicitly configured skills are injected into the sub-agent system
+   * prompt.
+   */
   allowedSkills?: string[];
-  /** Per-state model/thinking overrides for this agent turn. */
-  options?: TurnOptions;
-  /** Upper bound before the agent must yield control back to the runner. */
-  maxTurns?: number;
-  /** Optional JSON Schema used to request and validate structured output before merging it into state. */
-  outputSchema?: Record<string, unknown>;
 }
 
 /** Runs a shell command. This is the generic integration primitive. */
@@ -230,9 +233,9 @@ export interface StateMachineScriptState extends StateMachineBaseState {
   kind: "script";
   /**
    * Shell command used for integrations, setup, cleanup, and deterministic
-   * checks. The runner renders this as a template before execution using
-   * session.state only; keep state-machine definitions serializable instead of storing
-   * executable functions here.
+   * checks. The runner renders this as a template using transition input; keep
+   * state-machine definitions serializable instead of storing executable
+   * functions here.
    */
   command: string;
   /** Working directory for the command. Defaults to the state-machine session cwd. */
@@ -267,13 +270,11 @@ export type StateMachinePoll =
       successCodes?: number[];
     }
   | {
-      kind: "prompt";
+      kind: "timer";
       /**
-       * Prompt used once per poll attempt when the check needs an agent to inspect
-       * an external source through available tools.
+       * Pure delay poll. The first visit sleeps; the scheduled wake lets the
+       * parent runner choose the next state without invoking a script or agent.
        */
-      prompt: string;
-      outputSchema?: Record<string, unknown>;
     };
 
 /** Finalizes the session when reached. Terminal outcomes are just state machine states. */
@@ -297,7 +298,12 @@ export interface StateMachineTerminalResult {
 export type StateMachineSessionEvent =
   | { type: "session_started"; timestamp: number }
   | { type: "runner_decided"; timestamp: number; decision: unknown }
-  | { type: "state_started"; timestamp: number; state: string; effectiveState?: StateMachineState }
+  | {
+      type: "state_started";
+      timestamp: number;
+      state: string;
+      input?: Record<string, unknown>;
+    }
   | { type: "state_completed"; timestamp: number; state: string; output?: unknown }
   | { type: "state_failed"; timestamp: number; state: string; error: string }
   | { type: "session_completed"; timestamp: number; terminal: StateMachineTerminalResult };

--- a/test/helpers/turn-runner-protocol.ts
+++ b/test/helpers/turn-runner-protocol.ts
@@ -96,7 +96,6 @@ export function createStateMachineState(currentState: string): TurnState {
       definition,
       prompt: "Prospect Ada until she books a meeting.",
       currentState,
-      state: {},
       history: [],
       createdAt: Date.now(),
       updatedAt: Date.now(),
@@ -118,7 +117,12 @@ export function createOutreachStateMachine(): StateMachineDefinition {
       {
         kind: "script",
         name: "send_email",
-        command: "scripts/send-email.sh '{{ state.email }}'",
+        inputSchema: {
+          type: "object",
+          properties: { email: { type: "string" } },
+          required: ["email"],
+        },
+        command: "scripts/send-email.sh '{{ input.email }}'",
       },
       {
         kind: "poll",
@@ -126,7 +130,15 @@ export function createOutreachStateMachine(): StateMachineDefinition {
         intervalMs: 300_000,
         poll: {
           kind: "script",
-          command: "scripts/check-email-reply.sh '{{ state.email }}'",
+          command: "scripts/check-email-reply.sh '{{ input.email }}'",
+        },
+      },
+      {
+        kind: "poll",
+        name: "wait_before_retry",
+        intervalMs: 300_000,
+        poll: {
+          kind: "timer",
         },
       },
       {

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -14,7 +14,7 @@ let tempDir: string | undefined;
 
 class SkillPromptTurnRunner extends TurnRunner {
   systemPromptForTest(systemPrompt?: string): string {
-    return this.createBaseSystemPromptWithAppendedLayers(systemPrompt);
+    return this.createBaseSystemPromptWithAppendedLayers({ append: [systemPrompt] });
   }
 }
 

--- a/test/turn-runner-protocol.test.ts
+++ b/test/turn-runner-protocol.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { Skill } from "@mariozechner/pi-coding-agent";
 import assert from "node:assert";
 import {
   createTurnRunner,
@@ -355,18 +356,13 @@ describe("TurnRunner protocol scenarios", () => {
       behavior: "steer",
     });
 
-    const started = terminal.state.stateMachine?.history.find(
-      (event) => event.type === "state_started",
-    );
-    expect(started?.type === "state_started" ? started.effectiveState : undefined).toMatchObject({
-      prompt: "Research Grace Hopper.",
-    });
+    expect(runner.workerInputs[1]?.prompt).toBe("Research Grace Hopper.");
     expect(terminal.state.stateMachine?.definition.states[0]).toMatchObject({
       prompt: "Research the prospect and company.",
     });
   });
 
-  test("bounds state-machine history injected into agent state prompts", async () => {
+  test("uses optional state agent system prompts without injecting state-machine context", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("research_prospect");
     if (!turnState.stateMachine) throw new Error("Expected state machine session");
@@ -374,24 +370,10 @@ describe("TurnRunner protocol scenarios", () => {
       ...turnState.stateMachine.definition,
       states: turnState.stateMachine.definition.states.map((state) =>
         state.name === "waiting_for_reply" && state.kind === "agent"
-          ? { ...state, contextScope: "state_machine" }
+          ? { ...state, systemPrompt: "You are handling the waiting state." }
           : state,
       ),
     };
-    turnState.stateMachine.history = [
-      {
-        type: "state_completed",
-        timestamp: 1,
-        state: "research_prospect",
-        output: { marker: "old-history", data: "x".repeat(20_000) },
-      },
-      {
-        type: "state_completed",
-        timestamp: 2,
-        state: "send_email",
-        output: { marker: "recent-history" },
-      },
-    ];
     runner.controlResults.push({
       type: "select_state_machine_state",
       decision: { kind: "run_state", state: "waiting_for_reply" },
@@ -406,12 +388,55 @@ describe("TurnRunner protocol scenarios", () => {
 
     const agentStatePrompt = runner.workerInputs[1]?.prompt ?? "";
     const agentStateSystemPrompt = runner.workerInputs[1]?.appendSystemPrompt ?? "";
-    expect(agentStatePrompt.includes("recent-history")).toBe(true);
-    expect(agentStatePrompt.includes("old-history")).toBe(false);
-    expect(agentStatePrompt.includes('"omitted": 1')).toBe(true);
-    expect(agentStateSystemPrompt.includes("recent-history")).toBe(false);
-    expect(agentStateSystemPrompt.includes("old-history")).toBe(false);
-    expect(agentStateSystemPrompt.includes("State-machine context:")).toBe(true);
+    expect(agentStatePrompt).toBe("Wait for or incorporate the prospect reply.");
+    expect(agentStateSystemPrompt).toBe("You are handling the waiting state.");
+  });
+
+  test("restricts injected skills for state-machine agent states", async () => {
+    const { runner } = createTurnRunner({
+      skills: [
+        {
+          name: "allowed-skill",
+          description: "Allowed skill.",
+          baseDir: "/tmp/allowed-skill",
+          filePath: "/tmp/allowed-skill/SKILL.md",
+          sourceInfo: {} as Skill["sourceInfo"],
+          disableModelInvocation: false,
+        },
+        {
+          name: "blocked-skill",
+          description: "Blocked skill.",
+          baseDir: "/tmp/blocked-skill",
+          filePath: "/tmp/blocked-skill/SKILL.md",
+          sourceInfo: {} as Skill["sourceInfo"],
+          disableModelInvocation: false,
+        },
+      ],
+    });
+    const turnState = createStateMachineState("research_prospect");
+    if (!turnState.stateMachine) throw new Error("Expected state machine session");
+    turnState.stateMachine.definition = {
+      ...turnState.stateMachine.definition,
+      states: turnState.stateMachine.definition.states.map((state) =>
+        state.name === "research_prospect" && state.kind === "agent"
+          ? { ...state, allowedSkills: ["allowed-skill"] }
+          : state,
+      ),
+    };
+    runner.controlResults.push({
+      type: "select_state_machine_state",
+      decision: { kind: "run_state", state: "research_prospect" },
+    });
+
+    await runner.turn({
+      type: "prompt",
+      state: turnState,
+      message: "Continue outreach.",
+      behavior: "follow_up",
+    });
+
+    const childInput = runner.workerInputs[1];
+    expect(childInput?.skills?.map((skill) => skill.name)).toEqual(["allowed-skill"]);
   });
 
   test("asks the parent runner for the next state immediately after a state completes", async () => {
@@ -450,6 +475,228 @@ describe("TurnRunner protocol scenarios", () => {
         },
       },
     });
+  });
+
+  test("renders parent-provided transition input into agent prompts", async () => {
+    const { runner } = createTurnRunner();
+    const turnState = createStateMachineState("research_prospect");
+    assert(turnState.stateMachine);
+    turnState.stateMachine.definition = {
+      ...turnState.stateMachine.definition,
+      states: turnState.stateMachine.definition.states.map((state) =>
+        state.name === "research_prospect" && state.kind === "agent"
+          ? {
+              ...state,
+              inputSchema: {
+                type: "object",
+                properties: {
+                  prospect: { type: "string" },
+                },
+                required: ["prospect"],
+              },
+              prompt: "Research {{ input.prospect }}.",
+            }
+          : state,
+      ),
+    };
+    runner.controlResults.push(
+      {
+        type: "select_state_machine_state",
+        decision: {
+          kind: "run_state",
+          state: "research_prospect",
+          input: { prospect: "Ada Lovelace" },
+        },
+      },
+      { type: "none" },
+      {
+        type: "select_state_machine_state",
+        decision: { kind: "terminal", state: "meeting_scheduled" },
+      },
+    );
+    let calls = 0;
+    runner.worker = async (input, next) => {
+      calls += 1;
+      if (calls === 2) {
+        runner.workerInputs.push(input);
+        return {
+          control: { type: "none" },
+          terminal: {
+            type: "complete",
+            status: "completed",
+            result: "Research complete.",
+            state: {
+              ...input.state,
+              status: "completed",
+              agent: { ...input.state.agent, status: "completed" },
+            },
+          },
+        };
+      }
+      return next();
+    };
+
+    const terminal = await runner.turn({
+      type: "prompt",
+      state: turnState,
+      message: "Continue.",
+      behavior: "follow_up",
+    });
+
+    const started = terminal.state.stateMachine?.history.find(
+      (event) => event.type === "state_started" && event.state === "research_prospect",
+    );
+    expect(started?.type === "state_started" ? started.input : undefined).toMatchObject({
+      prospect: "Ada Lovelace",
+    });
+    expect(runner.workerInputs[1]?.prompt).toContain("Research Ada Lovelace.");
+    const parentPrompt = runner.workerInputs[2]?.prompt ?? "";
+    expect(parentPrompt).toContain("<output>");
+    expect(parentPrompt).toContain("Research complete.");
+    expect(parentPrompt).toContain("childStatus");
+    expect(parentPrompt).toContain("<terminal>");
+  });
+
+  test("timer poll continues without script and forwards elapsed output", async () => {
+    const { runner } = createTurnRunner();
+    const turnState = createStateMachineState("wait_before_retry");
+    const startedAt = Date.now() - 12_000;
+    turnState.stateMachine?.history.push({
+      type: "state_started",
+      timestamp: startedAt,
+      state: "wait_before_retry",
+    });
+    runner.controlResults.push({
+      type: "select_state_machine_state",
+      decision: { kind: "terminal", state: "meeting_scheduled" },
+    });
+
+    const terminal = await runner.turn({
+      type: "wake",
+      state: { ...turnState, status: "sleeping" },
+    });
+
+    expect(runner.workerInputs).toHaveLength(1);
+    const parentPrompt = runner.workerInputs[0]?.prompt ?? "";
+    expect(parentPrompt).toContain('The state "wait_before_retry" finished.');
+    expect(parentPrompt).toContain("<elapsedMs>");
+    expect(parentPrompt).toContain("<output>");
+    const completed = terminal.state.stateMachine?.history.find(
+      (event) =>
+        event.type === "state_completed" &&
+        event.state === "wait_before_retry" &&
+        typeof (event.output as { elapsedMs?: unknown } | undefined)?.elapsedMs === "number",
+    );
+    expect(completed).toBeDefined();
+    const output = completed?.type === "state_completed" ? completed.output : undefined;
+    expect((output as { elapsedMs: number }).elapsedMs).toBeGreaterThanOrEqual(12_000);
+  });
+
+  test("timer poll sleeps when first selected before producing output on wake", async () => {
+    const { runner } = createTurnRunner();
+    const turnState = createStateMachineState("wait_before_retry");
+    runner.controlResults.push({
+      type: "select_state_machine_state",
+      decision: { kind: "run_state", state: "wait_before_retry" },
+    });
+
+    const terminal = await runner.turn({
+      type: "prompt",
+      state: turnState,
+      message: "Wait before retrying.",
+      behavior: "follow_up",
+    });
+
+    expect(terminal).toMatchObject({
+      type: "sleep",
+      state: {
+        status: "sleeping",
+        stateMachine: { currentState: "wait_before_retry" },
+      },
+    });
+    expect(terminal.state.stateMachine?.history.at(-1)).toMatchObject({ type: "state_started" });
+    expect(runner.workerInputs).toHaveLength(1);
+  });
+
+  test("poll timeout fails after the maximum time in the poll state", async () => {
+    const { runner } = createTurnRunner();
+    const turnState = createStateMachineState("wait_before_retry");
+    const startedAt = Date.now() - 10_000;
+    if (!turnState.stateMachine) throw new Error("Expected state machine session");
+    turnState.stateMachine.definition = {
+      ...turnState.stateMachine.definition,
+      states: turnState.stateMachine.definition.states.map((state) =>
+        state.name === "wait_before_retry" && state.kind === "poll"
+          ? { ...state, timeoutMs: 5_000 }
+          : state,
+      ),
+    };
+    turnState.stateMachine.history.push({
+      type: "state_started",
+      timestamp: startedAt,
+      state: "wait_before_retry",
+    });
+
+    const terminal = await runner.turn({
+      type: "wake",
+      state: { ...turnState, status: "sleeping" },
+    });
+
+    expect(terminal).toMatchObject({
+      type: "complete",
+      status: "failed",
+      error: expect.stringContaining('Poll state "wait_before_retry" timed out'),
+    });
+    expect(terminal.state.stateMachine?.history.at(-1)).toMatchObject({
+      type: "state_failed",
+      state: "wait_before_retry",
+    });
+  });
+
+  test("script states honor successCodes and forward stdout plus parsed state", async () => {
+    const { runner } = createTurnRunner();
+    const turnState = createStateMachineState("send_email");
+    runner.controlResults.push(
+      {
+        type: "select_state_machine_state",
+        decision: {
+          kind: "run_state",
+          state: "send_email",
+          override: {
+            kind: "script",
+            state: {
+              command: 'printf \'{"sent":true,"messageId":"msg_123"}\'; printf "warn" >&2; exit 2',
+              successCodes: [2],
+            },
+          },
+          input: { email: "ada@example.com" },
+        },
+      },
+      {
+        type: "select_state_machine_state",
+        decision: { kind: "terminal", state: "meeting_scheduled" },
+      },
+    );
+
+    const terminal = await runner.turn({
+      type: "prompt",
+      state: turnState,
+      message: "Send the email.",
+      behavior: "follow_up",
+    });
+
+    const started = terminal.state.stateMachine?.history.find(
+      (event) => event.type === "state_started" && event.state === "send_email",
+    );
+    expect(started?.type === "state_started" ? started.input : undefined).toMatchObject({
+      email: "ada@example.com",
+    });
+    const parentPrompt = runner.workerInputs[1]?.prompt ?? "";
+    expect(parentPrompt).toContain("<stdout>");
+    expect(parentPrompt).toContain("<stderr>warn</stderr>");
+    expect(parentPrompt).toContain("<exitCode>2</exitCode>");
+    expect(parentPrompt).toContain("msg_123");
+    expect(parentPrompt).toContain("<sent>true</sent>");
   });
 
   test("retries when the parent runner does not choose the next state after completion", async () => {
@@ -681,7 +928,7 @@ describe("TurnRunner protocol scenarios", () => {
     expect(runner.workerInputs[1]?.prompt).toBe(
       "Use the user's answer to continue the waiting state.",
     );
-    expect(runner.workerInputs[1]?.appendSystemPrompt).toContain("waiting_for_reply");
+    expect(runner.workerInputs[1]?.appendSystemPrompt).toBeUndefined();
     expect(terminal).toMatchObject({
       type: "complete",
       status: "completed",

--- a/test/turn-runner-tools.test.ts
+++ b/test/turn-runner-tools.test.ts
@@ -99,6 +99,85 @@ describe("TurnRunner tools", () => {
     expect(result.content).toEqual([{ type: "text", text: JSON.stringify(details, null, 2) }]);
   });
 
+  test("accepts state transition input that matches the selected state's schema", async () => {
+    const tools = createTurnRunnerTools({
+      cwd: process.cwd(),
+      mode: {
+        name: "outreach",
+        prompt: "Use for outreach work.",
+        states: [
+          {
+            kind: "script",
+            name: "send_email",
+            inputSchema: {
+              type: "object",
+              properties: { email: { type: "string" } },
+              required: ["email"],
+            },
+            command: "send '{{ input.email }}'",
+          },
+        ],
+      },
+    });
+    const selectStateTool = tools.find((tool) => tool.name === "select_state_machine_state");
+
+    expect(selectStateTool).toBeDefined();
+    if (!selectStateTool) throw new Error("select_state_machine_state tool missing");
+
+    const result = await selectStateTool.execute("tool-1", {
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        input: { email: "ada@example.com" },
+      },
+    });
+
+    expect(result.details).toMatchObject({
+      type: "select_state_machine_state",
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        input: { email: "ada@example.com" },
+      },
+    });
+  });
+
+  test("rejects state transition input that does not match the selected state's schema", async () => {
+    const tools = createTurnRunnerTools({
+      cwd: process.cwd(),
+      mode: {
+        name: "outreach",
+        prompt: "Use for outreach work.",
+        states: [
+          {
+            kind: "script",
+            name: "send_email",
+            inputSchema: {
+              type: "object",
+              properties: { email: { type: "string" } },
+              required: ["email"],
+            },
+            command: "send '{{ input.email }}'",
+          },
+        ],
+      },
+    });
+    const selectStateTool = tools.find((tool) => tool.name === "select_state_machine_state");
+
+    expect(selectStateTool).toBeDefined();
+    if (!selectStateTool) throw new Error("select_state_machine_state tool missing");
+
+    const result = selectStateTool.execute("tool-1", {
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        input: { email: 123 },
+      },
+    });
+
+    await expect(result).rejects.toThrow('Invalid input for state "send_email"');
+  });
+
   test("returns state-machine agent prompts in tool details and model-visible content", async () => {
     const tools = createTurnRunnerTools({
       cwd: process.cwd(),
@@ -199,4 +278,30 @@ describe("TurnRunner tools", () => {
     expect(stateMachineTools.some((tool) => tool.name === "select_state_machine_state")).toBe(true);
     expect(stateMachineTools.some((tool) => tool.name === "prompt_state_machine_agent")).toBe(true);
   });
+
+  test("describes tool schema properties for provider tool prompts", () => {
+    const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "auto" });
+    const createDefinitionTool = tools.find(
+      (tool) => tool.name === "create_state_machine_definition",
+    );
+    const selectStateTool = tools.find((tool) => tool.name === "select_state_machine_state");
+
+    expect(createDefinitionTool).toBeDefined();
+    expect(selectStateTool).toBeDefined();
+    if (!createDefinitionTool || !selectStateTool) throw new Error("Expected state-machine tools");
+
+    expect(createDefinitionTool.description).toContain("{{ input.email }}");
+    expect(selectStateTool.description).toContain("input object");
+    expect(propertyDescription(createDefinitionTool.parameters, "definition")).toContain(
+      "State-machine",
+    );
+    expect(propertyDescription(selectStateTool.parameters, "decision")).toContain(
+      "State transition",
+    );
+  });
 });
+
+function propertyDescription(schema: unknown, property: string): string {
+  const record = schema as { properties?: Record<string, { description?: string }> };
+  return record.properties?.[property]?.description ?? "";
+}

--- a/test/turn-runner-tools.test.ts
+++ b/test/turn-runner-tools.test.ts
@@ -72,6 +72,115 @@ describe("TurnRunner tools", () => {
     expect(result.content).toEqual([{ type: "text", text: JSON.stringify(details, null, 2) }]);
   });
 
+  test("accepts dynamically created definitions with required and optional input fields", async () => {
+    const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "auto" });
+    const createDefinitionTool = tools.find(
+      (tool) => tool.name === "create_state_machine_definition",
+    );
+
+    expect(createDefinitionTool).toBeDefined();
+    if (!createDefinitionTool) throw new Error("create_state_machine_definition tool missing");
+
+    const result = await createDefinitionTool.execute("tool-1", {
+      definition: {
+        name: "outreach",
+        prompt: "Use for outreach work.",
+        states: [
+          {
+            kind: "script",
+            name: "send_email",
+            inputSchema: {
+              type: "object",
+              properties: {
+                email: { type: "string" },
+                followUpCount: { type: "integer", minimum: 0 },
+              },
+              required: ["email"],
+              additionalProperties: false,
+            },
+            command: "send email",
+          },
+        ],
+      },
+    });
+
+    expect(result.details).toMatchObject({
+      type: "create_state_machine_definition",
+      definition: {
+        states: [
+          {
+            name: "send_email",
+            inputSchema: {
+              required: ["email"],
+              properties: {
+                email: { type: "string" },
+                followUpCount: { type: "integer", minimum: 0 },
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  test("rejects dynamically created definitions with invalid input schemas", async () => {
+    const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "auto" });
+    const createDefinitionTool = tools.find(
+      (tool) => tool.name === "create_state_machine_definition",
+    );
+
+    expect(createDefinitionTool).toBeDefined();
+    if (!createDefinitionTool) throw new Error("create_state_machine_definition tool missing");
+
+    const result = createDefinitionTool.execute("tool-1", {
+      definition: {
+        name: "outreach",
+        prompt: "Use for outreach work.",
+        states: [
+          {
+            kind: "script",
+            name: "send_email",
+            inputSchema: { type: "bogus" },
+            command: "send email",
+          },
+        ],
+      },
+    });
+
+    await expect(result).rejects.toThrow('Invalid inputSchema for state "send_email"');
+  });
+
+  test("rejects dynamically created definitions with invalid nested input schemas", async () => {
+    const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "auto" });
+    const createDefinitionTool = tools.find(
+      (tool) => tool.name === "create_state_machine_definition",
+    );
+
+    expect(createDefinitionTool).toBeDefined();
+    if (!createDefinitionTool) throw new Error("create_state_machine_definition tool missing");
+
+    const result = createDefinitionTool.execute("tool-1", {
+      definition: {
+        name: "outreach",
+        prompt: "Use for outreach work.",
+        states: [
+          {
+            kind: "script",
+            name: "send_email",
+            inputSchema: {
+              type: "object",
+              properties: { email: { type: "bogus" } },
+              required: ["email"],
+            },
+            command: "send email",
+          },
+        ],
+      },
+    });
+
+    await expect(result).rejects.toThrow('Invalid inputSchema for state "send_email"');
+  });
+
   test("returns selected state decisions in tool details and model-visible content", async () => {
     const tools = createTurnRunnerTools({
       cwd: process.cwd(),
@@ -111,8 +220,12 @@ describe("TurnRunner tools", () => {
             name: "send_email",
             inputSchema: {
               type: "object",
-              properties: { email: { type: "string" } },
+              properties: {
+                email: { type: "string" },
+                followUpCount: { type: "integer", minimum: 0 },
+              },
               required: ["email"],
+              additionalProperties: false,
             },
             command: "send '{{ input.email }}'",
           },
@@ -138,6 +251,23 @@ describe("TurnRunner tools", () => {
         kind: "run_state",
         state: "send_email",
         input: { email: "ada@example.com" },
+      },
+    });
+
+    const resultWithOptionalField = await selectStateTool.execute("tool-2", {
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        input: { email: "ada@example.com", followUpCount: 1 },
+      },
+    });
+
+    expect(resultWithOptionalField.details).toMatchObject({
+      type: "select_state_machine_state",
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        input: { email: "ada@example.com", followUpCount: 1 },
       },
     });
   });
@@ -176,6 +306,188 @@ describe("TurnRunner tools", () => {
     });
 
     await expect(result).rejects.toThrow('Invalid input for state "send_email"');
+  });
+
+  test("rejects state transition input that omits required fields", async () => {
+    const tools = createTurnRunnerTools({
+      cwd: process.cwd(),
+      mode: {
+        name: "outreach",
+        prompt: "Use for outreach work.",
+        states: [
+          {
+            kind: "script",
+            name: "send_email",
+            inputSchema: {
+              type: "object",
+              properties: {
+                email: { type: "string" },
+                followUpCount: { type: "integer" },
+              },
+              required: ["email"],
+            },
+            command: "send '{{ input.email }}'",
+          },
+        ],
+      },
+    });
+    const selectStateTool = tools.find((tool) => tool.name === "select_state_machine_state");
+
+    expect(selectStateTool).toBeDefined();
+    if (!selectStateTool) throw new Error("select_state_machine_state tool missing");
+
+    const result = selectStateTool.execute("tool-1", {
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        input: { followUpCount: 1 },
+      },
+    });
+
+    await expect(result).rejects.toThrow('Invalid input for state "send_email"');
+  });
+
+  test("rejects state transition input with unexpected optional fields when disallowed", async () => {
+    const tools = createTurnRunnerTools({
+      cwd: process.cwd(),
+      mode: {
+        name: "outreach",
+        prompt: "Use for outreach work.",
+        states: [
+          {
+            kind: "script",
+            name: "send_email",
+            inputSchema: {
+              type: "object",
+              properties: {
+                email: { type: "string" },
+                followUpCount: { type: "integer" },
+              },
+              required: ["email"],
+              additionalProperties: false,
+            },
+            command: "send '{{ input.email }}'",
+          },
+        ],
+      },
+    });
+    const selectStateTool = tools.find((tool) => tool.name === "select_state_machine_state");
+
+    expect(selectStateTool).toBeDefined();
+    if (!selectStateTool) throw new Error("select_state_machine_state tool missing");
+
+    const result = selectStateTool.execute("tool-1", {
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        input: { email: "ada@example.com", extra: true },
+      },
+    });
+
+    await expect(result).rejects.toThrow('Invalid input for state "send_email"');
+  });
+
+  test("rejects state transition overrides with invalid input schemas", async () => {
+    const tools = createTurnRunnerTools({
+      cwd: process.cwd(),
+      mode: {
+        name: "outreach",
+        prompt: "Use for outreach work.",
+        states: [{ kind: "script", name: "send_email", command: "send email" }],
+      },
+    });
+    const selectStateTool = tools.find((tool) => tool.name === "select_state_machine_state");
+
+    expect(selectStateTool).toBeDefined();
+    if (!selectStateTool) throw new Error("select_state_machine_state tool missing");
+
+    const result = selectStateTool.execute("tool-1", {
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        override: {
+          kind: "script",
+          state: { inputSchema: { type: "bogus" } },
+        },
+      },
+    });
+
+    await expect(result).rejects.toThrow('Invalid inputSchema for state "send_email"');
+  });
+
+  test("validates state transition input against override input schemas", async () => {
+    const tools = createTurnRunnerTools({
+      cwd: process.cwd(),
+      mode: {
+        name: "outreach",
+        prompt: "Use for outreach work.",
+        states: [
+          {
+            kind: "script",
+            name: "send_email",
+            inputSchema: {
+              type: "object",
+              properties: { email: { type: "string" } },
+              required: ["email"],
+            },
+            command: "send '{{ input.email }}'",
+          },
+        ],
+      },
+    });
+    const selectStateTool = tools.find((tool) => tool.name === "select_state_machine_state");
+
+    expect(selectStateTool).toBeDefined();
+    if (!selectStateTool) throw new Error("select_state_machine_state tool missing");
+
+    const accepted = await selectStateTool.execute("tool-1", {
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        override: {
+          kind: "script",
+          state: {
+            inputSchema: {
+              type: "object",
+              properties: { prospectId: { type: "string" } },
+              required: ["prospectId"],
+              additionalProperties: false,
+            },
+          },
+        },
+        input: { prospectId: "prospect-1" },
+      },
+    });
+
+    expect(accepted.details).toMatchObject({
+      type: "select_state_machine_state",
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        input: { prospectId: "prospect-1" },
+      },
+    });
+
+    const rejected = selectStateTool.execute("tool-2", {
+      decision: {
+        kind: "run_state",
+        state: "send_email",
+        override: {
+          kind: "script",
+          state: {
+            inputSchema: {
+              type: "object",
+              properties: { prospectId: { type: "string" } },
+              required: ["prospectId"],
+              additionalProperties: false,
+            },
+          },
+        },
+        input: { email: "ada@example.com" },
+      },
+    });
+
+    await expect(rejected).rejects.toThrow('Invalid input for state "send_email"');
   });
 
   test("returns state-machine agent prompts in tool details and model-visible content", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["src/**/*", "test/**/*", "evals/**/*"],
-  "exclude": ["node_modules", "dist", "examples"]
+  "include": ["src/**/*", "test/**/*", "evals/**/*", "examples/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Replace shared state-machine state/output schema flow with explicit transition input and `{{ input.* }}` templates for agent prompts and script commands.
- Add poll timer elapsed/timeout handling, per-state skill allowlists, and clearer tool schema descriptions for state-machine creation/selection.
- Typecheck examples and add focused tests/evals for template rendering and state-machine routing behavior.

## Test plan
- `bun run check-types`
- `bun test test/turn-runner-protocol.test.ts test/turn-runner-tools.test.ts ./evals/state-template.eval.ts`
- `bun run lint`
- `bun run eval`
- `bun run test`

Made with [Cursor](https://cursor.com)