### PR TITLE
Serialize active turn runner calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ const terminal = await turnRunner.turn({
 });
 ```
 
+`TurnRunner.turn()` is the concurrency boundary. Callers may call it repeatedly
+while work is active; the runner folds active `prompt` and `answer` commands
+back into the active pi agent as `steer` or `follow_up`, queues wakes and other
+work it cannot absorb immediately, and emits one terminal event when the whole
+active work chain is done. The parent runner transcript stays linear: state
+machine continuations, script results, poll results, and user follow-ups rejoin
+the parent agent rather than creating separate conversation branches.
+
 ## Memory And Persistence
 
 duet-agent owns a concrete event-emitting `MemoryStore` internally. It is the runtime state container, not a database adapter.

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ stateDiagram-v2
 
 Each state is one of the four kinds the runner understands:
 
-- **agent** states run a sub-agent with a prompt, context scope, and skill access.
+- **agent** states run a sub-agent with a prompt, optional system prompt, and optional skill allowlist.
 - **script** states shell out (`bash`, `curl`, CLIs) for anything with an API.
-- **poll** states wait on an external signal by re-running a script or prompt on an interval.
+- **poll** states wait on an external signal by running one script check per interval, or by using a timer poll for pure delays.
 - **terminal** states record a business outcome (`completed`, `cancelled`, `failed`).
 
 Observational memory, pi coding tools, and guardrails sit underneath every state transition; they
@@ -74,7 +74,7 @@ The memory model follows observational memory: turn runner session messages are 
 
 ### Pi Coding Tools
 
-Sub-agents use the default tools from `@mariozechner/pi-coding-agent`: read, bash, edit, and write. The turn runner supplies a working directory and filters the allowed tool names; it does not wrap those tools in a second sandbox abstraction.
+Sub-agents use the default tools from `@mariozechner/pi-coding-agent`: read, bash, edit, and write. The turn runner supplies a working directory and can restrict which skills are injected into a state-machine agent state; it does not wrap those tools in a second sandbox abstraction.
 
 ### Native Interrupts
 
@@ -82,7 +82,7 @@ Interrupt behavior comes from the underlying pi agent runtime. A user can send a
 
 ### Multi-Agent by Default
 
-The turn runner can delegate durable process steps into agent states. Agent states are not pre-built classes; they are state-machine states with prompts, context scope, model options, and skill access.
+The turn runner can delegate durable process steps into agent states. Agent states are not pre-built classes; they are state-machine states with prompts, optional system prompts, and optional skill allowlists.
 
 ### Three Execution Modes
 
@@ -98,13 +98,13 @@ The current code is still scaffolding, but this is the intended boundary: normal
 
 duet-agent is exploring long-running agent-routed state machines for business processes like outbound sales, conference outreach, and development loops. The design goal is **not** to become a workflow engine like Temporal, Airflow, or GitHub Actions.
 
-Instead, state machines are agent-routed. A state-machine definition describes the available business states: agent states, shell-script states, wait states, and terminal states. A state-machine runner agent sees the original prompt, current state, state history, and available state definitions, then decides what should happen next.
+Instead, state machines are agent-routed. A state-machine definition describes the available business states: agent states, shell-script states, poll states, and terminal states. The runner keeps the state-machine system prompt cache-friendly by including only stable routing instructions plus the original prompt and available state definitions. Current state and history stay in the parent agent conversation, where state transitions, script results, poll results, and user follow-ups are already recorded.
 
 The state machine is higher level than task execution. It tracks one current business state at a time. If a state needs fan-out, parallelism, or a task-level workflow, that belongs inside an agent or script state. The agent can execute a complex workflow internally; the state machine only records the business transition before and after that state.
 
 This keeps state machines flexible enough to start in the middle. For example, a user can say: "prospect person X, I've already sent email, just wait for response." The same outreach state machine can skip research and email sending, then choose the wait-for-response state because the runner agent understands the existing context.
 
-External integrations stay simple: anything with an API or CLI is a script state or polling wait. Email, GitHub, Calendly, CRM systems, and webhooks do not need first-class engine concepts. If the state machine can tolerate a few minutes of polling delay, a bash script is enough.
+External integrations stay simple: anything with an API or CLI is a script state or script poll. Timer polls cover pure delays such as "wait before retry." Email, GitHub, Calendly, CRM systems, and webhooks do not need first-class engine concepts. If the state machine can tolerate a few minutes of polling delay, a bash script is enough.
 
 What this is not:
 

--- a/evals/child-agent-resume.eval.ts
+++ b/evals/child-agent-resume.eval.ts
@@ -97,9 +97,9 @@ class EvalTurnRunner extends TurnRunner {
 
   protected override async runAgentWorker(
     input: AgentWorkerInput,
-    activeSlot: "parent" | "child" = "parent",
+    activeSlot: "parent" | "state_machine_child" = "parent",
   ): Promise<AgentWorkerResult> {
-    if (activeSlot === "child") {
+    if (activeSlot === "state_machine_child") {
       this.childInputs.push(input);
       const result = this.childResults.shift();
       if (!result) throw new Error("Missing child result");

--- a/evals/child-agent-resume.eval.ts
+++ b/evals/child-agent-resume.eval.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import {
+  TurnRunner,
+  type AgentWorkerInput,
+  type AgentWorkerResult,
+} from "../src/turn-runner/turn-runner.js";
+import type { TurnQuestion, TurnState } from "../src/types/protocol.js";
+import type { StateMachineDefinition } from "../src/types/state-machine.js";
+import type { TurnRunnerControlResult } from "../src/turn-runner/tools.js";
+
+describe("state-machine child agent resume", () => {
+  test("hydrates a child-agent ask terminal and resumes with an answer", async () => {
+    const firstRunner = new EvalTurnRunner({
+      childResults: [
+        {
+          type: "ask",
+          questions: [
+            { question: "Which company did Ada found?", options: [{ label: "Analytical" }] },
+          ],
+        },
+      ],
+      parentControls: [
+        { type: "select_state_machine_state", decision: { kind: "run_state", state: "ask_child" } },
+      ],
+    });
+
+    const askTerminal = await firstRunner.turn({
+      type: "start",
+      mode: childResumeDefinition,
+      prompt: "Run the child state and ask for missing company context.",
+    });
+
+    expect(askTerminal.type).toBe("ask");
+    if (askTerminal.type !== "ask") throw new Error("Expected child agent to ask a question.");
+    expect(askTerminal.state.status).toBe("waiting_for_human");
+    expect(askTerminal.state.stateMachine?.currentState).toBe("ask_child");
+
+    const hydratedState = JSON.parse(JSON.stringify(askTerminal.state)) as TurnState;
+    const secondRunner = new EvalTurnRunner({
+      childResults: [{ type: "complete", text: "Used the hydrated answer." }],
+      parentControls: [
+        { type: "select_state_machine_state", decision: { kind: "terminal", state: "done" } },
+      ],
+    });
+
+    const terminal = await secondRunner.turn({
+      type: "answer",
+      state: hydratedState,
+      questions: askTerminal.questions,
+      answers: { company: "Analytical Engines Ltd." },
+      behavior: "follow_up",
+    });
+
+    expect(terminal).toMatchObject({
+      type: "complete",
+      status: "completed",
+      state: {
+        status: "completed",
+        stateMachine: { terminal: { state: "done", status: "completed" } },
+      },
+    });
+    expect(secondRunner.childInputs).toHaveLength(1);
+    expect(messageText(secondRunner.childInputs[0]!.state)).toContain("Analytical Engines Ltd.");
+  });
+});
+
+const childResumeDefinition: StateMachineDefinition = {
+  name: "child_resume_eval",
+  prompt: "Use this state machine to test child agent answer hydration.",
+  states: [
+    {
+      kind: "agent",
+      name: "ask_child",
+      prompt: "Ask for missing company context, then use the answer.",
+    },
+    { kind: "terminal", name: "done", status: "completed" },
+  ],
+};
+
+type ChildResult = { type: "ask"; questions: TurnQuestion[] } | { type: "complete"; text: string };
+
+class EvalTurnRunner extends TurnRunner {
+  readonly parentInputs: AgentWorkerInput[] = [];
+  readonly childInputs: AgentWorkerInput[] = [];
+  private readonly parentControls: TurnRunnerControlResult[];
+  private readonly childResults: ChildResult[];
+
+  constructor(input: { parentControls: TurnRunnerControlResult[]; childResults: ChildResult[] }) {
+    super({
+      model: "anthropic:claude-opus-4-7",
+      skillDiscovery: { includeDefaults: false },
+    });
+    this.parentControls = [...input.parentControls];
+    this.childResults = [...input.childResults];
+  }
+
+  protected override async runAgentWorker(
+    input: AgentWorkerInput,
+    activeSlot: "parent" | "child" = "parent",
+  ): Promise<AgentWorkerResult> {
+    if (activeSlot === "child") {
+      this.childInputs.push(input);
+      const result = this.childResults.shift();
+      if (!result) throw new Error("Missing child result");
+      if (result.type === "ask") {
+        return {
+          control: { type: "ask_user_question", questions: result.questions },
+          terminal: {
+            type: "ask",
+            questions: result.questions,
+            state: {
+              ...input.state,
+              status: "waiting_for_human",
+              agent: {
+                status: "waiting",
+                messages: [...input.state.agent.messages, assistantMessage("What company?")],
+              },
+            },
+          },
+        };
+      }
+
+      const state = {
+        ...input.state,
+        status: "completed" as const,
+        agent: {
+          status: "completed" as const,
+          messages: [...input.state.agent.messages, assistantMessage(result.text)],
+        },
+      };
+      return {
+        control: { type: "none" },
+        terminal: { type: "complete", status: "completed", result: result.text, state },
+      };
+    }
+
+    this.parentInputs.push(input);
+    const control = this.parentControls.shift() ?? { type: "none" };
+    const state = {
+      ...input.state,
+      status: "completed" as const,
+      agent: {
+        status: "completed" as const,
+        messages: [...input.state.agent.messages, assistantMessage("Parent decision.")],
+      },
+    };
+    return {
+      control,
+      terminal: { type: "complete", status: "completed", result: "Parent decision.", state },
+    };
+  }
+}
+
+function assistantMessage(text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "unknown",
+    provider: "unknown",
+    model: "eval",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+function messageText(state: TurnState): string {
+  return state.agent.messages
+    .map((message) => {
+      const content = "content" in message ? message.content : undefined;
+      if (typeof content === "string") return content;
+      if (!Array.isArray(content)) return "";
+      return content
+        .map((part) =>
+          part && typeof part === "object" && "text" in part && typeof part.text === "string"
+            ? part.text
+            : "",
+        )
+        .join("\n");
+    })
+    .join("\n");
+}

--- a/evals/prompt-cache.eval.ts
+++ b/evals/prompt-cache.eval.ts
@@ -21,7 +21,9 @@ describe("prompt cache resume", () => {
     });
     expect(first.type).toBe("complete");
     const firstUsage = latestAssistantUsage(first.state);
-    expect(firstUsage.cacheWrite).toBeGreaterThan(0);
+    // The stable prefix may already be warm from a previous eval run, in which case
+    // the first turn reads from cache instead of reporting another cache write.
+    expect(firstUsage.cacheRead + firstUsage.cacheWrite).toBeGreaterThan(0);
 
     const resumedState = JSON.parse(JSON.stringify(first.state)) as TurnState;
     const second = await runner.turn({

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -105,7 +105,7 @@ export class Session {
           type: "prompt",
           state: this.state,
           message: input.prompt,
-          behavior: "steer",
+          behavior: "follow_up",
           ...(input.options ? { options: input.options } : {}),
         }
       : {
@@ -122,13 +122,14 @@ export class Session {
     this.cancelWake();
     const wasSleeping = state.status === "sleeping";
     this.restoreSleepAfterTurn = wasSleeping && this.isWaitingOnPoll(state);
-    this.dispatchTurn({
+    const command: TurnCommand = {
       type: "prompt",
       state,
       message: input.message,
-      behavior: input.behavior ?? "steer",
+      behavior: input.behavior ?? "follow_up",
       ...(input.options ? { options: input.options } : {}),
-    });
+    };
+    this.dispatchTurn(command);
   }
 
   async answer(input: SessionAnswerInput): Promise<void> {
@@ -162,6 +163,10 @@ export class Session {
     });
   }
 
+  isTurnActive(): boolean {
+    return Boolean(this.activeTurn);
+  }
+
   async dispose(): Promise<void> {
     this.unsubscribeRunner();
     this.cancelWake();
@@ -175,7 +180,7 @@ export class Session {
       .then(() => undefined)
       .catch((error) => {
         this.emit({
-          type: "log",
+          type: "system",
           level: "error",
           message: error instanceof Error ? error.message : String(error),
         });
@@ -214,6 +219,13 @@ export class Session {
       this.isWaitingOnPoll(event.state)
     ) {
       this.restoreSleepAfterTurn = false;
+      if (event.status === "failed") {
+        this.emit({
+          type: "system",
+          level: "error",
+          message: event.error ?? event.result ?? "Prompt failed while waiting on poll.",
+        });
+      }
       const state = this.currentPollState(event.state);
       return {
         type: "sleep",

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -64,6 +64,7 @@ export interface AgentWorkerInput {
   appendSystemPrompt?: string;
   skills?: Skill[];
   tools: AgentTool[];
+  agentScope?: "parent" | "child";
 }
 
 export interface AgentWorkerResult {
@@ -95,10 +96,20 @@ export class TurnRunner {
   private memoryStorageDispose?: () => Promise<void>;
   /** Current pi agent, if a model turn is active; used for out-of-band interruption. */
   private activeAgent?: Agent;
+  /** Whether the active pi agent owns the parent transcript or a state-machine child turn. */
+  private activeAgentScope?: "parent" | "child";
   /** Current script or poll abort controller, used to interrupt non-agent state work. */
   private activeAbortController?: AbortController;
   /** Terminal event prepared by `interrupt()` and returned when active work unwinds. */
   private interruptedTerminal?: TurnTerminalEvent;
+  /**
+   * Active work-chain promise. Callers may call turn() repeatedly while this is
+   * set; those commands either join the active pi agent as steer/follow-up or
+   * queue behind non-agent work. The runner emits one terminal for the chain.
+   */
+  private activeTurnPromise?: Promise<TurnTerminalEvent>;
+  /** Commands that could not be absorbed into the active pi agent and must run later. */
+  private readonly queuedTurnCommands: TurnCommand[] = [];
   /** Explicit and discovered skills available for prompt injection and slash commands. */
   private skills: Skill[] = [];
   /** Ensures skill discovery runs once even when multiple turns share this runner. */
@@ -127,24 +138,113 @@ export class TurnRunner {
   async turn(command: TurnCommand): Promise<TurnTerminalEvent> {
     await this.ensureMemoryLoaded();
     await this.ensureSkillsLoaded();
+    if (this.activeTurnPromise) {
+      // turn() is the concurrency boundary: repeated calls extend or queue
+      // behind the active chain instead of creating a separate parent transcript.
+      this.handleCommandDuringActiveTurn(command);
+      return this.activeTurnPromise;
+    }
+
+    const activeTurnPromise = this.runTurnChain(command);
+    this.activeTurnPromise = activeTurnPromise;
+    try {
+      return await activeTurnPromise;
+    } finally {
+      if (this.activeTurnPromise === activeTurnPromise) {
+        this.activeTurnPromise = undefined;
+      }
+    }
+  }
+
+  private async runTurnChain(command: TurnCommand): Promise<TurnTerminalEvent> {
     this.emit({ type: "ready" });
     let terminal: TurnTerminalEvent;
-    switch (command.type) {
-      case "start":
-        terminal = await this.start(command);
-        break;
-      case "prompt":
-        terminal = await this.prompt(command);
-        break;
-      case "answer":
-        terminal = await this.answer(command);
-        break;
-      case "wake":
-        terminal = await this.wake(command);
-        break;
-    }
+    terminal = await this.executeTurnCommand(command);
+    terminal = await this.drainQueuedTurnCommands(terminal);
     this.emit(terminal);
     return terminal;
+  }
+
+  private async executeTurnCommand(command: TurnCommand): Promise<TurnTerminalEvent> {
+    switch (command.type) {
+      case "start":
+        return this.start(command);
+      case "prompt":
+        return this.prompt(command);
+      case "answer":
+        return this.answer(command);
+      case "wake":
+        return this.wake(command);
+    }
+  }
+
+  private handleCommandDuringActiveTurn(command: TurnCommand): void {
+    if ((command.type === "prompt" || command.type === "answer") && this.activeAgent) {
+      if (this.activeAgentScope === "child" && command.type !== "answer") {
+        this.queuedTurnCommands.push(command);
+        return;
+      }
+      const message = this.commandToUserMessage(command);
+      const agentMessage = { role: "user" as const, content: message, timestamp: Date.now() };
+      if (command.behavior === "steer") {
+        this.activeAgent.steer(agentMessage);
+      } else {
+        // State-machine continuations and normal user input stay linear by
+        // entering the active parent transcript as pi follow-ups.
+        this.activeAgent.followUp(agentMessage);
+      }
+      return;
+    }
+
+    this.queuedTurnCommands.push(command);
+  }
+
+  private async drainQueuedTurnCommands(terminal: TurnTerminalEvent): Promise<TurnTerminalEvent> {
+    let latest = terminal;
+    while (this.queuedTurnCommands.length > 0) {
+      if (
+        latest.type === "interrupted" ||
+        (latest.type === "complete" && latest.status === "failed")
+      ) {
+        this.queuedTurnCommands.length = 0;
+        return latest;
+      }
+      const queued = this.queuedTurnCommands.shift()!;
+      const command = this.rebaseQueuedCommand(queued, latest.state);
+      latest = await this.executeTurnCommand(command);
+    }
+    return latest;
+  }
+
+  private rebaseQueuedCommand(command: TurnCommand, state: TurnState): TurnCommand {
+    switch (command.type) {
+      case "start":
+        return {
+          type: "prompt",
+          state,
+          message: command.prompt,
+          behavior: "follow_up",
+          options: command.options,
+        };
+      case "prompt":
+        return { ...command, state };
+      case "answer":
+        return { ...command, state };
+      case "wake":
+        return { ...command, state };
+    }
+  }
+
+  private commandToUserMessage(command: TurnPromptCommand | TurnAnswerCommand): string {
+    if (command.type === "prompt") {
+      return this.resolveSlashSkillPrompt(command.message);
+    }
+
+    return dedent`
+      Here are my answers to your questions.
+
+      ${toXML([{ questions: command.questions }, { answers: command.answers }])}
+    `;
   }
 
   interrupt(command: TurnInterruptCommand): void {
@@ -164,7 +264,10 @@ export class TurnRunner {
     }
     this.activeAgent?.abort();
     this.activeAbortController?.abort();
+    this.activeAgent?.clearAllQueues();
+    this.queuedTurnCommands.length = 0;
     this.activeAgent = undefined;
+    this.activeAgentScope = undefined;
     this.activeAbortController = undefined;
   }
 
@@ -195,16 +298,19 @@ export class TurnRunner {
   protected async prompt(command: TurnPromptCommand): Promise<TurnTerminalEvent> {
     const state: TurnState = { ...command.state, status: "running" };
     const prompt = this.resolveSlashSkillPrompt(command.message);
+    let terminal: TurnTerminalEvent;
     if (state.mode === "agent") {
-      return this.runAgentMode(state, prompt, command.options);
+      terminal = await this.runAgentMode(state, prompt, command.options);
+    } else {
+      terminal = await this.runTurnRunnerAgentWithStateMachineTools({
+        state,
+        prompt,
+        mode: state.mode,
+        options: command.options,
+      });
     }
 
-    return this.runTurnRunnerAgentWithStateMachineTools({
-      state,
-      prompt,
-      mode: state.mode,
-      options: command.options,
-    });
+    return this.restoreSleepAfterPromptIfNeeded(command.state, terminal);
   }
 
   protected async answer(command: TurnAnswerCommand): Promise<TurnTerminalEvent> {
@@ -365,6 +471,7 @@ export class TurnRunner {
       control = result;
     });
     this.activeAgent = agent;
+    this.activeAgentScope = input.agentScope ?? "parent";
 
     const unsubscribe = agent.subscribe((event) => this.emitAgentEvent(event));
     try {
@@ -377,6 +484,7 @@ export class TurnRunner {
       unsubscribe();
       if (this.activeAgent === agent) {
         this.activeAgent = undefined;
+        this.activeAgentScope = undefined;
       }
     }
 
@@ -663,6 +771,7 @@ export class TurnRunner {
         prompt,
         appendSystemPrompt: state.systemPrompt,
         skills: this.resolveStateAgentSkills(state),
+        agentScope: "child",
         ...this.createTools("agent"),
       })
     ).terminal;
@@ -814,6 +923,34 @@ export class TurnRunner {
       type: "sleep",
       wakeAt: Date.now() + state.intervalMs,
       state: { ...session, status: "sleeping" },
+    };
+  }
+
+  private restoreSleepAfterPromptIfNeeded(
+    originalState: TurnState,
+    terminal: TurnTerminalEvent,
+  ): TurnTerminalEvent {
+    if (
+      originalState.status !== "sleeping" ||
+      terminal.type !== "complete" ||
+      !this.isWaitingOnPoll(terminal.state)
+    ) {
+      return terminal;
+    }
+
+    if (terminal.status === "failed") {
+      this.emit({
+        type: "system",
+        level: "error",
+        message: terminal.error ?? terminal.result ?? "Prompt failed while waiting on poll.",
+      });
+    }
+
+    const state = this.currentPollState(terminal.state);
+    return {
+      type: "sleep",
+      wakeAt: Date.now() + (state?.intervalMs ?? 0),
+      state: { ...terminal.state, status: "sleeping" },
     };
   }
 
@@ -979,6 +1116,18 @@ export class TurnRunner {
 
   private findState(session: StateMachineSession, name: string): StateMachineState | undefined {
     return session.definition.states.find((state) => state.name === name);
+  }
+
+  private isWaitingOnPoll(state: TurnState | undefined): boolean {
+    return Boolean(this.currentPollState(state) && !state?.stateMachine?.terminal);
+  }
+
+  private currentPollState(state: TurnState | undefined): StateMachinePollState | undefined {
+    const stateMachine = state?.stateMachine;
+    const currentState = stateMachine?.currentState;
+    if (!stateMachine || !currentState) return undefined;
+    const definitionState = this.findState(stateMachine, currentState);
+    return definitionState?.kind === "poll" ? definitionState : undefined;
   }
 
   private appendUserMessage(session: TurnState, text: string): TurnState {

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -84,8 +84,6 @@ type ActiveStateWork =
       promptTerminal?: Promise<TurnTerminalEvent>;
     };
 
-type ActiveAgentSlot = "parent" | "state_machine_child";
-
 function parseSlashCommands(prompt: string): {
   commands: string[];
 } {
@@ -544,7 +542,7 @@ export class TurnRunner {
 
   protected async runAgentWorker(
     input: AgentWorkerInput,
-    activeSlot: ActiveAgentSlot = "parent",
+    activeSlot: "parent" | "state_machine_child" = "parent",
   ): Promise<AgentWorkerResult> {
     if (activeSlot === "parent" && this.activeAgent) {
       throw new Error("Cannot start a parent agent while another parent agent is active.");

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -544,6 +544,13 @@ export class TurnRunner {
     input: AgentWorkerInput,
     activeSlot: "parent" | "child" = "parent",
   ): Promise<AgentWorkerResult> {
+    if (activeSlot === "parent" && this.activeAgent) {
+      throw new Error("Cannot start a parent agent while another parent agent is active.");
+    }
+    if (activeSlot === "child" && this.activeChildAgent) {
+      throw new Error("Cannot start a child agent while another child agent is active.");
+    }
+
     let control: TurnRunnerControlResult = { type: "none" };
     const agent = this.createAgent(input, (result) => {
       control = result;

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -84,6 +84,8 @@ type ActiveStateWork =
       promptTerminal?: Promise<TurnTerminalEvent>;
     };
 
+type ActiveAgentSlot = "parent" | "state_machine_child";
+
 function parseSlashCommands(prompt: string): {
   commands: string[];
 } {
@@ -542,13 +544,15 @@ export class TurnRunner {
 
   protected async runAgentWorker(
     input: AgentWorkerInput,
-    activeSlot: "parent" | "child" = "parent",
+    activeSlot: ActiveAgentSlot = "parent",
   ): Promise<AgentWorkerResult> {
     if (activeSlot === "parent" && this.activeAgent) {
       throw new Error("Cannot start a parent agent while another parent agent is active.");
     }
-    if (activeSlot === "child" && this.activeChildAgent) {
-      throw new Error("Cannot start a child agent while another child agent is active.");
+    if (activeSlot === "state_machine_child" && this.activeChildAgent) {
+      throw new Error(
+        "Cannot start a state-machine child agent while another child agent is active.",
+      );
     }
 
     let control: TurnRunnerControlResult = { type: "none" };
@@ -863,7 +867,7 @@ export class TurnRunner {
           skills: this.resolveStateAgentSkills(state),
           ...this.createTools("agent"),
         },
-        "child",
+        "state_machine_child",
       )
     ).terminal;
     const parentSession = { ...session, agent: childResult.state.agent };

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -112,9 +112,9 @@ export class TurnRunner {
    */
   private activeAgent?: Agent;
   /**
-   * Active state-machine child pi agent. Child agents run without state-machine
-   * tools, so only structured answers are passed through directly; prompts queue
-   * for the parent to handle after the child state finishes.
+   * Active state-machine child pi agent, when a child state is running. Child
+   * agents run without state-machine tools; only command types explicitly routed
+   * to children should use this slot, while normal prompts queue for the parent.
    */
   private activeChildAgent?: Agent;
   /** Current script or poll abort controller, used to interrupt non-agent state work. */
@@ -203,26 +203,14 @@ export class TurnRunner {
 
   private handleCommandDuringActiveTurn(command: TurnCommand): void {
     if ((command.type === "prompt" || command.type === "answer") && this.activeAgent) {
-      const message = this.commandToUserMessage(command);
-      const agentMessage = { role: "user" as const, content: message, timestamp: Date.now() };
-      if (command.behavior === "steer") {
-        this.activeAgent.steer(agentMessage);
-      } else {
-        // State-machine continuations and normal user input stay linear by
-        // entering the active parent transcript as pi follow-ups.
-        this.activeAgent.followUp(agentMessage);
-      }
+      // State-machine continuations and normal user input stay linear by
+      // entering the active parent transcript as pi follow-ups.
+      this.sendCommandToAgent(this.activeAgent, command);
       return;
     }
 
     if (command.type === "answer" && this.activeChildAgent) {
-      const message = this.commandToUserMessage(command);
-      const agentMessage = { role: "user" as const, content: message, timestamp: Date.now() };
-      if (command.behavior === "steer") {
-        this.activeChildAgent.steer(agentMessage);
-      } else {
-        this.activeChildAgent.followUp(agentMessage);
-      }
+      this.sendCommandToAgent(this.activeChildAgent, command);
       return;
     }
 
@@ -235,6 +223,16 @@ export class TurnRunner {
     }
 
     this.queuedTurnCommands.push(command);
+  }
+
+  private sendCommandToAgent(agent: Agent, command: TurnPromptCommand | TurnAnswerCommand): void {
+    const message = this.commandToUserMessage(command);
+    const agentMessage = { role: "user" as const, content: message, timestamp: Date.now() };
+    if (command.behavior === "steer") {
+      agent.steer(agentMessage);
+    } else {
+      agent.followUp(agentMessage);
+    }
   }
 
   private async drainQueuedTurnCommands(terminal: TurnTerminalEvent): Promise<TurnTerminalEvent> {

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -72,6 +72,19 @@ export interface AgentWorkerResult {
   control: TurnRunnerControlResult;
 }
 
+type ShellCommandOutput = { stdout: string; stderr: string; exitCode: number };
+
+type ActiveStateWork =
+  | { kind: "script" }
+  | {
+      kind: "poll";
+      session: TurnState;
+      state: StateMachinePollState;
+      promptStarted: Promise<void>;
+      resolvePromptStarted: () => void;
+      promptTerminal?: Promise<TurnTerminalEvent>;
+    };
+
 function parseSlashCommands(prompt: string): {
   commands: string[];
 } {
@@ -100,6 +113,8 @@ export class TurnRunner {
   private activeAgentScope?: "parent" | "child";
   /** Current script or poll abort controller, used to interrupt non-agent state work. */
   private activeAbortController?: AbortController;
+  /** Current non-agent state work, if a script or poll owns the active turn. */
+  private activeStateWork?: ActiveStateWork;
   /** Terminal event prepared by `interrupt()` and returned when active work unwinds. */
   private interruptedTerminal?: TurnTerminalEvent;
   /**
@@ -110,6 +125,8 @@ export class TurnRunner {
   private activeTurnPromise?: Promise<TurnTerminalEvent>;
   /** Commands that could not be absorbed into the active pi agent and must run later. */
   private readonly queuedTurnCommands: TurnCommand[] = [];
+  /** Prevents queued user prompts from recursively preempting continuation prompts. */
+  private drainingQueuedCommandsBeforeContinuation = false;
   /** Explicit and discovered skills available for prompt injection and slash commands. */
   private skills: Skill[] = [];
   /** Ensures skill discovery runs once even when multiple turns share this runner. */
@@ -196,6 +213,14 @@ export class TurnRunner {
       return;
     }
 
+    if (
+      (command.type === "prompt" || command.type === "answer") &&
+      this.activeStateWork?.kind === "poll"
+    ) {
+      this.runPromptDuringActivePoll(this.activeStateWork, command);
+      return;
+    }
+
     this.queuedTurnCommands.push(command);
   }
 
@@ -235,6 +260,42 @@ export class TurnRunner {
     }
   }
 
+  private runPromptDuringActivePoll(
+    work: Extract<ActiveStateWork, { kind: "poll" }>,
+    command: TurnPromptCommand | TurnAnswerCommand,
+  ): void {
+    if (work.promptTerminal) {
+      this.queuedTurnCommands.push(command);
+      return;
+    }
+
+    const prompt = this.commandToUserMessage(command);
+    work.promptTerminal = this.prompt({
+      type: "prompt",
+      state: { ...work.session, status: "running" },
+      message: prompt,
+      behavior: command.behavior,
+      options: command.options,
+    }).then((terminal) => this.restorePollSleepAfterMidPollPrompt(work, terminal));
+    work.resolvePromptStarted();
+  }
+
+  private restorePollSleepAfterMidPollPrompt(
+    work: Extract<ActiveStateWork, { kind: "poll" }>,
+    terminal: TurnTerminalEvent,
+  ): TurnTerminalEvent {
+    if (terminal.type !== "complete" || terminal.status !== "completed") {
+      return terminal;
+    }
+
+    const currentPoll = this.currentPollState(terminal.state);
+    if (!currentPoll || currentPoll.name !== work.state.name) {
+      return terminal;
+    }
+
+    return this.sleep(terminal.state, currentPoll);
+  }
+
   private commandToUserMessage(command: TurnPromptCommand | TurnAnswerCommand): string {
     if (command.type === "prompt") {
       return this.resolveSlashSkillPrompt(command.message);
@@ -269,6 +330,7 @@ export class TurnRunner {
     this.activeAgent = undefined;
     this.activeAgentScope = undefined;
     this.activeAbortController = undefined;
+    this.activeStateWork = undefined;
   }
 
   protected emit(event: TurnEvent): void {
@@ -806,6 +868,7 @@ export class TurnRunner {
   ): Promise<TurnTerminalEvent> {
     const abortController = new AbortController();
     this.activeAbortController = abortController;
+    this.activeStateWork = { kind: "script" };
     try {
       const command = this.renderTemplate(state.command, session.stateMachine?.currentInput ?? {});
       const shellOutput = await this.runShellCommand(command, {
@@ -844,6 +907,9 @@ export class TurnRunner {
       if (this.activeAbortController === abortController) {
         this.activeAbortController = undefined;
       }
+      if (this.activeStateWork?.kind === "script") {
+        this.activeStateWork = undefined;
+      }
     }
   }
 
@@ -875,31 +941,85 @@ export class TurnRunner {
       );
     } else {
       const abortController = new AbortController();
+      let resolvePromptStarted!: () => void;
+      const promptStarted = new Promise<void>((resolve) => {
+        resolvePromptStarted = resolve;
+      });
+      const work: Extract<ActiveStateWork, { kind: "poll" }> = {
+        kind: "poll",
+        session,
+        state,
+        promptStarted,
+        resolvePromptStarted,
+      };
       this.activeAbortController = abortController;
+      this.activeStateWork = work;
       try {
         const command = this.renderTemplate(
           state.poll.command,
           session.stateMachine?.currentInput ?? {},
         );
-        const shellOutput = await this.runShellCommand(command, {
+        let settledShell:
+          | { status: "fulfilled"; value: ShellCommandOutput }
+          | { status: "rejected"; reason: unknown }
+          | undefined;
+        const shellPromise = this.runShellCommand(command, {
           cwd: state.poll.cwd ?? this.config.cwd ?? process.cwd(),
           signal: abortController.signal,
           successCodes: state.poll.successCodes,
-        });
-        const { stdout } = shellOutput;
-        const output = this.parseJsonObject(stdout);
-        if (Object.keys(output).length > 0) {
-          const rawOutput = {
-            ...shellOutput,
-            stdout: stdout.trim(),
-            stderr: shellOutput.stderr.trim(),
-            parsed: output,
-          };
-          return this.continueStateMachineAfterStateCompleted(
-            this.recordStateCompleted(session, state.name, rawOutput),
-            state.name,
-            rawOutput,
+        }).then(
+          (value) => {
+            settledShell = { status: "fulfilled", value };
+            return value;
+          },
+          (reason) => {
+            settledShell = { status: "rejected", reason };
+            throw reason;
+          },
+        );
+        shellPromise.catch(() => undefined);
+
+        const first = await Promise.race([
+          shellPromise.then(
+            () => "shell" as const,
+            () => "shell" as const,
+          ),
+          work.promptStarted.then(() => "prompt" as const),
+        ]);
+
+        if (first === "prompt") {
+          const promptTerminal = await work.promptTerminal;
+          if (!promptTerminal) {
+            return this.sleep(session, state);
+          }
+          if (!settledShell) {
+            abortController.abort();
+            return promptTerminal;
+          }
+          if (settledShell.status === "rejected") {
+            return promptTerminal;
+          }
+          return this.completePollStateAfterShellResult(
+            { ...promptTerminal.state, status: "running" },
+            state,
+            settledShell.value,
           );
+        }
+
+        if (work.promptTerminal) {
+          const promptTerminal = await work.promptTerminal;
+          if (settledShell?.status === "fulfilled") {
+            return this.completePollStateAfterShellResult(
+              { ...promptTerminal.state, status: "running" },
+              state,
+              settledShell.value,
+            );
+          }
+          return promptTerminal;
+        }
+
+        if (settledShell?.status === "fulfilled") {
+          return this.completePollStateAfterShellResult(session, state, settledShell.value);
         }
       } catch {
         if (this.interruptedTerminal) {
@@ -912,10 +1032,37 @@ export class TurnRunner {
         if (this.activeAbortController === abortController) {
           this.activeAbortController = undefined;
         }
+        if (this.activeStateWork === work) {
+          this.activeStateWork = undefined;
+        }
       }
     }
 
     return this.sleep(session, state);
+  }
+
+  private completePollStateAfterShellResult(
+    session: TurnState,
+    state: StateMachinePollState,
+    shellOutput: ShellCommandOutput,
+  ): Promise<TurnTerminalEvent> | TurnTerminalEvent {
+    const { stdout } = shellOutput;
+    const output = this.parseJsonObject(stdout);
+    if (Object.keys(output).length === 0) {
+      return this.sleep(session, state);
+    }
+
+    const rawOutput = {
+      ...shellOutput,
+      stdout: stdout.trim(),
+      stderr: shellOutput.stderr.trim(),
+      parsed: output,
+    };
+    return this.continueStateMachineAfterStateCompleted(
+      this.recordStateCompleted(session, state.name, rawOutput),
+      state.name,
+      rawOutput,
+    );
   }
 
   private sleep(session: TurnState, state: StateMachinePollState): TurnTerminalEvent {
@@ -980,6 +1127,23 @@ export class TurnRunner {
   ): Promise<TurnTerminalEvent> {
     if (session.mode === "agent") {
       return this.complete(session, "completed", typeof output === "string" ? output : undefined);
+    }
+
+    if (!this.drainingQueuedCommandsBeforeContinuation && this.queuedTurnCommands.length > 0) {
+      this.drainingQueuedCommandsBeforeContinuation = true;
+      try {
+        const terminal = await this.drainQueuedTurnCommands({
+          type: "complete",
+          status: "completed",
+          state: session,
+        });
+        if (terminal.type !== "complete" || terminal.status !== "completed") {
+          return terminal;
+        }
+        session = terminal.state;
+      } finally {
+        this.drainingQueuedCommandsBeforeContinuation = false;
+      }
     }
 
     let nextSession = session;
@@ -1257,7 +1421,7 @@ export class TurnRunner {
       signal: AbortSignal;
       successCodes?: number[];
     },
-  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  ): Promise<ShellCommandOutput> {
     try {
       const result = await execFileAsync("sh", ["-lc", command], {
         cwd: options.cwd,

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -64,7 +64,6 @@ export interface AgentWorkerInput {
   appendSystemPrompt?: string;
   skills?: Skill[];
   tools: AgentTool[];
-  agentScope?: "parent" | "child";
 }
 
 export interface AgentWorkerResult {
@@ -107,10 +106,17 @@ export class TurnRunner {
   protected readonly memory = new MemoryStore();
   /** Stops memory persistence subscriptions/databases when the runner is disposed. */
   private memoryStorageDispose?: () => Promise<void>;
-  /** Current pi agent, if a model turn is active; used for out-of-band interruption. */
+  /**
+   * Active parent pi agent. Prompts, steers, and follow-ups only target this
+   * transcript so all user-visible conversation stays linear in the parent.
+   */
   private activeAgent?: Agent;
-  /** Whether the active pi agent owns the parent transcript or a state-machine child turn. */
-  private activeAgentScope?: "parent" | "child";
+  /**
+   * Active state-machine child pi agent. Child agents run without state-machine
+   * tools, so only structured answers are passed through directly; prompts queue
+   * for the parent to handle after the child state finishes.
+   */
+  private activeChildAgent?: Agent;
   /** Current script or poll abort controller, used to interrupt non-agent state work. */
   private activeAbortController?: AbortController;
   /** Current non-agent state work, if a script or poll owns the active turn. */
@@ -197,10 +203,6 @@ export class TurnRunner {
 
   private handleCommandDuringActiveTurn(command: TurnCommand): void {
     if ((command.type === "prompt" || command.type === "answer") && this.activeAgent) {
-      if (this.activeAgentScope === "child" && command.type !== "answer") {
-        this.queuedTurnCommands.push(command);
-        return;
-      }
       const message = this.commandToUserMessage(command);
       const agentMessage = { role: "user" as const, content: message, timestamp: Date.now() };
       if (command.behavior === "steer") {
@@ -209,6 +211,17 @@ export class TurnRunner {
         // State-machine continuations and normal user input stay linear by
         // entering the active parent transcript as pi follow-ups.
         this.activeAgent.followUp(agentMessage);
+      }
+      return;
+    }
+
+    if (command.type === "answer" && this.activeChildAgent) {
+      const message = this.commandToUserMessage(command);
+      const agentMessage = { role: "user" as const, content: message, timestamp: Date.now() };
+      if (command.behavior === "steer") {
+        this.activeChildAgent.steer(agentMessage);
+      } else {
+        this.activeChildAgent.followUp(agentMessage);
       }
       return;
     }
@@ -318,17 +331,19 @@ export class TurnRunner {
         agent: { ...interruptedState.agent, status: "cancelled" },
       },
     };
-    if (this.activeAgent || this.activeAbortController) {
+    if (this.activeAgent || this.activeChildAgent || this.activeAbortController) {
       // The active turn emits this terminal event after agent.prompt() unwinds.
       // interrupt() only aborts out-of-band; it does not own turn completion.
       this.interruptedTerminal = terminal;
     }
     this.activeAgent?.abort();
+    this.activeChildAgent?.abort();
     this.activeAbortController?.abort();
     this.activeAgent?.clearAllQueues();
+    this.activeChildAgent?.clearAllQueues();
     this.queuedTurnCommands.length = 0;
     this.activeAgent = undefined;
-    this.activeAgentScope = undefined;
+    this.activeChildAgent = undefined;
     this.activeAbortController = undefined;
     this.activeStateWork = undefined;
   }
@@ -527,13 +542,19 @@ export class TurnRunner {
     return workerResult.terminal;
   }
 
-  protected async runAgentWorker(input: AgentWorkerInput): Promise<AgentWorkerResult> {
+  protected async runAgentWorker(
+    input: AgentWorkerInput,
+    activeSlot: "parent" | "child" = "parent",
+  ): Promise<AgentWorkerResult> {
     let control: TurnRunnerControlResult = { type: "none" };
     const agent = this.createAgent(input, (result) => {
       control = result;
     });
-    this.activeAgent = agent;
-    this.activeAgentScope = input.agentScope ?? "parent";
+    if (activeSlot === "parent") {
+      this.activeAgent = agent;
+    } else {
+      this.activeChildAgent = agent;
+    }
 
     const unsubscribe = agent.subscribe((event) => this.emitAgentEvent(event));
     try {
@@ -544,9 +565,10 @@ export class TurnRunner {
       }
     } finally {
       unsubscribe();
-      if (this.activeAgent === agent) {
+      if (activeSlot === "parent" && this.activeAgent === agent) {
         this.activeAgent = undefined;
-        this.activeAgentScope = undefined;
+      } else if (activeSlot === "child" && this.activeChildAgent === agent) {
+        this.activeChildAgent = undefined;
       }
     }
 
@@ -828,14 +850,16 @@ export class TurnRunner {
       agent: { ...session.agent, status: "running" },
     };
     const childResult = (
-      await this.runAgentWorker({
-        state: childState,
-        prompt,
-        appendSystemPrompt: state.systemPrompt,
-        skills: this.resolveStateAgentSkills(state),
-        agentScope: "child",
-        ...this.createTools("agent"),
-      })
+      await this.runAgentWorker(
+        {
+          state: childState,
+          prompt,
+          appendSystemPrompt: state.systemPrompt,
+          skills: this.resolveStateAgentSkills(state),
+          ...this.createTools("agent"),
+        },
+        "child",
+      )
     ).terminal;
     const parentSession = { ...session, agent: childResult.state.agent };
     const rawOutput = {

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -563,9 +563,9 @@ export class TurnRunner {
       }
     } finally {
       unsubscribe();
-      if (activeSlot === "parent" && this.activeAgent === agent) {
+      if (activeSlot === "parent") {
         this.activeAgent = undefined;
-      } else if (activeSlot === "child" && this.activeChildAgent === agent) {
+      } else {
         this.activeChildAgent = undefined;
       }
     }

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -147,6 +147,9 @@ export class TurnRunner {
   }
 
   async dispose(): Promise<void> {
+    this.activeAgent?.clearAllQueues();
+    this.activeChildAgent?.clearAllQueues();
+    this.queuedTurnCommands.length = 0;
     await this.memoryStorageDispose?.();
     this.memoryStorageDispose = undefined;
   }
@@ -162,6 +165,9 @@ export class TurnRunner {
     await this.ensureMemoryLoaded();
     await this.ensureSkillsLoaded();
     if (this.activeTurnPromise) {
+      if (command.type === "start") {
+        throw new Error("Cannot start a new turn while another turn is active.");
+      }
       // turn() is the concurrency boundary: repeated calls extend or queue
       // behind the active chain instead of creating a separate parent transcript.
       this.handleCommandDuringActiveTurn(command);

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -246,7 +246,13 @@ export interface TurnStartCommand {
   options?: TurnOptions;
 }
 
-/** Send a new user prompt while turn state exists. */
+/**
+ * Send a new user prompt while turn state exists.
+ *
+ * Callers may send prompt commands even while a previous `turn()` call is
+ * active. The turn runner maps `behavior` onto the active pi agent when it can
+ * and otherwise queues the command behind active non-agent work.
+ */
 export interface TurnPromptCommand {
   type: "prompt";
   /** Existing turn state to continue. */
@@ -257,7 +263,13 @@ export interface TurnPromptCommand {
   options?: TurnOptions;
 }
 
-/** Provide answers to a structured question emitted by the runner. */
+/**
+ * Provide answers to a structured question emitted by the runner.
+ *
+ * Answers serialize into parent-agent prompt text and follow the same active
+ * turn behavior as prompts, except answers to current child-agent questions may
+ * be routed directly to that child agent.
+ */
 export interface TurnAnswerCommand {
   type: "answer";
   /** Existing turn state to continue. */
@@ -345,14 +357,18 @@ export interface TurnSleepEvent extends TurnTerminalBaseEvent {
   wakeAt: number;
 }
 
-export interface TurnLogEvent {
-  type: "log";
+export interface TurnSystemEvent {
+  type: "system";
   level: "debug" | "info" | "warn" | "error";
   message: string;
 }
 
 /** Events emitted while the runner is still working on the current turn. */
-export type TurnDuringEvent = TurnStepEvent | TurnTodosEvent | TurnStateMachineEvent | TurnLogEvent;
+export type TurnDuringEvent =
+  | TurnStepEvent
+  | TurnTodosEvent
+  | TurnStateMachineEvent
+  | TurnSystemEvent;
 
 /** Events that end the current turn. */
 export type TurnTerminalEvent =

--- a/test/helpers/async.ts
+++ b/test/helpers/async.ts
@@ -1,0 +1,13 @@
+import { setTimeout as delay } from "node:timers/promises";
+
+export { delay };
+
+export async function waitFor(assertion: () => boolean, timeoutMs = 1000): Promise<void> {
+  const started = Date.now();
+  while (!assertion()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await delay(1);
+  }
+}

--- a/test/helpers/messages.ts
+++ b/test/helpers/messages.ts
@@ -1,0 +1,38 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+
+export function createAssistantMessage(input: {
+  text?: string;
+  errorMessage?: string;
+  extraContent?: AssistantMessage["content"];
+  stopReason?: AssistantMessage["stopReason"];
+  timestamp?: number;
+}): AssistantMessage {
+  const content: AssistantMessage["content"] = [
+    ...(input.text !== undefined ? [{ type: "text" as const, text: input.text }] : []),
+    ...(input.extraContent ?? []),
+  ];
+  return {
+    role: "assistant",
+    content,
+    api: "unknown",
+    provider: "unknown",
+    model: "test",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason:
+      input.stopReason ??
+      (input.extraContent?.some((part) => part.type === "toolCall")
+        ? "toolUse"
+        : input.errorMessage
+          ? "error"
+          : "stop"),
+    ...(input.errorMessage ? { errorMessage: input.errorMessage } : {}),
+    timestamp: input.timestamp ?? Date.now(),
+  };
+}

--- a/test/helpers/turn-runner-protocol.ts
+++ b/test/helpers/turn-runner-protocol.ts
@@ -3,11 +3,11 @@ import {
   type AgentWorkerInput,
   type AgentWorkerResult,
 } from "../../src/turn-runner/turn-runner.js";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { TurnRunnerControlResult } from "../../src/turn-runner/tools.js";
 import type { TurnRunnerConfig } from "../../src/types/config.js";
 import type { TurnEvent, TurnState } from "../../src/types/protocol.js";
 import type { StateMachineDefinition } from "../../src/types/state-machine.js";
+import { createAssistantMessage } from "./messages.js";
 
 export class TestTurnRunner extends TurnRunner {
   readonly workerInputs: AgentWorkerInput[] = [];
@@ -31,23 +31,7 @@ export class TestTurnRunner extends TurnRunner {
     const resultText = input.prompt.includes("capital of France")
       ? "Paris"
       : `Completed: ${input.prompt}`;
-    const assistantMessage: AssistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: resultText }],
-      api: "unknown",
-      provider: "unknown",
-      model: "test",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: Date.now(),
-    };
+    const assistantMessage = createAssistantMessage({ text: resultText });
     const state = {
       ...input.state,
       status: "completed" as const,

--- a/test/serializer.test.ts
+++ b/test/serializer.test.ts
@@ -1,29 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { assistantText } from "../src/core/serializer.js";
+import { createAssistantMessage } from "./helpers/messages.js";
 
 describe("assistantText", () => {
   test("returns only the latest assistant text", () => {
-    expect(assistantText([assistantMessage("first"), assistantMessage("second")])).toBe("second");
+    expect(
+      assistantText([
+        createAssistantMessage({ text: "first", timestamp: 1 }),
+        createAssistantMessage({ text: "second", timestamp: 1 }),
+      ]),
+    ).toBe("second");
   });
 });
-
-function assistantMessage(text: string): AssistantMessage {
-  return {
-    role: "assistant",
-    content: [{ type: "text", text }],
-    api: "unknown",
-    provider: "unknown",
-    model: "test",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
-    stopReason: "stop",
-    timestamp: 1,
-  };
-}

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -12,6 +12,7 @@ import type {
   TurnCommand,
 } from "../src/types/protocol.js";
 import { testIfDocker } from "./helpers/docker-only.js";
+import { waitFor } from "./helpers/async.js";
 import { createStateMachineState } from "./helpers/turn-runner-protocol.js";
 
 class FakeTurnRunner implements SessionTurnRunner {
@@ -452,11 +453,3 @@ describe("SessionManager", () => {
     await manager.dispose();
   });
 });
-
-async function waitFor(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt++) {
-    if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-  throw new Error("Timed out waiting for condition");
-}

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -164,7 +164,7 @@ describe("Session", () => {
     await session.start({ prompt: "hello" });
     await session.waitForTerminal();
     unsubscribe();
-    runner.emit({ type: "log", level: "info", message: "ignored" });
+    runner.emit({ type: "system", level: "info", message: "ignored" });
 
     expect(events[0]).toEqual({ type: "ready" });
   });
@@ -238,22 +238,34 @@ describe("Session", () => {
     await second.waitForTerminal();
 
     expect(secondTurnRunner.commands).toEqual([
-      { type: "prompt", state: turnState, message: "continue", behavior: "steer" },
+      { type: "prompt", state: turnState, message: "continue", behavior: "follow_up" },
     ]);
   });
 
-  testIfDocker("forwards steer and follow-up prompts while a turn is active", async () => {
+  testIfDocker("sends active prompts through turn runner", async () => {
     const runner = new FakeTurnRunner([]);
     const session = await createSession(runner);
 
     await session.start({ prompt: "start" });
     await waitFor(() => runner.commands.length === 1);
     await session.prompt({ message: "steer now", behavior: "steer" });
-    await session.prompt({ message: "queue later", behavior: "follow_up" });
 
     expect(runner.commands).toEqual([
       { type: "start", mode: undefined, prompt: "start" },
       { type: "prompt", state: turnState, message: "steer now", behavior: "steer" },
+    ]);
+  });
+
+  testIfDocker("sends follow-up prompts through turn runner while active", async () => {
+    const runner = new FakeTurnRunner([]);
+    const session = await createSession(runner);
+
+    await session.start({ prompt: "start" });
+    await waitFor(() => runner.commands.length === 1);
+    await session.prompt({ message: "queue later", behavior: "follow_up" });
+
+    expect(runner.commands).toEqual([
+      { type: "start", mode: undefined, prompt: "start" },
       { type: "prompt", state: turnState, message: "queue later", behavior: "follow_up" },
     ]);
   });
@@ -373,7 +385,7 @@ describe("Session", () => {
 
       expect(runner.commands).toEqual([
         { type: "start", mode: undefined, prompt: "start" },
-        { type: "prompt", state: turnState, message: "next", behavior: "steer" },
+        { type: "prompt", state: turnState, message: "next", behavior: "follow_up" },
       ]);
     },
   );

--- a/test/turn-runner-active-turns.test.ts
+++ b/test/turn-runner-active-turns.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@mariozechner/pi-ai";
 import { TurnRunner, type AgentWorkerInput } from "../src/turn-runner/turn-runner.js";
 import type { TurnEvent, TurnState, TurnTerminalEvent } from "../src/types/protocol.js";
+import type { StateMachineDefinition } from "../src/types/state-machine.js";
 import { createStateMachineState } from "./helpers/turn-runner-protocol.js";
 
 class StreamingTurnRunner extends TurnRunner {
@@ -41,6 +42,18 @@ class StreamingTurnRunner extends TurnRunner {
       type: "done",
       reason: "stop",
       message: createAssistantMessage(text, options?.error),
+    });
+  }
+
+  completeNextToolCall(name: string, args: Record<string, unknown>): void {
+    const stream = this.pendingStreams.shift();
+    if (!stream) throw new Error("No pending stream");
+    stream.push({
+      type: "done",
+      reason: "toolUse",
+      message: createAssistantMessage("", undefined, [
+        { type: "toolCall", id: `tool_${this.contexts.length}`, name, arguments: args },
+      ]),
     });
   }
 }
@@ -145,6 +158,173 @@ describe("TurnRunner active turns", () => {
     });
   });
 
+  test("prompts sent during script work run before state-machine continuation", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: scriptThenTerminalDefinition(),
+      prompt: "run script flow",
+    });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "script_step" },
+    });
+    await waitFor(() =>
+      events.some(
+        (event) => event.type === "state_machine" && event.currentState === "script_step",
+      ),
+    );
+
+    const prompt = runner.turn({
+      type: "prompt",
+      state,
+      message: "question during script",
+      behavior: "follow_up",
+    });
+
+    await waitFor(() => runner.contexts.length >= 2);
+    expect(lastUserText(runner.contexts[1]!)).toContain("question during script");
+    runner.completeNext("answer after script");
+
+    await waitFor(() => runner.contexts.length >= 3);
+    expect(lastUserText(runner.contexts[2]!)).toContain('The state "script_step" finished');
+    expect(contextText(runner.contexts[2]!)).toContain("answer after script");
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "terminal", state: "done" },
+    });
+
+    const [turnTerminal, promptTerminal] = await Promise.all([turn, prompt]);
+    expect(turnTerminal).toBe(promptTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+    expect(turnTerminal).toMatchObject({ type: "complete", status: "completed" });
+  });
+
+  test("prompts sent during poll checks run immediately and return to sleep when unresolved", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: unresolvedPollDefinition(),
+      prompt: "run poll flow",
+    });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "poll_reply" },
+    });
+    await waitFor(() =>
+      events.some((event) => event.type === "state_machine" && event.currentState === "poll_reply"),
+    );
+
+    const prompt = runner.turn({
+      type: "prompt",
+      state,
+      message: "question during poll",
+      behavior: "follow_up",
+    });
+
+    await waitFor(() => runner.contexts.length >= 2, 100);
+    expect(lastUserText(runner.contexts[1]!)).toContain("question during poll");
+    runner.completeNext("poll still waiting");
+
+    const [turnTerminal, promptTerminal] = await Promise.all([turn, prompt]);
+    expect(turnTerminal).toBe(promptTerminal);
+    expect(turnTerminal.type).toBe("sleep");
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
+
+  test("additional prompts during a mid-poll answer join the active parent agent", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: unresolvedPollDefinition(),
+      prompt: "run poll flow",
+    });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "poll_reply" },
+    });
+    await waitFor(() =>
+      events.some((event) => event.type === "state_machine" && event.currentState === "poll_reply"),
+    );
+
+    const firstPrompt = runner.turn({
+      type: "prompt",
+      state,
+      message: "first question during poll",
+      behavior: "follow_up",
+    });
+    await waitFor(() => runner.contexts.length >= 2);
+
+    const secondPrompt = runner.turn({
+      type: "prompt",
+      state,
+      message: "second question during poll",
+      behavior: "follow_up",
+    });
+
+    runner.completeNext("first poll answer");
+    await waitFor(() => runner.contexts.length >= 3);
+    expect(lastUserText(runner.contexts[2]!)).toContain("second question during poll");
+    runner.completeNext("second poll answer");
+
+    const [turnTerminal, firstTerminal, secondTerminal] = await Promise.all([
+      turn,
+      firstPrompt,
+      secondPrompt,
+    ]);
+    expect(turnTerminal).toBe(firstTerminal);
+    expect(firstTerminal).toBe(secondTerminal);
+    expect(turnTerminal.type).toBe("sleep");
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
+
+  test("resolved polls enqueue state-machine continuation after the mid-poll agent answer", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: resolvedPollDefinition(),
+      prompt: "run resolved poll flow",
+    });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "poll_reply" },
+    });
+    await waitFor(() =>
+      events.some((event) => event.type === "state_machine" && event.currentState === "poll_reply"),
+    );
+
+    const prompt = runner.turn({
+      type: "prompt",
+      state,
+      message: "question during resolving poll",
+      behavior: "follow_up",
+    });
+
+    await waitFor(() => runner.contexts.length >= 2);
+    expect(lastUserText(runner.contexts[1]!)).toContain("question during resolving poll");
+    await delay(75);
+    runner.completeNext("agent saw user before continuation");
+
+    await waitFor(() => runner.contexts.length >= 3);
+    expect(lastUserText(runner.contexts[2]!)).toContain('The state "poll_reply" finished');
+    expect(contextText(runner.contexts[2]!)).toContain("agent saw user before continuation");
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "terminal", state: "done" },
+    });
+
+    const [turnTerminal, promptTerminal] = await Promise.all([turn, prompt]);
+    expect(turnTerminal).toBe(promptTerminal);
+    expect(turnTerminal).toMatchObject({ type: "complete", status: "completed" });
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
+
   test("sleeping follow-up failure emits system error and resolves to sleep", async () => {
     const { runner, events } = createStreamingRunner();
     const sleeping = {
@@ -195,6 +375,48 @@ describe("TurnRunner active turns", () => {
     expect(firstTerminal.type).toBe("interrupted");
     expect(messageTexts(firstTerminal.state)).not.toContain("queued");
   });
+
+  test("answers can follow up the active child agent directly", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: childAgentDefinition(),
+      prompt: "run child flow",
+    });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "child_agent" },
+    });
+    await waitFor(() =>
+      events.some(
+        (event) => event.type === "state_machine" && event.currentState === "child_agent",
+      ),
+    );
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const answer = runner.turn({
+      type: "answer",
+      state,
+      questions: [{ question: "Child question", options: [{ label: "A" }] }],
+      answers: { choice: "A" },
+      behavior: "follow_up",
+    });
+
+    runner.completeNext("child first response");
+    await waitFor(() => runner.contexts.length >= 3);
+    expect(lastUserText(runner.contexts[2]!)).toContain("Here are my answers");
+    runner.completeNext("child answer response");
+    await waitFor(() => runner.contexts.length >= 4);
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "terminal", state: "done" },
+    });
+
+    const [turnTerminal, answerTerminal] = await Promise.all([turn, answer]);
+    expect(turnTerminal).toBe(answerTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
 });
 
 function createStreamingRunner(): { runner: StreamingTurnRunner; events: TurnEvent[] } {
@@ -234,6 +456,29 @@ function messageTexts(state: TurnState): string[] {
   });
 }
 
+function contextText(context: Context): string {
+  return context.messages
+    .map((message) => {
+      const content = "content" in message ? message.content : undefined;
+      if (typeof content === "string") return content;
+      if (!Array.isArray(content)) return "";
+      return content
+        .map((part) =>
+          part && typeof part === "object" && "text" in part && typeof part.text === "string"
+            ? part.text
+            : "",
+        )
+        .join("\n");
+    })
+    .join("\n");
+}
+
+function lastUserText(context: Context): string {
+  const user = [...context.messages].reverse().find((message) => message.role === "user");
+  if (!user) return "";
+  return contextText({ ...context, messages: [user] });
+}
+
 async function waitFor(assertion: () => boolean, timeoutMs = 1000): Promise<void> {
   const started = Date.now();
   while (!assertion()) {
@@ -244,10 +489,18 @@ async function waitFor(assertion: () => boolean, timeoutMs = 1000): Promise<void
   }
 }
 
-function createAssistantMessage(text: string, errorMessage?: string): AssistantMessage {
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createAssistantMessage(
+  text: string,
+  errorMessage?: string,
+  extraContent: AssistantMessage["content"] = [],
+): AssistantMessage {
   return {
     role: "assistant",
-    content: [{ type: "text", text }],
+    content: [{ type: "text", text }, ...extraContent],
     api: "unknown",
     provider: "unknown",
     model: "test",
@@ -259,8 +512,70 @@ function createAssistantMessage(text: string, errorMessage?: string): AssistantM
       totalTokens: 0,
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
-    stopReason: errorMessage ? "error" : "stop",
+    stopReason: extraContent.some((part) => part.type === "toolCall")
+      ? "toolUse"
+      : errorMessage
+        ? "error"
+        : "stop",
     ...(errorMessage ? { errorMessage } : {}),
     timestamp: Date.now(),
+  };
+}
+
+function scriptThenTerminalDefinition(): StateMachineDefinition {
+  return {
+    name: "script_flow",
+    prompt: "Use for script test.",
+    states: [
+      {
+        kind: "script",
+        name: "script_step",
+        command: "sleep 0.05; printf '{\"scriptDone\":true}'",
+      },
+      { kind: "terminal", name: "done", status: "completed" },
+    ],
+  };
+}
+
+function unresolvedPollDefinition(): StateMachineDefinition {
+  return {
+    name: "poll_flow",
+    prompt: "Use for poll test.",
+    states: [
+      {
+        kind: "poll",
+        name: "poll_reply",
+        intervalMs: 60_000,
+        poll: { kind: "script", command: "sleep 2; printf '{}'" },
+      },
+      { kind: "terminal", name: "done", status: "completed" },
+    ],
+  };
+}
+
+function resolvedPollDefinition(): StateMachineDefinition {
+  return {
+    name: "resolved_poll_flow",
+    prompt: "Use for resolved poll test.",
+    states: [
+      {
+        kind: "poll",
+        name: "poll_reply",
+        intervalMs: 60_000,
+        poll: { kind: "script", command: 'sleep 0.05; printf \'{"reply":"yes"}\'' },
+      },
+      { kind: "terminal", name: "done", status: "completed" },
+    ],
+  };
+}
+
+function childAgentDefinition(): StateMachineDefinition {
+  return {
+    name: "child_flow",
+    prompt: "Use for child test.",
+    states: [
+      { kind: "agent", name: "child_agent", prompt: "Ask the child question." },
+      { kind: "terminal", name: "done", status: "completed" },
+    ],
   };
 }

--- a/test/turn-runner-active-turns.test.ts
+++ b/test/turn-runner-active-turns.test.ts
@@ -5,6 +5,7 @@ import {
   type AssistantMessage,
   type Context,
 } from "@mariozechner/pi-ai";
+import { setTimeout as delay } from "node:timers/promises";
 import { TurnRunner, type AgentWorkerInput } from "../src/turn-runner/turn-runner.js";
 import type { TurnEvent, TurnState, TurnTerminalEvent } from "../src/types/protocol.js";
 import type { StateMachineDefinition } from "../src/types/state-machine.js";
@@ -739,10 +740,6 @@ async function waitFor(assertion: () => boolean, timeoutMs = 1000): Promise<void
     }
     await new Promise((resolve) => setTimeout(resolve, 1));
   }
-}
-
-async function delay(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function createAssistantMessage(

--- a/test/turn-runner-active-turns.test.ts
+++ b/test/turn-runner-active-turns.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from "bun:test";
+import { Agent } from "@mariozechner/pi-agent-core";
+import {
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type Context,
+} from "@mariozechner/pi-ai";
+import { TurnRunner, type AgentWorkerInput } from "../src/turn-runner/turn-runner.js";
+import type { TurnEvent, TurnState, TurnTerminalEvent } from "../src/types/protocol.js";
+import { createStateMachineState } from "./helpers/turn-runner-protocol.js";
+
+class StreamingTurnRunner extends TurnRunner {
+  readonly contexts: Context[] = [];
+  readonly pendingStreams: ReturnType<typeof createAssistantMessageEventStream>[] = [];
+
+  constructor() {
+    super({
+      model: "anthropic:claude-opus-4-7",
+      skillDiscovery: { includeDefaults: false },
+    });
+  }
+
+  protected override createAgent(
+    input: AgentWorkerInput,
+    onControlResult?: Parameters<TurnRunner["createAgent"]>[1],
+  ): Agent {
+    const agent = super.createAgent(input, onControlResult);
+    agent.streamFn = (_model, context) => {
+      this.contexts.push(JSON.parse(JSON.stringify(context)) as Context);
+      const stream = createAssistantMessageEventStream();
+      this.pendingStreams.push(stream);
+      return stream;
+    };
+    return agent;
+  }
+
+  completeNext(text: string, options?: { error?: string }): void {
+    const stream = this.pendingStreams.shift();
+    if (!stream) throw new Error("No pending stream");
+    stream.push({
+      type: "done",
+      reason: "stop",
+      message: createAssistantMessage(text, options?.error),
+    });
+  }
+}
+
+describe("TurnRunner active turns", () => {
+  test("repeated prompt turns join the active agent chain and emit one terminal", async () => {
+    const { runner, events } = createStreamingRunner();
+    const first = runner.turn({ type: "start", mode: "agent", prompt: "first" });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const second = runner.turn({
+      type: "prompt",
+      state,
+      message: "second",
+      behavior: "follow_up",
+    });
+
+    runner.completeNext("first response");
+    await waitFor(() => runner.pendingStreams.length === 1);
+    runner.completeNext("second response");
+
+    const [firstTerminal, secondTerminal] = await Promise.all([first, second]);
+    expect(firstTerminal).toBe(secondTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+    expect(firstTerminal).toMatchObject({ type: "complete", status: "completed" });
+    expect(messageTexts(firstTerminal.state)).toEqual([
+      "first",
+      "first response",
+      "second",
+      "second response",
+    ]);
+  });
+
+  test("steer is handled through turn and still shares the active terminal", async () => {
+    const { runner, events } = createStreamingRunner();
+    const first = runner.turn({ type: "start", mode: "agent", prompt: "first" });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const steer = runner.turn({
+      type: "prompt",
+      state,
+      message: "steer now",
+      behavior: "steer",
+    });
+
+    runner.completeNext("first response");
+    await waitFor(() => runner.pendingStreams.length === 1);
+    runner.completeNext("steered response");
+
+    const [firstTerminal, steerTerminal] = await Promise.all([first, steer]);
+    expect(firstTerminal).toBe(steerTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+    expect(messageTexts(firstTerminal.state)).toContain("steer now");
+  });
+
+  test("answers behave like prompts after serialization during active turns", async () => {
+    const { runner, events } = createStreamingRunner();
+    const first = runner.turn({ type: "start", mode: "agent", prompt: "ask me later" });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const answer = runner.turn({
+      type: "answer",
+      state,
+      questions: [{ question: "Pick one", options: [{ label: "A" }] }],
+      answers: { choice: "A" },
+      behavior: "follow_up",
+    });
+
+    runner.completeNext("first response");
+    await waitFor(() => runner.pendingStreams.length === 1);
+    runner.completeNext("answer response");
+
+    const [firstTerminal, answerTerminal] = await Promise.all([first, answer]);
+    expect(firstTerminal).toBe(answerTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+    expect(messageTexts(firstTerminal.state).join("\n")).toContain("Here are my answers");
+  });
+
+  test("queued wake rebases onto latest state and no-ops when no longer sleeping on a poll", async () => {
+    const { runner, events } = createStreamingRunner();
+    const first = runner.turn({ type: "start", mode: "agent", prompt: "finish work" });
+    await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const wake = runner.turn({
+      type: "wake",
+      state: { ...createStateMachineState("poll_email_reply"), status: "sleeping" },
+    });
+
+    runner.completeNext("done");
+    const [firstTerminal, wakeTerminal] = await Promise.all([first, wake]);
+
+    expect(firstTerminal).toBe(wakeTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+    expect(wakeTerminal).toMatchObject({
+      type: "complete",
+      status: "completed",
+      result: "Nothing to wake.",
+    });
+  });
+
+  test("sleeping follow-up failure emits system error and resolves to sleep", async () => {
+    const { runner, events } = createStreamingRunner();
+    const sleeping = {
+      ...createStateMachineState("poll_email_reply"),
+      status: "sleeping" as const,
+    };
+
+    const turn = runner.turn({
+      type: "prompt",
+      state: sleeping,
+      message: "anything new?",
+      behavior: "follow_up",
+    });
+    await waitFor(() => runner.pendingStreams.length === 1);
+    runner.completeNext("", { error: "model failed" });
+
+    const terminal = await turn;
+    expect(terminal.type).toBe("sleep");
+    expect(terminal.state.status).toBe("sleeping");
+    expect(events).toContainEqual({
+      type: "system",
+      level: "error",
+      message: "model failed",
+    });
+    expect(
+      events.filter((event) => event.type === "complete" && event.status === "failed"),
+    ).toEqual([]);
+  });
+
+  test("interrupt drops queued work and emits one interrupted terminal", async () => {
+    const { runner, events } = createStreamingRunner();
+    const first = runner.turn({ type: "start", mode: "agent", prompt: "start" });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const followUp = runner.turn({
+      type: "prompt",
+      state,
+      message: "queued",
+      behavior: "follow_up",
+    });
+    runner.interrupt({ type: "interrupt", state });
+    runner.completeNext("", { error: "aborted" });
+
+    const [firstTerminal, followUpTerminal] = await Promise.all([first, followUp]);
+    expect(firstTerminal).toBe(followUpTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+    expect(firstTerminal.type).toBe("interrupted");
+    expect(messageTexts(firstTerminal.state)).not.toContain("queued");
+  });
+});
+
+function createStreamingRunner(): { runner: StreamingTurnRunner; events: TurnEvent[] } {
+  const runner = new StreamingTurnRunner();
+  const events: TurnEvent[] = [];
+  runner.subscribe((event) => events.push(event));
+  return { runner, events };
+}
+
+async function waitForStartedState(events: TurnEvent[]): Promise<TurnState> {
+  await waitFor(() => events.some((event) => event.type === "session_started"));
+  const event = events.find((item) => item.type === "session_started");
+  if (!event || event.type !== "session_started") throw new Error("Missing session_started event");
+  return event.state;
+}
+
+function terminalEvents(events: TurnEvent[]): TurnTerminalEvent[] {
+  return events.filter(
+    (event): event is TurnTerminalEvent =>
+      event.type === "ask" ||
+      event.type === "complete" ||
+      event.type === "interrupted" ||
+      event.type === "sleep",
+  );
+}
+
+function messageTexts(state: TurnState): string[] {
+  return state.agent.messages.flatMap((message) => {
+    const content = "content" in message ? message.content : undefined;
+    if (typeof content === "string") return [content];
+    if (!Array.isArray(content)) return [];
+    return content.flatMap((part) =>
+      part && typeof part === "object" && "text" in part && typeof part.text === "string"
+        ? [part.text]
+        : [],
+    );
+  });
+}
+
+async function waitFor(assertion: () => boolean, timeoutMs = 1000): Promise<void> {
+  const started = Date.now();
+  while (!assertion()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
+function createAssistantMessage(text: string, errorMessage?: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "unknown",
+    provider: "unknown",
+    model: "test",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: errorMessage ? "error" : "stop",
+    ...(errorMessage ? { errorMessage } : {}),
+    timestamp: Date.now(),
+  };
+}

--- a/test/turn-runner-active-turns.test.ts
+++ b/test/turn-runner-active-turns.test.ts
@@ -417,6 +417,50 @@ describe("TurnRunner active turns", () => {
     expect(turnTerminal).toBe(answerTerminal);
     expect(terminalEvents(events)).toHaveLength(1);
   });
+
+  test("prompts during active child agent work queue for the parent", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: childAgentDefinition(),
+      prompt: "run child flow",
+    });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "child_agent" },
+    });
+    await waitFor(() =>
+      events.some(
+        (event) => event.type === "state_machine" && event.currentState === "child_agent",
+      ),
+    );
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const prompt = runner.turn({
+      type: "prompt",
+      state,
+      message: "parent should handle this",
+      behavior: "follow_up",
+    });
+
+    runner.completeNext("child response");
+    await waitFor(() => runner.contexts.length >= 3);
+    expect(lastUserText(runner.contexts[1]!)).not.toContain("parent should handle this");
+    expect(lastUserText(runner.contexts[2]!)).toContain("parent should handle this");
+    runner.completeNext("parent response");
+
+    await waitFor(() => runner.contexts.length >= 4);
+    expect(lastUserText(runner.contexts[3]!)).toContain('The state "child_agent" finished');
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "terminal", state: "done" },
+    });
+
+    const [turnTerminal, promptTerminal] = await Promise.all([turn, prompt]);
+    expect(turnTerminal).toBe(promptTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
 });
 
 function createStreamingRunner(): { runner: StreamingTurnRunner; events: TurnEvent[] } {

--- a/test/turn-runner-active-turns.test.ts
+++ b/test/turn-runner-active-turns.test.ts
@@ -135,6 +135,23 @@ describe("TurnRunner active turns", () => {
     expect(messageTexts(firstTerminal.state).join("\n")).toContain("Here are my answers");
   });
 
+  test("start during an active turn rejects without creating another branch", async () => {
+    const { runner, events } = createStreamingRunner();
+    const first = runner.turn({ type: "start", mode: "agent", prompt: "first" });
+    await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const second = runner.turn({ type: "start", mode: "agent", prompt: "second" });
+    await expect(second).rejects.toThrow("Cannot start a new turn while another turn is active.");
+
+    runner.completeNext("first response");
+
+    const terminal = await first;
+    expect(terminal).toMatchObject({ type: "complete", status: "completed" });
+    expect(messageTexts(terminal.state)).not.toContain("second");
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
+
   test("queued wake rebases onto latest state and no-ops when no longer sleeping on a poll", async () => {
     const { runner, events } = createStreamingRunner();
     const first = runner.turn({ type: "start", mode: "agent", prompt: "finish work" });
@@ -201,6 +218,91 @@ describe("TurnRunner active turns", () => {
     expect(turnTerminal).toMatchObject({ type: "complete", status: "completed" });
   });
 
+  test("answers sent during script work run before state-machine continuation", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: scriptThenTerminalDefinition(),
+      prompt: "run script flow",
+    });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "script_step" },
+    });
+    await waitFor(() =>
+      events.some(
+        (event) => event.type === "state_machine" && event.currentState === "script_step",
+      ),
+    );
+
+    const answer = runner.turn({
+      type: "answer",
+      state,
+      questions: [{ question: "Pick one", options: [{ label: "A" }] }],
+      answers: { choice: "A" },
+      behavior: "follow_up",
+    });
+
+    await waitFor(() => runner.contexts.length >= 2);
+    expect(lastUserText(runner.contexts[1]!)).toContain("Here are my answers");
+    runner.completeNext("answer after script");
+
+    await waitFor(() => runner.contexts.length >= 3);
+    expect(lastUserText(runner.contexts[2]!)).toContain('The state "script_step" finished');
+    expect(contextText(runner.contexts[2]!)).toContain("answer after script");
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "terminal", state: "done" },
+    });
+
+    const [turnTerminal, answerTerminal] = await Promise.all([turn, answer]);
+    expect(turnTerminal).toBe(answerTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
+
+  test("steer prompts sent during script work run before state-machine continuation", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: scriptThenTerminalDefinition(),
+      prompt: "run script flow",
+    });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "script_step" },
+    });
+    await waitFor(() =>
+      events.some(
+        (event) => event.type === "state_machine" && event.currentState === "script_step",
+      ),
+    );
+
+    const steer = runner.turn({
+      type: "prompt",
+      state,
+      message: "steer during script",
+      behavior: "steer",
+    });
+
+    await waitFor(() => runner.contexts.length >= 2);
+    expect(lastUserText(runner.contexts[1]!)).toContain("steer during script");
+    runner.completeNext("steer after script");
+
+    await waitFor(() => runner.contexts.length >= 3);
+    expect(lastUserText(runner.contexts[2]!)).toContain('The state "script_step" finished');
+    expect(contextText(runner.contexts[2]!)).toContain("steer after script");
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "terminal", state: "done" },
+    });
+
+    const [turnTerminal, steerTerminal] = await Promise.all([turn, steer]);
+    expect(turnTerminal).toBe(steerTerminal);
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
+
   test("prompts sent during poll checks run immediately and return to sleep when unresolved", async () => {
     const { runner, events } = createStreamingRunner();
     const turn = runner.turn({
@@ -232,6 +334,66 @@ describe("TurnRunner active turns", () => {
     const [turnTerminal, promptTerminal] = await Promise.all([turn, prompt]);
     expect(turnTerminal).toBe(promptTerminal);
     expect(turnTerminal.type).toBe("sleep");
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
+
+  test("steer prompts sent during poll checks run immediately and return to sleep", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: unresolvedPollDefinition(),
+      prompt: "run poll flow",
+    });
+    const state = await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "poll_reply" },
+    });
+    await waitFor(() =>
+      events.some((event) => event.type === "state_machine" && event.currentState === "poll_reply"),
+    );
+
+    const steer = runner.turn({
+      type: "prompt",
+      state,
+      message: "steer during poll",
+      behavior: "steer",
+    });
+
+    await waitFor(() => runner.contexts.length >= 2, 100);
+    expect(lastUserText(runner.contexts[1]!)).toContain("steer during poll");
+    runner.completeNext("poll still waiting after steer");
+
+    const [turnTerminal, steerTerminal] = await Promise.all([turn, steer]);
+    expect(turnTerminal).toBe(steerTerminal);
+    expect(turnTerminal.type).toBe("sleep");
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
+
+  test("queued wake behind state-machine work rebases onto sleeping poll state", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({
+      type: "start",
+      mode: immediateUnresolvedPollDefinition(),
+      prompt: "run poll flow",
+    });
+    await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const wake = runner.turn({
+      type: "wake",
+      state: { ...createStateMachineState("poll_email_reply"), status: "sleeping" },
+    });
+
+    runner.completeNextToolCall("select_state_machine_state", {
+      decision: { kind: "run_state", state: "poll_reply" },
+    });
+
+    const [turnTerminal, wakeTerminal] = await Promise.all([turn, wake]);
+    expect(turnTerminal).toBe(wakeTerminal);
+    expect(turnTerminal.type).toBe("sleep");
+    expect(turnTerminal.state.stateMachine?.currentState).toBe("poll_reply");
     expect(terminalEvents(events)).toHaveLength(1);
   });
 
@@ -354,6 +516,28 @@ describe("TurnRunner active turns", () => {
     ).toEqual([]);
   });
 
+  test("failed active turns emit one failed terminal and drop queued commands", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({ type: "start", mode: "agent", prompt: "start" });
+    await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const wake = runner.turn({
+      type: "wake",
+      state: { ...createStateMachineState("poll_email_reply"), status: "sleeping" },
+    });
+
+    runner.completeNext("", { error: "model failed" });
+
+    const [turnTerminal, wakeTerminal] = await Promise.all([turn, wake]);
+    expect(turnTerminal).toBe(wakeTerminal);
+    expect(turnTerminal).toMatchObject({ type: "complete", status: "failed" });
+    expect(turnTerminal.type === "complete" ? turnTerminal.result : "").not.toBe(
+      "Nothing to wake.",
+    );
+    expect(terminalEvents(events)).toHaveLength(1);
+  });
+
   test("interrupt drops queued work and emits one interrupted terminal", async () => {
     const { runner, events } = createStreamingRunner();
     const first = runner.turn({ type: "start", mode: "agent", prompt: "start" });
@@ -374,6 +558,30 @@ describe("TurnRunner active turns", () => {
     expect(terminalEvents(events)).toHaveLength(1);
     expect(firstTerminal.type).toBe("interrupted");
     expect(messageTexts(firstTerminal.state)).not.toContain("queued");
+  });
+
+  test("dispose drops queued work without starting another command", async () => {
+    const { runner, events } = createStreamingRunner();
+    const turn = runner.turn({ type: "start", mode: "agent", prompt: "start" });
+    await waitForStartedState(events);
+    await waitFor(() => runner.pendingStreams.length === 1);
+
+    const wake = runner.turn({
+      type: "wake",
+      state: { ...createStateMachineState("poll_email_reply"), status: "sleeping" },
+    });
+    await delay(0);
+    await runner.dispose();
+
+    runner.completeNext("done");
+
+    const [turnTerminal, wakeTerminal] = await Promise.all([turn, wake]);
+    expect(turnTerminal).toBe(wakeTerminal);
+    expect(turnTerminal).toMatchObject({ type: "complete", status: "completed" });
+    expect(turnTerminal.type === "complete" ? turnTerminal.result : "").not.toBe(
+      "Nothing to wake.",
+    );
+    expect(terminalEvents(events)).toHaveLength(1);
   });
 
   test("answers can follow up the active child agent directly", async () => {
@@ -607,6 +815,22 @@ function resolvedPollDefinition(): StateMachineDefinition {
         name: "poll_reply",
         intervalMs: 60_000,
         poll: { kind: "script", command: 'sleep 0.05; printf \'{"reply":"yes"}\'' },
+      },
+      { kind: "terminal", name: "done", status: "completed" },
+    ],
+  };
+}
+
+function immediateUnresolvedPollDefinition(): StateMachineDefinition {
+  return {
+    name: "immediate_poll_flow",
+    prompt: "Use for immediate poll test.",
+    states: [
+      {
+        kind: "poll",
+        name: "poll_reply",
+        intervalMs: 60_000,
+        poll: { kind: "script", command: "printf '{}'" },
       },
       { kind: "terminal", name: "done", status: "completed" },
     ],

--- a/test/turn-runner-active-turns.test.ts
+++ b/test/turn-runner-active-turns.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { Agent } from "@mariozechner/pi-agent-core";
-import {
-  createAssistantMessageEventStream,
-  type AssistantMessage,
-  type Context,
-} from "@mariozechner/pi-ai";
-import { setTimeout as delay } from "node:timers/promises";
+import { createAssistantMessageEventStream, type Context } from "@mariozechner/pi-ai";
 import { TurnRunner, type AgentWorkerInput } from "../src/turn-runner/turn-runner.js";
 import type { TurnEvent, TurnState, TurnTerminalEvent } from "../src/types/protocol.js";
 import type { StateMachineDefinition } from "../src/types/state-machine.js";
+import { delay, waitFor } from "./helpers/async.js";
+import { createAssistantMessage } from "./helpers/messages.js";
 import { createStateMachineState } from "./helpers/turn-runner-protocol.js";
 
 class StreamingTurnRunner extends TurnRunner {
@@ -42,7 +39,7 @@ class StreamingTurnRunner extends TurnRunner {
     stream.push({
       type: "done",
       reason: "stop",
-      message: createAssistantMessage(text, options?.error),
+      message: createAssistantMessage({ text, errorMessage: options?.error }),
     });
   }
 
@@ -52,9 +49,12 @@ class StreamingTurnRunner extends TurnRunner {
     stream.push({
       type: "done",
       reason: "toolUse",
-      message: createAssistantMessage("", undefined, [
-        { type: "toolCall", id: `tool_${this.contexts.length}`, name, arguments: args },
-      ]),
+      message: createAssistantMessage({
+        text: "",
+        extraContent: [
+          { type: "toolCall", id: `tool_${this.contexts.length}`, name, arguments: args },
+        ],
+      }),
     });
   }
 }
@@ -730,45 +730,6 @@ function lastUserText(context: Context): string {
   const user = [...context.messages].reverse().find((message) => message.role === "user");
   if (!user) return "";
   return contextText({ ...context, messages: [user] });
-}
-
-async function waitFor(assertion: () => boolean, timeoutMs = 1000): Promise<void> {
-  const started = Date.now();
-  while (!assertion()) {
-    if (Date.now() - started > timeoutMs) {
-      throw new Error("Timed out waiting for condition");
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1));
-  }
-}
-
-function createAssistantMessage(
-  text: string,
-  errorMessage?: string,
-  extraContent: AssistantMessage["content"] = [],
-): AssistantMessage {
-  return {
-    role: "assistant",
-    content: [{ type: "text", text }, ...extraContent],
-    api: "unknown",
-    provider: "unknown",
-    model: "test",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
-    stopReason: extraContent.some((part) => part.type === "toolCall")
-      ? "toolUse"
-      : errorMessage
-        ? "error"
-        : "stop",
-    ...(errorMessage ? { errorMessage } : {}),
-    timestamp: Date.now(),
-  };
 }
 
 function scriptThenTerminalDefinition(): StateMachineDefinition {

--- a/test/turn-runner-interrupt.test.ts
+++ b/test/turn-runner-interrupt.test.ts
@@ -1,30 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import assert from "node:assert";
 import { Agent, type StreamFn } from "@mariozechner/pi-agent-core";
-import { createAssistantMessageEventStream, type AssistantMessage } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { TurnRunner, type AgentWorkerInput } from "../src/turn-runner/turn-runner.js";
 import type { TurnEvent, TurnState } from "../src/types/protocol.js";
-
-function createAbortedMessage(): AssistantMessage {
-  return {
-    role: "assistant",
-    content: [],
-    api: "unknown",
-    provider: "unknown",
-    model: "test",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
-    stopReason: "aborted",
-    errorMessage: "Interrupted",
-    timestamp: Date.now(),
-  };
-}
+import { createAssistantMessage } from "./helpers/messages.js";
 
 class InterruptTurnRunner extends TurnRunner {
   streamStarted: Promise<void>;
@@ -60,7 +40,10 @@ class InterruptTurnRunner extends TurnRunner {
       options?.signal?.addEventListener(
         "abort",
         () => {
-          const message = createAbortedMessage();
+          const message = createAssistantMessage({
+            errorMessage: "Interrupted",
+            stopReason: "aborted",
+          });
           stream.push({ type: "error", reason: "aborted", error: message });
           stream.end(message);
         },

--- a/test/turn-runner-serialization.test.ts
+++ b/test/turn-runner-serialization.test.ts
@@ -1,12 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import {
-  createAssistantMessageEventStream,
-  type AssistantMessage,
-  type Context,
-} from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream, type Context } from "@mariozechner/pi-ai";
 import { TurnRunner, type AgentWorkerInput } from "../src/turn-runner/turn-runner.js";
 import type { TurnRunnerConfig } from "../src/types/config.js";
 import type { TurnState } from "../src/types/protocol.js";
+import { createAssistantMessage } from "./helpers/messages.js";
 
 class CapturingTurnRunner extends TurnRunner {
   constructor(config?: Partial<TurnRunnerConfig>) {
@@ -27,7 +24,11 @@ class CapturingTurnRunner extends TurnRunner {
       contexts.push(JSON.parse(JSON.stringify(context)) as Context);
       const stream = createAssistantMessageEventStream();
       queueMicrotask(() => {
-        stream.push({ type: "done", reason: "stop", message: createAssistantMessage("ok") });
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: createAssistantMessage({ text: "ok" }),
+        });
       });
       return stream;
     };
@@ -144,14 +145,18 @@ function createSerializableTurnState(): TurnState {
           content: [{ type: "text", text: "Inspect the deployment." }],
           timestamp: 1,
         },
-        createAssistantMessage("I will inspect the deployment.", [
-          {
-            type: "toolCall",
-            id: "tool-1",
-            name: "read_file",
-            arguments: { path: "package.json" },
-          },
-        ]),
+        createAssistantMessage({
+          text: "I will inspect the deployment.",
+          timestamp: 2,
+          extraContent: [
+            {
+              type: "toolCall",
+              id: "tool-1",
+              name: "read_file",
+              arguments: { path: "package.json" },
+            },
+          ],
+        }),
         {
           role: "toolResult",
           toolCallId: "tool-1",
@@ -161,31 +166,8 @@ function createSerializableTurnState(): TurnState {
           isError: false,
           timestamp: 3,
         },
-        createAssistantMessage("The deployment config is serializable."),
+        createAssistantMessage({ text: "The deployment config is serializable.", timestamp: 2 }),
       ],
     },
-  };
-}
-
-function createAssistantMessage(
-  text: string,
-  extraContent: AssistantMessage["content"] = [],
-): AssistantMessage {
-  return {
-    role: "assistant",
-    content: [{ type: "text", text }, ...extraContent],
-    api: "unknown",
-    provider: "unknown",
-    model: "test",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
-    stopReason: "stop",
-    timestamp: 2,
   };
 }


### PR DESCRIPTION
## Summary
- Serialize repeated `TurnRunner.turn()` calls into one active work chain instead of creating parallel parent-agent branches.
- Route active prompts/answers through pi steer/follow-up behavior, queue wakes/non-agent work, and preserve sleep on poll-wait failures with system events.
- Document the public turn concurrency contract and add dedicated active-turn coverage.

## Test plan
- `bun run test`
- `bun run check-types`
- `bun run lint`
- `bun run format:check`


Made with [Cursor](https://cursor.com)