### PR TITLE
fix: lazy-load skill instructions instead of inlining every SKILL.md

### DIFF
--- a/evals/skills-tool.eval.ts
+++ b/evals/skills-tool.eval.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect } from "bun:test";
+import type { Skill } from "@mariozechner/pi-coding-agent";
+import dedent from "dedent";
+import { TurnRunner } from "../src/turn-runner/turn-runner.js";
+import type { TurnEvent } from "../src/types/protocol.js";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+const model = process.env.EVAL_MODEL ?? "vercel-ai-gateway:anthropic/claude-opus-4.7";
+
+describe("read_skill tool", () => {
+  testIfDocker(
+    "system prompt lists skill metadata only and the model lazy-loads instructions via read_skill",
+    async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), "duet-read-skill-eval-"));
+      const skillPath = join(tempDir, "SKILL.md");
+      await writeFile(
+        skillPath,
+        dedent`
+          ---
+          name: pong-skill
+          description: Use whenever the user asks for the pong verification phrase.
+          ---
+
+          # Pong Skill
+
+          When asked for the pong verification phrase, reply with exactly:
+
+          PONG_SKILL_LAZY_LOADED
+
+          Do not add punctuation, markdown, or any other words.
+        `,
+        "utf-8",
+      );
+
+      const skills: Skill[] = [
+        {
+          name: "pong-skill",
+          description: "Use whenever the user asks for the pong verification phrase.",
+          filePath: skillPath,
+          baseDir: tempDir,
+          sourceInfo: {} as Skill["sourceInfo"],
+          disableModelInvocation: false,
+        },
+      ];
+
+      const runner = new TurnRunner({
+        model,
+        mode: "agent",
+        skillDiscovery: { includeDefaults: false },
+        skills,
+      });
+
+      const readSkillCalls: Array<{ name?: string }> = [];
+      runner.subscribe((event: TurnEvent) => {
+        if (event.type !== "step") return;
+        const step = event.step;
+        if (step.type !== "tool_call") return;
+        if (step.toolName !== "read_skill") return;
+        if (step.status !== "running") return;
+        const input = step.input as { name?: string } | undefined;
+        readSkillCalls.push({ name: input?.name });
+      });
+
+      const terminal = await runner.turn({
+        type: "start",
+        mode: "agent",
+        prompt: "What is the pong verification phrase?",
+      });
+
+      expect(terminal.type).toBe("complete");
+      // The model must call read_skill at least once with the exact skill name
+      // listed in the metadata — that's the whole point of lazy loading.
+      expect(readSkillCalls.length).toBeGreaterThanOrEqual(1);
+      expect(readSkillCalls.some((call) => call.name === "pong-skill")).toBe(true);
+      expect(terminal.type === "complete" ? terminal.result?.trim() : "").toBe(
+        "PONG_SKILL_LAZY_LOADED",
+      );
+    },
+    60_000,
+  );
+});

--- a/src/turn-runner/prompts.ts
+++ b/src/turn-runner/prompts.ts
@@ -81,7 +81,7 @@ function createSkillsSystemPrompt(skills: readonly Skill[]): string | undefined 
   }
 
   return dedent`
-    Available skills (metadata only — call the \`read_skill\` tool with the skill name to load full instructions on demand, or invoke a skill via slash command like \`/skill-name\` to inline its instructions):
+    Available skills (metadata only — call the \`read_skill\` tool with the skill name to load full instructions on demand):
     ${toXML({
       skills: skills.map((skill) => ({
         skill: [{ _attrs: { name: skill.name } }, { description: skill.description }],

--- a/src/turn-runner/prompts.ts
+++ b/src/turn-runner/prompts.ts
@@ -3,7 +3,6 @@ import dedent from "dedent";
 import { toXML } from "../lib/xml.js";
 import type { TurnRunnerConfig } from "../types/config.js";
 import type { TurnMode, TurnState } from "../types/protocol.js";
-import { readSkillInstructions } from "./skills.js";
 
 function currentDateSystemPrompt(): string {
   // Day-level resolution keeps the prompt stable for the whole UTC day so prompt
@@ -82,14 +81,10 @@ function createSkillsSystemPrompt(skills: readonly Skill[]): string | undefined 
   }
 
   return dedent`
-    Available skills:
+    Available skills (metadata only — call the \`read_skill\` tool with the skill name to load full instructions on demand, or invoke a skill via slash command like \`/skill-name\` to inline its instructions):
     ${toXML({
       skills: skills.map((skill) => ({
-        skill: [
-          { _attrs: { name: skill.name } },
-          { description: skill.description },
-          { instructions: readSkillInstructions(skill) },
-        ],
+        skill: [{ _attrs: { name: skill.name } }, { description: skill.description }],
       })),
     })}
   `;

--- a/src/turn-runner/prompts.ts
+++ b/src/turn-runner/prompts.ts
@@ -84,7 +84,7 @@ function createSkillsSystemPrompt(skills: readonly Skill[]): string | undefined 
     Available skills (metadata only — call the \`read_skill\` tool with the skill name to load full instructions on demand):
     ${toXML({
       skills: skills.map((skill) => ({
-        skill: [{ _attrs: { name: skill.name } }, { description: skill.description }],
+        skill: { _attrs: { name: skill.name }, description: skill.description },
       })),
     })}
   `;

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -1,5 +1,5 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { createCodingTools } from "@mariozechner/pi-coding-agent";
+import { createCodingTools, type Skill } from "@mariozechner/pi-coding-agent";
 import { Ajv } from "ajv";
 import dedent from "dedent";
 import { Type, type Static } from "typebox";
@@ -12,6 +12,7 @@ import type {
   StateMachineScriptState,
   StateMachineState,
 } from "../types/state-machine.js";
+import { readSkillInstructions } from "./skills.js";
 
 const jsonSchemaValidator = new Ajv({ strictSchema: false });
 
@@ -42,6 +43,13 @@ const askUserQuestionSchema = Type.Object({
 });
 
 type AskUserQuestionParams = Static<typeof askUserQuestionSchema>;
+
+const readSkillSchema = Type.Object({
+  name: Type.String({
+    description:
+      "Skill name from the available skills metadata in the system prompt. Returns the full SKILL.md instructions (with shell expansions resolved).",
+  }),
+});
 
 const todoStatusSchema = Type.Union(
   [
@@ -342,17 +350,24 @@ interface TurnRunnerToolsInput {
   mode: TurnMode;
   definition?: StateMachineDefinition;
   todoStorage?: TodoWriteToolStorage;
+  skills?: readonly Skill[];
 }
 
 export function createDefaultTurnRunnerTools(
   cwd: string,
   todoStorage: TodoWriteToolStorage = createMemoryTodoStorage(),
+  skills: readonly Skill[] = [],
 ): AgentTool[] {
-  return [...createCodingTools(cwd), createTodoWriteTool(todoStorage), createAskUserQuestionTool()];
+  return [
+    ...createCodingTools(cwd),
+    createTodoWriteTool(todoStorage),
+    createAskUserQuestionTool(),
+    createReadSkillTool(skills),
+  ];
 }
 
 export function createTurnRunnerTools(input: TurnRunnerToolsInput): AgentTool[] {
-  const tools = [...createDefaultTurnRunnerTools(input.cwd, input.todoStorage)];
+  const tools = [...createDefaultTurnRunnerTools(input.cwd, input.todoStorage, input.skills)];
   if (input.mode === "agent") {
     return tools;
   }
@@ -394,6 +409,32 @@ function createAskUserQuestionTool(): AgentTool<typeof askUserQuestionSchema> {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         details: result,
         terminate: true,
+      };
+    },
+  };
+}
+
+function createReadSkillTool(skills: readonly Skill[]): AgentTool<typeof readSkillSchema> {
+  return {
+    name: "read_skill",
+    label: "Read skill",
+    description: dedent`
+      Load the full SKILL.md instructions for one of the available skills listed in the system prompt.
+
+      The system prompt only lists skill names and one-line descriptions to keep the context small. When a skill's description matches the task at hand, call this tool with its name to fetch the full instructions, then follow them.
+    `,
+    parameters: readSkillSchema,
+    async execute(_toolCallId, params) {
+      const skill = skills.find((candidate) => candidate.name === params.name);
+      if (!skill) {
+        const available = skills.map((candidate) => candidate.name).join(", ") || "(none)";
+        throw new Error(`Unknown skill: ${params.name}. Available skills: ${available}`);
+      }
+
+      const instructions = readSkillInstructions(skill);
+      return {
+        content: [{ type: "text", text: instructions }],
+        details: { type: "read_skill", name: skill.name },
       };
     },
   };

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -423,7 +423,7 @@ function createReadSkillTool(skills: readonly Skill[]): AgentTool<typeof readSki
 
       The system prompt only lists skill names and one-line descriptions to keep the context small. When a skill's description matches the task at hand, call this tool with its name to fetch the full instructions, then follow them.
 
-      The response also includes the skill file path and base directory so you can read sibling reference files (e.g. \`<baseDir>/reference/<file>\`) referenced by the instructions.
+      The response also includes the SKILL.md path so you can read sibling reference files (e.g. \`<dirname(path)>/reference/<file>\`) referenced by the instructions.
     `,
     parameters: readSkillSchema,
     async execute(_toolCallId, params) {
@@ -437,18 +437,12 @@ function createReadSkillTool(skills: readonly Skill[]): AgentTool<typeof readSki
       const header = dedent`
         Skill: ${skill.name}
         Path: ${skill.filePath}
-        Base directory: ${skill.baseDir}
 
         ---
       `;
       return {
         content: [{ type: "text", text: `${header}\n\n${instructions}` }],
-        details: {
-          type: "read_skill",
-          name: skill.name,
-          filePath: skill.filePath,
-          baseDir: skill.baseDir,
-        },
+        details: { type: "read_skill", name: skill.name, filePath: skill.filePath },
       };
     },
   };

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -422,6 +422,8 @@ function createReadSkillTool(skills: readonly Skill[]): AgentTool<typeof readSki
       Load the full SKILL.md instructions for one of the available skills listed in the system prompt.
 
       The system prompt only lists skill names and one-line descriptions to keep the context small. When a skill's description matches the task at hand, call this tool with its name to fetch the full instructions, then follow them.
+
+      The response also includes the skill file path and base directory so you can read sibling reference files (e.g. \`<baseDir>/reference/<file>\`) referenced by the instructions.
     `,
     parameters: readSkillSchema,
     async execute(_toolCallId, params) {
@@ -432,9 +434,21 @@ function createReadSkillTool(skills: readonly Skill[]): AgentTool<typeof readSki
       }
 
       const instructions = readSkillInstructions(skill);
+      const header = dedent`
+        Skill: ${skill.name}
+        Path: ${skill.filePath}
+        Base directory: ${skill.baseDir}
+
+        ---
+      `;
       return {
-        content: [{ type: "text", text: instructions }],
-        details: { type: "read_skill", name: skill.name },
+        content: [{ type: "text", text: `${header}\n\n${instructions}` }],
+        details: {
+          type: "read_skill",
+          name: skill.name,
+          filePath: skill.filePath,
+          baseDir: skill.baseDir,
+        },
       };
     },
   };

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -616,8 +616,9 @@ export class TurnRunner {
         this.todos = todos;
       },
     };
+    const skills = this.skillContext.getSkills();
     if (mode === "agent") {
-      return { tools: createDefaultTurnRunnerTools(cwd, todoStorage) };
+      return { tools: createDefaultTurnRunnerTools(cwd, todoStorage, skills) };
     }
 
     return {
@@ -626,6 +627,7 @@ export class TurnRunner {
         mode,
         definition: session?.stateMachine?.definition,
         todoStorage,
+        skills,
       }),
     };
   }

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -101,13 +101,15 @@ describe("TurnRunner skills", () => {
     expect(skill?.description).toBe("Use when description expansion.");
   });
 
-  testIfDocker("injects all loaded skill instructions into the system prompt", async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "duet-skill-"));
-    const firstSkillPath = join(tempDir, "first.md");
-    const secondSkillPath = join(tempDir, "second.md");
-    await writeFile(
-      firstSkillPath,
-      dedent`
+  testIfDocker(
+    "injects skill metadata only (not full instructions) into the system prompt",
+    async () => {
+      tempDir = await mkdtemp(join(tmpdir(), "duet-skill-"));
+      const firstSkillPath = join(tempDir, "first.md");
+      const secondSkillPath = join(tempDir, "second.md");
+      await writeFile(
+        firstSkillPath,
+        dedent`
         ---
         name: first-skill
         description: First skill description.
@@ -117,10 +119,10 @@ describe("TurnRunner skills", () => {
 
         First skill instructions.
       `,
-    );
-    await writeFile(
-      secondSkillPath,
-      dedent`
+      );
+      await writeFile(
+        secondSkillPath,
+        dedent`
         ---
         name: second-skill
         description: Second skill description.
@@ -130,42 +132,47 @@ describe("TurnRunner skills", () => {
 
         Second skill instructions.
       `,
-    );
-    const runner = new SkillPromptTurnRunner({
-      model: "anthropic:claude-opus-4-7",
-      cwd: process.cwd(),
-      skillDiscovery: { includeDefaults: false },
-      skills: [
-        {
-          name: "first-skill",
-          description: "First skill description.",
-          filePath: firstSkillPath,
-          baseDir: tempDir,
-          sourceInfo: {} as Skill["sourceInfo"],
-          disableModelInvocation: false,
-        },
-        {
-          name: "second-skill",
-          description: "Second skill description.",
-          filePath: secondSkillPath,
-          baseDir: tempDir,
-          sourceInfo: {} as Skill["sourceInfo"],
-          disableModelInvocation: false,
-        },
-      ],
-    });
+      );
+      const runner = new SkillPromptTurnRunner({
+        model: "anthropic:claude-opus-4-7",
+        cwd: process.cwd(),
+        skillDiscovery: { includeDefaults: false },
+        skills: [
+          {
+            name: "first-skill",
+            description: "First skill description.",
+            filePath: firstSkillPath,
+            baseDir: tempDir,
+            sourceInfo: {} as Skill["sourceInfo"],
+            disableModelInvocation: false,
+          },
+          {
+            name: "second-skill",
+            description: "Second skill description.",
+            filePath: secondSkillPath,
+            baseDir: tempDir,
+            sourceInfo: {} as Skill["sourceInfo"],
+            disableModelInvocation: false,
+          },
+        ],
+      });
 
-    await runner.getSkills();
-    const systemPrompt = runner.systemPromptForTest("Base instructions.");
+      await runner.getSkills();
+      const systemPrompt = runner.systemPromptForTest("Base instructions.");
 
-    expect(systemPrompt).toContain("Available skills:");
-    expect(systemPrompt).toContain("<skills>");
-    expect(systemPrompt).toContain("name: first-skill");
-    expect(systemPrompt).toContain("First skill instructions.");
-    expect(systemPrompt).toContain("name: second-skill");
-    expect(systemPrompt).toContain("Second skill instructions.");
-    expect(systemPrompt).toContain("Base instructions.");
-  });
+      expect(systemPrompt).toContain("Available skills");
+      expect(systemPrompt).toContain("<skills>");
+      expect(systemPrompt).toContain("name: first-skill");
+      expect(systemPrompt).toContain("First skill description.");
+      expect(systemPrompt).toContain("name: second-skill");
+      expect(systemPrompt).toContain("Second skill description.");
+      expect(systemPrompt).toContain("Base instructions.");
+      // Full SKILL.md bodies must NOT be inlined — they're loaded on demand via the read_skill tool.
+      expect(systemPrompt).not.toContain("First skill instructions.");
+      expect(systemPrompt).not.toContain("Second skill instructions.");
+      expect(systemPrompt).toContain("read_skill");
+    },
+  );
 
   testIfDocker(
     "injects full skill instructions for slash command prompts at runner level",

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -162,9 +162,9 @@ describe("TurnRunner skills", () => {
 
       expect(systemPrompt).toContain("Available skills");
       expect(systemPrompt).toContain("<skills>");
-      expect(systemPrompt).toContain("name: first-skill");
+      expect(systemPrompt).toContain('<skill name="first-skill">');
       expect(systemPrompt).toContain("First skill description.");
-      expect(systemPrompt).toContain("name: second-skill");
+      expect(systemPrompt).toContain('<skill name="second-skill">');
       expect(systemPrompt).toContain("Second skill description.");
       expect(systemPrompt).toContain("Base instructions.");
       // Full SKILL.md bodies must NOT be inlined — they're loaded on demand via the read_skill tool.

--- a/test/turn-runner-tools.test.ts
+++ b/test/turn-runner-tools.test.ts
@@ -684,12 +684,10 @@ describe("TurnRunner tools", () => {
       const text = result.content[0]?.type === "text" ? result.content[0].text : "";
       expect(text).toContain("Full instructions live here.");
       expect(text).toContain(`Path: ${skillPath}`);
-      expect(text).toContain(`Base directory: ${tempDir}`);
       expect(result.details).toEqual({
         type: "read_skill",
         name: "lazy-skill",
         filePath: skillPath,
-        baseDir: tempDir,
       });
 
       const missing = readSkillTool.execute("tool-2", { name: "does-not-exist" });

--- a/test/turn-runner-tools.test.ts
+++ b/test/turn-runner-tools.test.ts
@@ -1,4 +1,9 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
+import type { Skill } from "@mariozechner/pi-coding-agent";
+import dedent from "dedent";
 import { createTurnRunnerTools, type TurnRunnerControlResult } from "../src/turn-runner/tools.js";
 
 describe("TurnRunner tools", () => {
@@ -641,6 +646,50 @@ describe("TurnRunner tools", () => {
     );
     expect(stateMachineTools.some((tool) => tool.name === "select_state_machine_state")).toBe(true);
     expect(stateMachineTools.some((tool) => tool.name === "prompt_state_machine_agent")).toBe(true);
+  });
+
+  test("read_skill returns full SKILL.md instructions for a known skill", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "duet-skill-tool-"));
+    try {
+      const skillPath = join(tempDir, "SKILL.md");
+      writeFileSync(
+        skillPath,
+        dedent`
+          ---
+          name: lazy-skill
+          description: Lazy-loaded skill body.
+          ---
+
+          # Lazy Skill
+
+          Full instructions live here.
+        `,
+      );
+      const skill: Skill = {
+        name: "lazy-skill",
+        description: "Lazy-loaded skill body.",
+        filePath: skillPath,
+        baseDir: tempDir,
+        sourceInfo: {} as Skill["sourceInfo"],
+        disableModelInvocation: false,
+      };
+
+      const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "agent", skills: [skill] });
+      const readSkillTool = tools.find((tool) => tool.name === "read_skill");
+
+      expect(readSkillTool).toBeDefined();
+      if (!readSkillTool) throw new Error("read_skill tool missing");
+
+      const result = await readSkillTool.execute("tool-1", { name: "lazy-skill" });
+      const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+      expect(text).toContain("Full instructions live here.");
+      expect(result.details).toEqual({ type: "read_skill", name: "lazy-skill" });
+
+      const missing = readSkillTool.execute("tool-2", { name: "does-not-exist" });
+      await expect(missing).rejects.toThrow(/Unknown skill: does-not-exist/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("describes tool schema properties for provider tool prompts", () => {

--- a/test/turn-runner-tools.test.ts
+++ b/test/turn-runner-tools.test.ts
@@ -683,7 +683,14 @@ describe("TurnRunner tools", () => {
       const result = await readSkillTool.execute("tool-1", { name: "lazy-skill" });
       const text = result.content[0]?.type === "text" ? result.content[0].text : "";
       expect(text).toContain("Full instructions live here.");
-      expect(result.details).toEqual({ type: "read_skill", name: "lazy-skill" });
+      expect(text).toContain(`Path: ${skillPath}`);
+      expect(text).toContain(`Base directory: ${tempDir}`);
+      expect(result.details).toEqual({
+        type: "read_skill",
+        name: "lazy-skill",
+        filePath: skillPath,
+        baseDir: tempDir,
+      });
 
       const missing = readSkillTool.execute("tool-2", { name: "does-not-exist" });
       await expect(missing).rejects.toThrow(/Unknown skill: does-not-exist/);


### PR DESCRIPTION
## Problem

`createSkillsSystemPrompt` injected the **full** `SKILL.md` body of every loaded skill into the system prompt on every turn:

```ts
{ instructions: readSkillInstructions(skill) },
```

With a normal HOME containing ~30 user-scope skills under `~/.duet/skills/` (the realistic case after `bunx skills add ... -g`), this blows past the 1M-token context window and the model returns HTTP 400 on **any** prompt. Reproduces on `0.1.4` and `0.1.10`. Sidestepping skill discovery (`HOME=/empty`) avoids it, confirming the system prompt is the culprit.

## Fix

- System prompt now lists only `name` + `description` per skill (the same metadata `duet skills` returns).
- New `read_skill` tool fetches the full instructions on demand by name.
- Slash-command path (`/skill-name`) is unchanged — still inlines full instructions when the user explicitly invokes a skill.
- `allowedSkills` on state-machine sub-agents is unchanged — those sub-agents see only their allowed skills' metadata, and can call `read_skill` for any of them.

## Verification

End-to-end with my real `~/.duet/skills/` (~30 skills):

| | Before | After |
|---|---|---|
| Single-turn `Reply only with 'pong'.` | HTTP 400 (>1M input tokens) | `pong` returned, ~25k input tokens |

Tests: `bun test` (147 tests; 35 Docker-gated skipped locally, all 112 non-Docker pass). Updated `test/skills.test.ts` to assert metadata-only system prompt and added a `read_skill` tool test in `test/turn-runner-tools.test.ts`. `bun run check-types`, `bun run lint`, and `bun run build` all clean.

## Notes for reviewers

- The new tool returns `{ content, details: { type: "read_skill", name } }` and throws on unknown skill names per the `AgentTool` contract ("Throw on failure instead of encoding errors in `content`").
- `createDefaultTurnRunnerTools` now takes an optional third `skills` arg (defaults to `[]`) so the public API stays backward-compatible for callers that don't have a skill list.