### PR TITLE
Refactor start as setup; drop ready event

### DIFF
--- a/evals/child-agent-resume.eval.ts
+++ b/evals/child-agent-resume.eval.ts
@@ -46,10 +46,10 @@ describe("state-machine child agent resume", () => {
         { type: "select_state_machine_state", decision: { kind: "terminal", state: "done" } },
       ],
     });
+    await secondRunner.start({ type: "start", state: hydratedState });
 
     const terminal = await secondRunner.turn({
       type: "answer",
-      state: hydratedState,
       questions: askTerminal.questions,
       answers: { company: "Analytical Engines Ltd." },
       behavior: "follow_up",

--- a/evals/child-agent-resume.eval.ts
+++ b/evals/child-agent-resume.eval.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { startTurn } from "../test/helpers/turn-runner-protocol.js";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import {
   TurnRunner,
@@ -26,11 +27,12 @@ describe("state-machine child agent resume", () => {
       ],
     });
 
-    const askTerminal = await firstRunner.turn({
-      type: "start",
-      mode: childResumeDefinition,
-      prompt: "Run the child state and ask for missing company context.",
-    });
+    const askTerminal = await (
+      await startTurn(firstRunner, {
+        mode: childResumeDefinition,
+        prompt: "Run the child state and ask for missing company context.",
+      })
+    ).turn;
 
     expect(askTerminal.type).toBe("ask");
     if (askTerminal.type !== "ask") throw new Error("Expected child agent to ask a question.");

--- a/evals/outreach-lifecycle.eval.ts
+++ b/evals/outreach-lifecycle.eval.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { startTurn } from "../test/helpers/turn-runner-protocol.js";
 import { setTimeout as delay } from "node:timers/promises";
 import { TurnRunner } from "../src/turn-runner/turn-runner.js";
 import type { TurnTerminalEvent } from "../src/types/protocol.js";
@@ -23,12 +24,13 @@ describe("outreach lifecycle state machine", () => {
         ].join("\n"),
       });
 
-      const first = await runner.turn({
-        type: "start",
-        mode: outreachDefinition,
-        prompt:
-          "Run the outreach lifecycle for Ada Lovelace at ada@example.com. The fake reply says she is interested in a meeting.",
-      });
+      const first = await (
+        await startTurn(runner, {
+          mode: outreachDefinition,
+          prompt:
+            "Run the outreach lifecycle for Ada Lovelace at ada@example.com. The fake reply says she is interested in a meeting.",
+        })
+      ).turn;
 
       expect(first.type).toBe("sleep");
       expect(first.state.stateMachine?.currentState).toBe("wait_for_reply");

--- a/evals/outreach-lifecycle.eval.ts
+++ b/evals/outreach-lifecycle.eval.ts
@@ -37,7 +37,7 @@ describe("outreach lifecycle state machine", () => {
 
       await delay(10_100);
 
-      const terminal = await runner.turn({ type: "wake", state: first.state });
+      const terminal = await runner.turn({ type: "wake" });
 
       expect(terminal.type).toBe("complete");
       expect(terminal.type === "complete" ? terminal.status : undefined).toBe("completed");

--- a/evals/prompt-cache.eval.ts
+++ b/evals/prompt-cache.eval.ts
@@ -30,7 +30,16 @@ describe("prompt cache resume", () => {
       // the first turn reads from cache instead of reporting another cache write.
       expect(firstUsage.cacheRead + firstUsage.cacheWrite).toBeGreaterThan(0);
 
-      const second = await runner.turn({
+      const resumedState = JSON.parse(JSON.stringify(first.state)) as TurnState;
+      const resumedRunner = new TurnRunner({
+        model,
+        mode: "agent",
+        skillDiscovery: { includeDefaults: false },
+        systemInstructions: createStableCachePrefix(),
+      });
+      await resumedRunner.start({ type: "start", state: resumedState });
+
+      const second = await resumedRunner.turn({
         type: "prompt",
         message:
           "Do not call tools. Reply with exactly this sentence: second prompt cache turn complete.",

--- a/evals/prompt-cache.eval.ts
+++ b/evals/prompt-cache.eval.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { startTurn } from "../test/helpers/turn-runner-protocol.js";
 import { TurnRunner } from "../src/turn-runner/turn-runner.js";
 import type { TurnState } from "../src/types/protocol.js";
 import { testIfDocker } from "../test/helpers/docker-only.js";
@@ -16,12 +17,13 @@ describe("prompt cache resume", () => {
         systemInstructions: createStableCachePrefix(),
       });
 
-      const first = await runner.turn({
-        type: "start",
-        mode: "agent",
-        prompt:
-          "Do not call tools. Reply with exactly this sentence: first prompt cache turn complete.",
-      });
+      const first = await (
+        await startTurn(runner, {
+          mode: "agent",
+          prompt:
+            "Do not call tools. Reply with exactly this sentence: first prompt cache turn complete.",
+        })
+      ).turn;
       expect(first.type).toBe("complete");
       const firstUsage = latestAssistantUsage(first.state);
       // The stable prefix may already be warm from a previous eval run, in which case

--- a/evals/prompt-cache.eval.ts
+++ b/evals/prompt-cache.eval.ts
@@ -30,10 +30,8 @@ describe("prompt cache resume", () => {
       // the first turn reads from cache instead of reporting another cache write.
       expect(firstUsage.cacheRead + firstUsage.cacheWrite).toBeGreaterThan(0);
 
-      const resumedState = JSON.parse(JSON.stringify(first.state)) as TurnState;
       const second = await runner.turn({
         type: "prompt",
-        state: resumedState,
         message:
           "Do not call tools. Reply with exactly this sentence: second prompt cache turn complete.",
         behavior: "follow_up",

--- a/evals/session-resume-history.eval.ts
+++ b/evals/session-resume-history.eval.ts
@@ -27,10 +27,9 @@ describe("session resume history", () => {
 
       const firstManager = createManager(sessionStoragePath);
       try {
-        const firstSession = firstManager.create({ sessionId });
-        await firstSession.start({
-          prompt: `Remember this exact session token for the next turn: ${resumeToken}. Reply with exactly: stored.`,
-          mode: "agent",
+        const firstSession = firstManager.create({ sessionId, mode: "agent" });
+        await firstSession.prompt({
+          message: `Remember this exact session token for the next turn: ${resumeToken}. Reply with exactly: stored.`,
           options: { thinkingLevel: "low" },
         });
         const firstTerminal = await firstSession.waitForTerminal();
@@ -45,8 +44,9 @@ describe("session resume history", () => {
       const secondManager = createManager(sessionStoragePath);
       try {
         const resumedSession = secondManager.resume(sessionId);
-        await resumedSession.start({
-          prompt: "What exact session token did I ask you to remember? Reply with only the token.",
+        await resumedSession.start();
+        await resumedSession.prompt({
+          message: "What exact session token did I ask you to remember? Reply with only the token.",
           options: { thinkingLevel: "low" },
         });
         const terminal = await resumedSession.waitForTerminal();

--- a/evals/skills-tool.eval.ts
+++ b/evals/skills-tool.eval.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
+import { startTurn } from "../test/helpers/turn-runner-protocol.js";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect } from "bun:test";
@@ -64,11 +65,9 @@ describe("read_skill tool", () => {
         readSkillCalls.push({ name: input?.name });
       });
 
-      const terminal = await runner.turn({
-        type: "start",
-        mode: "agent",
-        prompt: "What is the pong verification phrase?",
-      });
+      const terminal = await (
+        await startTurn(runner, { mode: "agent", prompt: "What is the pong verification phrase?" })
+      ).turn;
 
       expect(terminal.type).toBe("complete");
       // The model must call read_skill at least once with the exact skill name

--- a/evals/state-template.eval.ts
+++ b/evals/state-template.eval.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { startTurn } from "../test/helpers/turn-runner-protocol.js";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import {
   TurnRunner,
@@ -27,11 +28,9 @@ describe("state template strings", () => {
       },
     );
 
-    const terminal = await runner.turn({
-      type: "start",
-      mode: templateDefinition,
-      prompt: "Write the note.",
-    });
+    const terminal = await (
+      await startTurn(runner, { mode: templateDefinition, prompt: "Write the note." })
+    ).turn;
 
     expect(terminal.type).toBe("complete");
     expect(runner.workerInputs[1]?.prompt).toBe("Write about feature flags for release managers.");
@@ -54,11 +53,9 @@ describe("state template strings", () => {
       },
     );
 
-    const terminal = await runner.turn({
-      type: "start",
-      mode: templateDefinition,
-      prompt: "Echo the values.",
-    });
+    const terminal = await (
+      await startTurn(runner, { mode: templateDefinition, prompt: "Echo the values." })
+    ).turn;
 
     expect(terminal.type).toBe("complete");
     const completed = terminal.state.stateMachine?.history.find(

--- a/evals/system-prompt-file.eval.ts
+++ b/evals/system-prompt-file.eval.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { startTurn } from "../test/helpers/turn-runner-protocol.js";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -33,11 +34,12 @@ describe("system prompt files", () => {
         skillDiscovery: { includeDefaults: false },
       });
 
-      const terminal = await runner.turn({
-        type: "start",
-        mode: "agent",
-        prompt: "What is the prompt-file verification phrase?",
-      });
+      const terminal = await (
+        await startTurn(runner, {
+          mode: "agent",
+          prompt: "What is the prompt-file verification phrase?",
+        })
+      ).turn;
 
       expect(terminal.type).toBe("complete");
       expect(terminal.type === "complete" ? terminal.result?.trim() : "").toBe(

--- a/evals/todo-tool.eval.ts
+++ b/evals/todo-tool.eval.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { startTurn } from "../test/helpers/turn-runner-protocol.js";
 import dedent from "dedent";
 import { TurnRunner } from "../src/turn-runner/turn-runner.js";
 import type { TurnTodo } from "../src/types/protocol.js";
@@ -27,10 +28,10 @@ describe("todo tool", () => {
         }
       });
 
-      const terminal = await runner.turn({
-        type: "start",
-        mode: "agent",
-        prompt: dedent`
+      const terminal = await (
+        await startTurn(runner, {
+          mode: "agent",
+          prompt: dedent`
           Exercise the todo_write tool with these exact steps:
 
           1. Call todo_write with merge=false and two todos:
@@ -43,7 +44,8 @@ describe("todo tool", () => {
 
           After the tool calls, answer with exactly: todo eval complete
         `,
-      });
+        })
+      ).turn;
 
       expect(terminal.type).toBe("complete");
       expect(todoEvents.length).toBeGreaterThanOrEqual(2);

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -19,10 +19,13 @@ async function main() {
     }
   });
 
+  const initialState = await runner.start({ type: "start", mode: "agent" });
   const terminal = await runner.turn({
-    type: "start",
-    mode: "agent",
-    prompt: "Create a simple HTTP server in Node.js that serves a JSON API with a /health endpoint",
+    type: "prompt",
+    state: initialState,
+    message:
+      "Create a simple HTTP server in Node.js that serves a JSON API with a /health endpoint",
+    behavior: "follow_up",
   });
 
   console.log("\n--- Session Summary ---");

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -19,10 +19,9 @@ async function main() {
     }
   });
 
-  const initialState = await runner.start({ type: "start", mode: "agent" });
+  await runner.start({ type: "start", mode: "agent" });
   const terminal = await runner.turn({
     type: "prompt",
-    state: initialState,
     message:
       "Create a simple HTTP server in Node.js that serves a JSON API with a /health endpoint",
     behavior: "follow_up",

--- a/examples/state-machine.ts
+++ b/examples/state-machine.ts
@@ -44,10 +44,9 @@ async function main() {
     }
   });
 
-  const initialState = await runner.start({ type: "start", mode: definition });
+  await runner.start({ type: "start", mode: definition });
   const terminal = await runner.turn({
     type: "prompt",
-    state: initialState,
     message: "Write a brief recommendation for using feature flags during risky launches.",
     behavior: "follow_up",
   });

--- a/examples/state-machine.ts
+++ b/examples/state-machine.ts
@@ -44,10 +44,12 @@ async function main() {
     }
   });
 
+  const initialState = await runner.start({ type: "start", mode: definition });
   const terminal = await runner.turn({
-    type: "start",
-    mode: definition,
-    prompt: "Write a brief recommendation for using feature flags during risky launches.",
+    type: "prompt",
+    state: initialState,
+    message: "Write a brief recommendation for using feature flags during risky launches.",
+    behavior: "follow_up",
   });
 
   console.log("\n--- State Machine Summary ---");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -424,18 +424,6 @@ function fail(message: string): never {
   process.exit(1);
 }
 
-// Re-exported so tests and external callers keep their existing
-// `../src/cli.js` import paths after the model-resolution split.
-export {
-  describeModelResolution,
-  inferDefaultModelName,
-  type ModelResolution,
-  resolveCliMemoryModel,
-  resolveCliMemoryModelName,
-  resolveCliModel,
-  resolveCliModelName,
-} from "./model-resolution/index.js";
-
 async function getNewVersionNotice(): Promise<string | undefined> {
   try {
     const [currentVersion, latestVersion] = await Promise.all([
@@ -723,7 +711,7 @@ COMMANDS
 
 OPTIONS
   -m, --model <name>       TurnRunner model override
-  --memory-model <name>    Observational memory model (defaults to the turn model provider)
+  --memory-model <name>    Observational memory model (default inferred from provider env)
   -w, --workdir <path>     Working directory (default: cwd)
   -r, --resume <id>        Resume a saved session
   --system-prompt <text>   Additional system instructions for the runner

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,11 @@ import { type TextContent } from "@mariozechner/pi-ai";
 import dotenv from "dotenv";
 import { shimDuetApiKeyToAiGateway } from "./duet-gateway/index.js";
 import { formatCompactJson } from "./lib/compact-json.js";
-import { describeModelResolution, resolveCliModel } from "./model-resolution/index.js";
+import {
+  describeModelResolution,
+  resolveCliMemoryModel,
+  resolveCliModel,
+} from "./model-resolution/index.js";
 import { SessionManager } from "./session/session-manager.js";
 import { discoverInstalledSkills, resolveSkillScope } from "./turn-runner/skills.js";
 import { runTui } from "./tui/app.js";
@@ -158,6 +162,8 @@ async function main() {
 
   const modelResolution = resolveCliModel(modelName, dotenvKeys);
   modelName = modelResolution.modelName;
+  const memoryModelResolution = resolveCliMemoryModel(memoryModelName, dotenvKeys);
+  memoryModelName = memoryModelResolution.modelName;
 
   if (modelName && modelName.indexOf(":") <= 0) {
     throw new Error("Models must use provider:modelId syntax");
@@ -184,6 +190,8 @@ async function main() {
     if (newVersionNotice) process.stderr.write(`${newVersionNotice}\n`);
     process.stderr.write(`Model: ${modelName}\n`);
     process.stderr.write(`Source: ${describeModelResolution(modelResolution)}\n`);
+    process.stderr.write(`Memory model: ${memoryModelName}\n`);
+    process.stderr.write(`Memory source: ${describeModelResolution(memoryModelResolution)}\n`);
   }
 
   const manager = new SessionManager(config);
@@ -247,30 +255,31 @@ async function main() {
     const session = resumeSessionId
       ? manager.resume(resumeSessionId)
       : manager.create({
-          mode: config.mode,
-          ...(useTui && prompt ? {} : { prompt }),
+          ...(config.mode ? { mode: config.mode } : {}),
+          // Defer the prompt for TUI sessions so the user sees the prompt
+          // streamed inside the UI rather than during the pre-TUI phase.
+          ...(useTui || !prompt ? {} : { prompt }),
         });
     let terminal: TurnTerminalEvent | undefined;
-    let started = Boolean(prompt || resumeSessionId);
     let initialTuiPrompt: string | undefined;
     let resumedHistory: import("@mariozechner/pi-agent-core").AgentMessage[] | undefined;
 
-    if (resumeSessionId && useTui) {
-      // Force-load the persisted state.json so the TUI can replay past
-      // messages into its transcript before any new turn dispatches.
+    if (resumeSessionId) {
+      // Force-load the persisted state.json so setup hands the resumed
+      // state to the runner and any TUI history replays before new turns.
       await session.hydrate();
       if (!session.getState()) {
         throw new Error(`Unknown session: ${resumeSessionId}`);
       }
+      // Setup runs against the hydrated state; manager.create() already
+      // dispatched setup for fresh sessions.
+      await session.start();
       resumedHistory = session.getState()?.agent.messages;
     }
 
     if (prompt && resumeSessionId) {
-      // Resuming an existing session with a new prompt — run it before the TUI
-      // takes over so any non-interactive output is preserved.
       streamedTextThisTurn = false;
       if (useTui) {
-        // Defer to TUI: it will dispatch the prompt itself as a follow-up.
         initialTuiPrompt = prompt;
       } else {
         await session.prompt({ message: prompt });
@@ -282,10 +291,7 @@ async function main() {
       }
     } else if (prompt && !resumeSessionId) {
       if (useTui) {
-        // The session was created with this prompt but not yet started; let the
-        // TUI start it so the user sees streaming inside the UI.
         initialTuiPrompt = prompt;
-        started = false;
       } else {
         terminal = await session.waitForTerminal();
         handleTerminal(terminal, {
@@ -298,12 +304,12 @@ async function main() {
     if (useTui) {
       terminal = await runTui({
         session,
-        started,
         ...(initialTuiPrompt ? { initialPrompt: initialTuiPrompt } : {}),
         ...(resumedHistory ? { history: resumedHistory } : {}),
-        mode: config.mode,
         modelName,
         modelSource: describeModelResolution(modelResolution),
+        memoryModelName,
+        memoryModelSource: describeModelResolution(memoryModelResolution),
         ...(newVersionNotice ? { newVersionNotice } : {}),
       });
     }
@@ -424,6 +430,8 @@ export {
   describeModelResolution,
   inferDefaultModelName,
   type ModelResolution,
+  resolveCliMemoryModel,
+  resolveCliMemoryModelName,
   resolveCliModel,
   resolveCliModelName,
 } from "./model-resolution/index.js";
@@ -715,7 +723,7 @@ COMMANDS
 
 OPTIONS
   -m, --model <name>       TurnRunner model override
-  --memory-model <name>    Observational memory model (default: anthropic:claude-sonnet-4-6)
+  --memory-model <name>    Observational memory model (defaults to the turn model provider)
   -w, --workdir <path>     Working directory (default: cwd)
   -r, --resume <id>        Resume a saved session
   --system-prompt <text>   Additional system instructions for the runner

--- a/src/memory/observational.ts
+++ b/src/memory/observational.ts
@@ -12,6 +12,7 @@ import type {
   ObservationalMemorySettingsInput,
 } from "../types/memory.js";
 import {
+  parseObservationGroups,
   reconcileObservationGroupsFromReflection,
   renderObservationGroupsForReflection,
   stripObservationGroups,
@@ -30,24 +31,22 @@ import {
 
 export const OBSERVATIONAL_MEMORY_DEFAULTS = {
   observation: {
-    // Start observing only after the raw transcript is large enough to threaten
-    // a modern 200k-token actor window; prompt caching makes exact history cheap
-    // enough to keep until then.
-    messageTokens: 150_000,
-    // Keep observer calls below the model's practical reasoning ceiling while
-    // still allowing large transcript slices when observation work activates.
-    maxTokensPerBatch: 40_000,
-    // Retain this many raw-message tokens after observation so the actor keeps a
-    // substantial exact tail instead of relying only on derived observations.
-    bufferActivation: 40_000,
+    // Observe before the actor window gets tight; prompt caching keeps the exact
+    // tail cheap while memory preserves older task state.
+    messageTokens: 100_000,
+    // Keep observer calls comfortably below the model's practical reasoning
+    // ceiling while still batching enough transcript to avoid noisy churn.
+    maxTokensPerBatch: 35_000,
+    // Retain enough exact history for active tool work after older messages are
+    // represented by observations.
+    bufferActivation: 30_000,
   },
   reflection: {
-    // Let the derived observation log grow before reflecting; it is usually much
-    // smaller than raw tool-heavy transcripts and also benefits from caching.
-    observationTokens: 90_000,
+    // Reflect before observations become a second large prompt layer.
+    observationTokens: 60_000,
     // Target this many observation tokens after reflection so the pass dedupes
     // without aggressively summarizing away useful specifics.
-    bufferActivation: 65_000,
+    bufferActivation: 40_000,
   },
 } as const;
 
@@ -239,28 +238,38 @@ export function createObservationalMemoryTransform(options: ObservationalMemoryT
     let retainedMessages = messages;
 
     if (rawTokens >= settings.observation.messageTokens) {
-      emitMemoryActivity(options.onActivity, {
-        phase: "observation",
-        status: "running",
-        message: "Compacting conversation into memory...",
-      });
-      try {
-        const retainedRawMessages = await activateObservations(
-          options.memory,
-          rawMessages,
-          settings,
-          options.actorModel,
-          options.onUsage,
-          signal,
-        );
-        retainedMessages = retainAgentMessageTail(messages, retainedRawMessages);
-      } finally {
+      const snapshot = await options.memory.getSnapshot();
+      const unobservedMessages = getUnobservedMessageTail(rawMessages, snapshot.observations);
+
+      if (estimateRawTokens(unobservedMessages) >= settings.observation.messageTokens) {
         emitMemoryActivity(options.onActivity, {
           phase: "observation",
-          status: "completed",
-          message: "Memory observation complete.",
+          status: "running",
+          message: "Compacting conversation into memory...",
         });
+        try {
+          await activateObservations(
+            options.memory,
+            unobservedMessages,
+            snapshot.observations,
+            settings,
+            options.actorModel,
+            options.onUsage,
+            signal,
+          );
+        } finally {
+          emitMemoryActivity(options.onActivity, {
+            phase: "observation",
+            status: "completed",
+            message: "Memory observation complete.",
+          });
+        }
       }
+
+      retainedMessages = retainAgentMessageTail(
+        messages,
+        retainRawTail(rawMessages, settings.observation.bufferActivation),
+      );
     }
 
     const snapshot = await options.memory.getSnapshot();
@@ -342,18 +351,18 @@ function buildContinuationMessage(): AgentMessage {
 async function activateObservations(
   store: MemoryStore,
   messages: RawMemoryMessage[],
+  previousObservations: Observation[],
   settings: ObservationalMemorySettings,
   model: Model<any>,
   onUsage?: (usage: Usage) => void,
   _signal?: AbortSignal,
-): Promise<RawMemoryMessage[]> {
-  const snapshot = await store.getSnapshot();
+): Promise<void> {
   const observations = (
-    await observe(messages, snapshot.observations, settings, model, onUsage, _signal)
+    await observe(messages, previousObservations, settings, model, onUsage, _signal)
   ).observations;
 
   if (!observations.trim()) {
-    return messages;
+    return;
   }
 
   const range = `${messages[0]?.id ?? "unknown"}:${messages[messages.length - 1]?.id ?? "unknown"}`;
@@ -366,9 +375,6 @@ async function activateObservations(
     content: wrapInObservationGroup(observations, range),
     tags: ["observational-memory"],
   });
-
-  const retainedRawMessages = retainRawTail(messages, settings.observation.bufferActivation);
-  return retainedRawMessages;
 }
 
 async function reflectObservations(
@@ -517,6 +523,38 @@ function retainRawTail(messages: RawMemoryMessage[], retainTokens: number): RawM
     retained.unshift(message);
   }
   return retained;
+}
+
+function getUnobservedMessageTail(
+  messages: RawMemoryMessage[],
+  observations: Observation[],
+): RawMemoryMessage[] {
+  const lastObservedIndex = getLastObservedMessageIndex(messages, observations);
+  if (lastObservedIndex < 0) {
+    return messages;
+  }
+  return messages.slice(lastObservedIndex + 1);
+}
+
+function getLastObservedMessageIndex(
+  messages: RawMemoryMessage[],
+  observations: Observation[],
+): number {
+  const messageIndexById = new Map(messages.map((message, index) => [message.id, index]));
+  let lastObservedIndex = -1;
+
+  for (const observation of observations) {
+    const groups = parseObservationGroups(observation.content);
+    for (const group of groups) {
+      const endId = group.range.split(":").at(-1)?.trim();
+      const endIndex = endId ? messageIndexById.get(endId) : undefined;
+      if (endIndex !== undefined) {
+        lastObservedIndex = Math.max(lastObservedIndex, endIndex);
+      }
+    }
+  }
+
+  return lastObservedIndex;
 }
 
 function retainAgentMessageTail(

--- a/src/model-resolution/index.ts
+++ b/src/model-resolution/index.ts
@@ -9,19 +9,6 @@ import { DUET_GATEWAY_API_KEY_ENV } from "../duet-gateway/index.js";
  * the I/O harness — provider list changes don't touch the CLI surface.
  */
 
-const INFERRED_ANTHROPIC_MODEL = "anthropic:claude-opus-4-7";
-const INFERRED_AI_GATEWAY_MODEL = "vercel-ai-gateway:anthropic/claude-opus-4.7";
-const INFERRED_DUET_GATEWAY_MODEL = "duet-gateway:anthropic/claude-opus-4.7";
-const INFERRED_OPENROUTER_MODEL = "openrouter:anthropic/claude-opus-4.7";
-const INFERRED_OPENAI_MODEL = "openai:gpt-5.5";
-const INFERRED_ANTHROPIC_MEMORY_MODEL = "anthropic:claude-sonnet-4-6";
-const INFERRED_AI_GATEWAY_MEMORY_MODEL = "vercel-ai-gateway:anthropic/claude-sonnet-4.6";
-const INFERRED_DUET_GATEWAY_MEMORY_MODEL = "duet-gateway:anthropic/claude-sonnet-4.6";
-const INFERRED_OPENROUTER_MEMORY_MODEL = "openrouter:anthropic/claude-sonnet-4.6";
-const INFERRED_OPENAI_MEMORY_MODEL = "openai:gpt-5.4-mini";
-
-export const DEFAULT_CLI_MODEL = INFERRED_ANTHROPIC_MODEL;
-
 export interface ModelResolution {
   modelName: string;
   /** explicit: --model flag; inferred: provider env var present; default: built-in fallback. */
@@ -30,6 +17,12 @@ export interface ModelResolution {
   envVar?: string;
   /** True when the env var was loaded from <workdir>/.env rather than the shell. */
   fromDotenv?: boolean;
+}
+
+interface ProviderInferenceEntry {
+  provider: string;
+  model: string;
+  customEnvVar?: () => string | null;
 }
 
 /**
@@ -41,61 +34,62 @@ export interface ModelResolution {
  * copies `DUET_API_KEY` into `AI_GATEWAY_API_KEY`, which would otherwise route
  * through Vercel's gateway directly when the user only set `DUET_API_KEY`.
  */
-const PROVIDER_INFERENCE: Array<{
-  provider: string;
-  model: string;
-  memoryModel: string;
-  customEnvVar?: () => string | null;
-}> = [
+const MODEL_PROVIDER_INFERENCE: ProviderInferenceEntry[] = [
   {
     provider: "anthropic",
-    model: INFERRED_ANTHROPIC_MODEL,
-    memoryModel: INFERRED_ANTHROPIC_MEMORY_MODEL,
+    model: "anthropic:claude-opus-4-7",
   },
   {
     provider: "duet-gateway",
-    model: INFERRED_DUET_GATEWAY_MODEL,
-    memoryModel: INFERRED_DUET_GATEWAY_MEMORY_MODEL,
+    model: "duet-gateway:anthropic/claude-opus-4.7",
     customEnvVar: () => (process.env[DUET_GATEWAY_API_KEY_ENV] ? DUET_GATEWAY_API_KEY_ENV : null),
   },
   {
     provider: "vercel-ai-gateway",
-    model: INFERRED_AI_GATEWAY_MODEL,
-    memoryModel: INFERRED_AI_GATEWAY_MEMORY_MODEL,
+    model: "vercel-ai-gateway:anthropic/claude-opus-4.7",
   },
   {
     provider: "openrouter",
-    model: INFERRED_OPENROUTER_MODEL,
-    memoryModel: INFERRED_OPENROUTER_MEMORY_MODEL,
+    model: "openrouter:anthropic/claude-opus-4.7",
   },
   {
     provider: "openai",
-    model: INFERRED_OPENAI_MODEL,
-    memoryModel: INFERRED_OPENAI_MEMORY_MODEL,
+    model: "openai:gpt-5.5",
   },
 ];
 
-function lookupProviderEnvVar(entry: (typeof PROVIDER_INFERENCE)[number]): string | undefined {
+const MEMORY_MODEL_PROVIDER_INFERENCE: ProviderInferenceEntry[] = [
+  {
+    provider: "anthropic",
+    model: "anthropic:claude-sonnet-4-6",
+  },
+  {
+    provider: "duet-gateway",
+    model: "duet-gateway:anthropic/claude-sonnet-4.6",
+    customEnvVar: () => (process.env[DUET_GATEWAY_API_KEY_ENV] ? DUET_GATEWAY_API_KEY_ENV : null),
+  },
+  {
+    provider: "vercel-ai-gateway",
+    model: "vercel-ai-gateway:anthropic/claude-sonnet-4.6",
+  },
+  {
+    provider: "openrouter",
+    model: "openrouter:anthropic/claude-sonnet-4.6",
+  },
+  {
+    provider: "openai",
+    model: "openai:gpt-5.4-mini",
+  },
+];
+
+export const DEFAULT_CLI_MODEL = MODEL_PROVIDER_INFERENCE[0].model;
+
+function lookupProviderEnvVar(entry: ProviderInferenceEntry): string | undefined {
   if (entry.customEnvVar) {
     return entry.customEnvVar() ?? undefined;
   }
   const envVars = findEnvKeys(entry.provider);
   return envVars && envVars.length > 0 ? envVars[0] : undefined;
-}
-
-export function inferDefaultModelName(): string | undefined {
-  return findInferredProviderEntry()?.entry.model;
-}
-
-export function resolveCliModelName(modelName: string | undefined): string {
-  return resolveCliModel(modelName).modelName;
-}
-
-export function resolveCliMemoryModelName(
-  memoryModelName: string | undefined,
-  dotenvKeys: Set<string> = new Set(),
-): string {
-  return resolveCliMemoryModel(memoryModelName, dotenvKeys).modelName;
 }
 
 /**
@@ -104,55 +98,44 @@ export function resolveCliMemoryModelName(
  */
 export function resolveCliMemoryModel(
   memoryModelName: string | undefined,
-  dotenvKeys: Set<string> = new Set(),
+  dotenvKeys: Set<string>,
 ): ModelResolution {
-  return resolveCliModelWith({
-    modelName: memoryModelName,
-    dotenvKeys,
-    selectInferredModel: (entry) => entry.memoryModel,
-    defaultModel: INFERRED_ANTHROPIC_MEMORY_MODEL,
-  });
+  return resolveCliModelWith(memoryModelName, MEMORY_MODEL_PROVIDER_INFERENCE, dotenvKeys);
 }
 
 /**
- * Same selection logic as resolveCliModelName, but also reports the provenance
- * so callers can show "inferred from ANTHROPIC_API_KEY in .env" etc.
+ * Resolve the user-visible model and report provenance so callers can show
+ * "inferred from ANTHROPIC_API_KEY in .env" etc.
  */
 export function resolveCliModel(
   modelName: string | undefined,
-  dotenvKeys: Set<string> = new Set(),
+  dotenvKeys: Set<string>,
 ): ModelResolution {
-  return resolveCliModelWith({
-    modelName,
-    dotenvKeys,
-    selectInferredModel: (entry) => entry.model,
-    defaultModel: DEFAULT_CLI_MODEL,
-  });
+  return resolveCliModelWith(modelName, MODEL_PROVIDER_INFERENCE, dotenvKeys);
 }
 
-function resolveCliModelWith(input: {
-  modelName: string | undefined;
-  dotenvKeys: Set<string>;
-  selectInferredModel: (entry: (typeof PROVIDER_INFERENCE)[number]) => string;
-  defaultModel: string;
-}): ModelResolution {
-  if (input.modelName) return { modelName: input.modelName, source: "explicit" };
-  const inferred = findInferredProviderEntry();
+function resolveCliModelWith(
+  modelName: string | undefined,
+  providerInference: ProviderInferenceEntry[],
+  dotenvKeys: Set<string>,
+): ModelResolution {
+  if (modelName) return { modelName, source: "explicit" };
+  const inferred = findInferredProviderEntry(providerInference);
   if (inferred) {
     return {
-      modelName: input.selectInferredModel(inferred.entry),
+      modelName: inferred.entry.model,
       source: "inferred",
       envVar: inferred.envVar,
-      fromDotenv: input.dotenvKeys.has(inferred.envVar),
+      fromDotenv: dotenvKeys.has(inferred.envVar),
     };
   }
-  return { modelName: input.defaultModel, source: "default" };
+  return { modelName: providerInference[0].model, source: "default" };
 }
 
-function findInferredProviderEntry():
-  | { entry: (typeof PROVIDER_INFERENCE)[number]; envVar: string }
-  | undefined {
-  for (const entry of PROVIDER_INFERENCE) {
+function findInferredProviderEntry(
+  providerInference: ProviderInferenceEntry[],
+): { entry: ProviderInferenceEntry; envVar: string } | undefined {
+  for (const entry of providerInference) {
     const envVar = lookupProviderEnvVar(entry);
     if (envVar) return { entry, envVar };
   }

--- a/src/model-resolution/index.ts
+++ b/src/model-resolution/index.ts
@@ -61,20 +61,20 @@ const MODEL_PROVIDER_INFERENCE: ProviderInferenceEntry[] = [
 const MEMORY_MODEL_PROVIDER_INFERENCE: ProviderInferenceEntry[] = [
   {
     provider: "anthropic",
-    model: "anthropic:claude-sonnet-4-6",
+    model: "anthropic:claude-haiku-4-5",
   },
   {
     provider: "duet-gateway",
-    model: "duet-gateway:anthropic/claude-sonnet-4.6",
+    model: "duet-gateway:anthropic/claude-haiku-4.5",
     customEnvVar: () => (process.env[DUET_GATEWAY_API_KEY_ENV] ? DUET_GATEWAY_API_KEY_ENV : null),
   },
   {
     provider: "vercel-ai-gateway",
-    model: "vercel-ai-gateway:anthropic/claude-sonnet-4.6",
+    model: "vercel-ai-gateway:anthropic/claude-haiku-4.5",
   },
   {
     provider: "openrouter",
-    model: "openrouter:anthropic/claude-sonnet-4.6",
+    model: "openrouter:anthropic/claude-haiku-4.5",
   },
   {
     provider: "openai",

--- a/src/model-resolution/index.ts
+++ b/src/model-resolution/index.ts
@@ -14,6 +14,11 @@ const INFERRED_AI_GATEWAY_MODEL = "vercel-ai-gateway:anthropic/claude-opus-4.7";
 const INFERRED_DUET_GATEWAY_MODEL = "duet-gateway:anthropic/claude-opus-4.7";
 const INFERRED_OPENROUTER_MODEL = "openrouter:anthropic/claude-opus-4.7";
 const INFERRED_OPENAI_MODEL = "openai:gpt-5.5";
+const INFERRED_ANTHROPIC_MEMORY_MODEL = "anthropic:claude-sonnet-4-6";
+const INFERRED_AI_GATEWAY_MEMORY_MODEL = "vercel-ai-gateway:anthropic/claude-sonnet-4.6";
+const INFERRED_DUET_GATEWAY_MEMORY_MODEL = "duet-gateway:anthropic/claude-sonnet-4.6";
+const INFERRED_OPENROUTER_MEMORY_MODEL = "openrouter:anthropic/claude-sonnet-4.6";
+const INFERRED_OPENAI_MEMORY_MODEL = "openai:gpt-5.4-mini";
 
 export const DEFAULT_CLI_MODEL = INFERRED_ANTHROPIC_MODEL;
 
@@ -39,17 +44,35 @@ export interface ModelResolution {
 const PROVIDER_INFERENCE: Array<{
   provider: string;
   model: string;
+  memoryModel: string;
   customEnvVar?: () => string | null;
 }> = [
-  { provider: "anthropic", model: INFERRED_ANTHROPIC_MODEL },
+  {
+    provider: "anthropic",
+    model: INFERRED_ANTHROPIC_MODEL,
+    memoryModel: INFERRED_ANTHROPIC_MEMORY_MODEL,
+  },
   {
     provider: "duet-gateway",
     model: INFERRED_DUET_GATEWAY_MODEL,
+    memoryModel: INFERRED_DUET_GATEWAY_MEMORY_MODEL,
     customEnvVar: () => (process.env[DUET_GATEWAY_API_KEY_ENV] ? DUET_GATEWAY_API_KEY_ENV : null),
   },
-  { provider: "vercel-ai-gateway", model: INFERRED_AI_GATEWAY_MODEL },
-  { provider: "openrouter", model: INFERRED_OPENROUTER_MODEL },
-  { provider: "openai", model: INFERRED_OPENAI_MODEL },
+  {
+    provider: "vercel-ai-gateway",
+    model: INFERRED_AI_GATEWAY_MODEL,
+    memoryModel: INFERRED_AI_GATEWAY_MEMORY_MODEL,
+  },
+  {
+    provider: "openrouter",
+    model: INFERRED_OPENROUTER_MODEL,
+    memoryModel: INFERRED_OPENROUTER_MEMORY_MODEL,
+  },
+  {
+    provider: "openai",
+    model: INFERRED_OPENAI_MODEL,
+    memoryModel: INFERRED_OPENAI_MEMORY_MODEL,
+  },
 ];
 
 function lookupProviderEnvVar(entry: (typeof PROVIDER_INFERENCE)[number]): string | undefined {
@@ -61,14 +84,34 @@ function lookupProviderEnvVar(entry: (typeof PROVIDER_INFERENCE)[number]): strin
 }
 
 export function inferDefaultModelName(): string | undefined {
-  for (const entry of PROVIDER_INFERENCE) {
-    if (lookupProviderEnvVar(entry)) return entry.model;
-  }
-  return undefined;
+  return findInferredProviderEntry()?.entry.model;
 }
 
 export function resolveCliModelName(modelName: string | undefined): string {
   return resolveCliModel(modelName).modelName;
+}
+
+export function resolveCliMemoryModelName(
+  memoryModelName: string | undefined,
+  dotenvKeys: Set<string> = new Set(),
+): string {
+  return resolveCliMemoryModel(memoryModelName, dotenvKeys).modelName;
+}
+
+/**
+ * Same selection logic as resolveCliModel, but picks each provider's cheaper
+ * observational-memory model.
+ */
+export function resolveCliMemoryModel(
+  memoryModelName: string | undefined,
+  dotenvKeys: Set<string> = new Set(),
+): ModelResolution {
+  return resolveCliModelWith({
+    modelName: memoryModelName,
+    dotenvKeys,
+    selectInferredModel: (entry) => entry.memoryModel,
+    defaultModel: INFERRED_ANTHROPIC_MEMORY_MODEL,
+  });
 }
 
 /**
@@ -79,19 +122,41 @@ export function resolveCliModel(
   modelName: string | undefined,
   dotenvKeys: Set<string> = new Set(),
 ): ModelResolution {
-  if (modelName) return { modelName, source: "explicit" };
+  return resolveCliModelWith({
+    modelName,
+    dotenvKeys,
+    selectInferredModel: (entry) => entry.model,
+    defaultModel: DEFAULT_CLI_MODEL,
+  });
+}
+
+function resolveCliModelWith(input: {
+  modelName: string | undefined;
+  dotenvKeys: Set<string>;
+  selectInferredModel: (entry: (typeof PROVIDER_INFERENCE)[number]) => string;
+  defaultModel: string;
+}): ModelResolution {
+  if (input.modelName) return { modelName: input.modelName, source: "explicit" };
+  const inferred = findInferredProviderEntry();
+  if (inferred) {
+    return {
+      modelName: input.selectInferredModel(inferred.entry),
+      source: "inferred",
+      envVar: inferred.envVar,
+      fromDotenv: input.dotenvKeys.has(inferred.envVar),
+    };
+  }
+  return { modelName: input.defaultModel, source: "default" };
+}
+
+function findInferredProviderEntry():
+  | { entry: (typeof PROVIDER_INFERENCE)[number]; envVar: string }
+  | undefined {
   for (const entry of PROVIDER_INFERENCE) {
     const envVar = lookupProviderEnvVar(entry);
-    if (envVar) {
-      return {
-        modelName: entry.model,
-        source: "inferred",
-        envVar,
-        fromDotenv: dotenvKeys.has(envVar),
-      };
-    }
+    if (envVar) return { entry, envVar };
   }
-  return { modelName: DEFAULT_CLI_MODEL, source: "default" };
+  return undefined;
 }
 
 export function describeModelResolution(resolution: ModelResolution): string {

--- a/src/model-resolution/index.ts
+++ b/src/model-resolution/index.ts
@@ -11,7 +11,7 @@ import { DUET_GATEWAY_API_KEY_ENV } from "../duet-gateway/index.js";
 
 export interface ModelResolution {
   modelName: string;
-  /** explicit: --model flag; inferred: provider env var present; default: built-in fallback. */
+  /** explicit: CLI flag; inferred: provider env var present; default: built-in fallback. */
   source: "explicit" | "inferred" | "default";
   /** Provider env var that triggered inference, e.g. "ANTHROPIC_API_KEY". */
   envVar?: string;
@@ -143,7 +143,7 @@ function findInferredProviderEntry(
 }
 
 export function describeModelResolution(resolution: ModelResolution): string {
-  if (resolution.source === "explicit") return "--model flag";
+  if (resolution.source === "explicit") return "explicit CLI flag";
   if (resolution.source === "inferred") {
     const where = resolution.fromDotenv ? "<workdir>/.env" : "shell environment";
     return `inferred from ${resolution.envVar} in ${where}`;

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -3,16 +3,26 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { nanoid } from "nanoid";
 import type { TurnRunnerConfig } from "../types/config.js";
-import type { TurnEvent } from "../types/protocol.js";
-import { Session, type SessionStartInput, type SessionTurnRunner } from "./session.js";
+import type { TurnEvent, TurnMode, TurnOptions } from "../types/protocol.js";
+import { Session, type SessionTurnRunner } from "./session.js";
 
 export const DEFAULT_DUET_DIR = ".duet";
 export const DEFAULT_DUET_HOME = join(homedir(), DEFAULT_DUET_DIR);
 export const DEFAULT_SESSION_STORAGE_DIR = join(DEFAULT_DUET_HOME, "sessions");
 export const DEFAULT_MEMORY_DB_PATH = join(DEFAULT_DUET_HOME, "memory.db");
 
-export interface SessionManagerCreateInput extends Partial<SessionStartInput> {
+export interface SessionManagerCreateInput {
+  /** Optional fixed id; the manager generates one when omitted. */
   sessionId?: string;
+  /** Routing mode for the new session. */
+  mode?: TurnMode;
+  /**
+   * When provided, the manager dispatches this prompt as the first turn after
+   * setup completes. Omit to leave the session idle until the caller sends a
+   * prompt directly.
+   */
+  prompt?: string;
+  options?: TurnOptions;
 }
 
 export interface SessionManagerOptions {
@@ -51,8 +61,18 @@ export class SessionManager {
   create(input: SessionManagerCreateInput): Session {
     const session = this.createSession(input.sessionId, false);
     this.sessions.set(session.id, session);
+    const setup = session.start({
+      ...(input.mode ? { mode: input.mode } : {}),
+      ...(input.options ? { options: input.options } : {}),
+    });
     if (input.prompt) {
-      void session.start({ prompt: input.prompt, mode: input.mode, options: input.options });
+      const prompt = input.prompt;
+      void setup.then(() =>
+        session.prompt({
+          message: prompt,
+          ...(input.options ? { options: input.options } : {}),
+        }),
+      );
     }
     return session;
   }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -80,7 +80,7 @@ export class Session {
   private state?: TurnState;
   /** In-flight runner turn, used to distinguish active work from a reusable terminal result. */
   private activeTurn?: Promise<void>;
-  /** In-flight runner setup, awaited before any turn dispatches so ready/session_started land first. */
+  /** In-flight runner setup, awaited before any turn dispatches so turn_started lands first. */
   private startPromise?: Promise<void>;
   /** Tracks whether `start()` has already issued setup so repeat calls stay idempotent. */
   private hasStarted = false;
@@ -116,8 +116,8 @@ export class Session {
 
   /**
    * Initialize the session before any turn runs. Calls the runner's setup
-   * step once so the caller (CLI/TUI) sees the `ready` event with skills and
-   * agent files immediately on launch, before the user types a prompt.
+   * step once so the caller can render skills and agent files immediately on
+   * launch, before the user types a prompt.
    *
    * Repeat calls are no-ops; resumed sessions reuse the persisted state.
    */
@@ -136,7 +136,7 @@ export class Session {
       ...(this.state ? { state: this.state } : {}),
       ...(input.options ? { options: input.options } : {}),
     };
-    // The runner emits `session_started` synchronously while `start` runs;
+    // The runner emits `turn_started` synchronously while `start` runs;
     // `handleTurnEvent` captures that state, so we only need to await setup.
     this.startPromise = this.runner.start(command).then(() => undefined);
     await this.startPromise;
@@ -276,7 +276,7 @@ export class Session {
       for (const resolve of this.terminalWaiters.splice(0)) {
         resolve(emitted);
       }
-    } else if (event.type === "session_started") {
+    } else if (event.type === "turn_started") {
       this.state = event.state;
     }
     this.emit(emitted);

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -150,7 +150,6 @@ export class Session {
     this.restoreSleepAfterTurn = wasSleeping && this.isWaitingOnPoll(state);
     const command: TurnCommand = {
       type: "prompt",
-      state,
       message: input.message,
       behavior: input.behavior ?? "follow_up",
       ...(input.options ? { options: input.options } : {}),
@@ -166,7 +165,6 @@ export class Session {
     this.restoreSleepAfterTurn = wasSleeping && this.isWaitingOnPoll(state);
     const command: TurnAnswerCommand = {
       type: "answer",
-      state,
       questions: input.questions,
       answers: input.answers,
       behavior: input.behavior ?? "follow_up",
@@ -177,9 +175,8 @@ export class Session {
 
   async interrupt(): Promise<void> {
     await this.ensureStarted();
-    const state = await this.requireState();
     this.cancelWake();
-    this.runner.interrupt({ type: "interrupt", state });
+    this.runner.interrupt({ type: "interrupt" });
   }
 
   private async ensureStarted(): Promise<void> {
@@ -322,7 +319,7 @@ export class Session {
       () => {
         this.wakeTimer = undefined;
         if (!this.state || this.state.status !== "sleeping") return;
-        this.dispatchTurn({ type: "wake", state: this.state });
+        this.dispatchTurn({ type: "wake" });
       },
       Math.max(0, terminal.wakeAt - Date.now()),
     );

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -2,7 +2,10 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { TurnRunner, type TurnEventHandler } from "../turn-runner/turn-runner.js";
 import type { TurnRunnerConfig } from "../types/config.js";
+import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { SkillCollision } from "../turn-runner/skills.js";
 import type {
+  TurnAgentFile,
   TurnAnswerCommand,
   TurnEditFollowUpQueueCommand,
   TurnEvent,
@@ -10,6 +13,7 @@ import type {
   TurnMode,
   TurnPromptBehavior,
   TurnQuestion,
+  TurnStartCommand,
   TurnState,
   TurnTerminalEvent,
   TurnCommand,
@@ -18,7 +22,7 @@ import type {
 import type { StateMachinePollState } from "../types/state-machine.js";
 
 export interface SessionStartInput {
-  prompt: string;
+  /** Routing mode for subsequent prompts. Omit to use the session's configured default. */
   mode?: TurnMode;
   options?: TurnOptions;
 }
@@ -43,10 +47,14 @@ export interface SessionEditFollowUpQueueInput {
 export type SessionEventHandler = (event: TurnEvent) => void;
 
 export interface SessionTurnRunner {
+  start(command: TurnStartCommand): Promise<TurnState>;
   turn(command: TurnCommand): Promise<TurnTerminalEvent>;
   interrupt(command: TurnInterruptCommand): void;
   editFollowUpQueue(command: TurnEditFollowUpQueueCommand): void;
   subscribe(handler: TurnEventHandler): () => void;
+  getSkills(): Promise<readonly Skill[]>;
+  getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]>;
+  getSkillCollisions(): Promise<readonly SkillCollision[]>;
   dispose(): Promise<void>;
 }
 
@@ -72,6 +80,10 @@ export class Session {
   private state?: TurnState;
   /** In-flight runner turn, used to distinguish active work from a reusable terminal result. */
   private activeTurn?: Promise<void>;
+  /** In-flight runner setup, awaited before any turn dispatches so ready/session_started land first. */
+  private startPromise?: Promise<void>;
+  /** Tracks whether `start()` has already issued setup so repeat calls stay idempotent. */
+  private hasStarted = false;
   /** Most recent terminal event, returned immediately when callers wait after a turn has settled. */
   private lastTerminal?: TurnTerminalEvent;
   /** Scheduled wake for sleeping poll states; cancelled when user input or interrupt arrives. */
@@ -102,28 +114,36 @@ export class Session {
     };
   }
 
-  async start(input: SessionStartInput): Promise<void> {
+  /**
+   * Initialize the session before any turn runs. Calls the runner's setup
+   * step once so the caller (CLI/TUI) sees the `ready` event with skills and
+   * agent files immediately on launch, before the user types a prompt.
+   *
+   * Repeat calls are no-ops; resumed sessions reuse the persisted state.
+   */
+  async start(input: SessionStartInput = {}): Promise<void> {
+    if (this.hasStarted) {
+      await this.startPromise;
+      return;
+    }
+    this.hasStarted = true;
     if (!this.state && this.resumeFromStorage) {
       this.state = await this.readStoredState();
     }
-    const command: TurnCommand = this.state
-      ? {
-          type: "prompt",
-          state: this.state,
-          message: input.prompt,
-          behavior: "follow_up",
-          ...(input.options ? { options: input.options } : {}),
-        }
-      : {
-          type: "start",
-          mode: input.mode ?? this.config.mode,
-          prompt: input.prompt,
-          ...(input.options ? { options: input.options } : {}),
-        };
-    this.dispatchTurn(command);
+    const command: TurnStartCommand = {
+      type: "start",
+      ...((input.mode ?? this.config.mode) ? { mode: input.mode ?? this.config.mode } : {}),
+      ...(this.state ? { state: this.state } : {}),
+      ...(input.options ? { options: input.options } : {}),
+    };
+    // The runner emits `session_started` synchronously while `start` runs;
+    // `handleTurnEvent` captures that state, so we only need to await setup.
+    this.startPromise = this.runner.start(command).then(() => undefined);
+    await this.startPromise;
   }
 
   async prompt(input: SessionPromptInput): Promise<void> {
+    await this.ensureStarted();
     const state = await this.requireState();
     this.cancelWake();
     const wasSleeping = state.status === "sleeping";
@@ -139,6 +159,7 @@ export class Session {
   }
 
   async answer(input: SessionAnswerInput): Promise<void> {
+    await this.ensureStarted();
     const state = await this.requireState();
     this.cancelWake();
     const wasSleeping = state.status === "sleeping";
@@ -155,9 +176,18 @@ export class Session {
   }
 
   async interrupt(): Promise<void> {
+    await this.ensureStarted();
     const state = await this.requireState();
     this.cancelWake();
     this.runner.interrupt({ type: "interrupt", state });
+  }
+
+  private async ensureStarted(): Promise<void> {
+    if (!this.hasStarted) {
+      await this.start();
+      return;
+    }
+    await this.startPromise;
   }
 
   editFollowUpQueue(input: SessionEditFollowUpQueueInput): void {
@@ -183,6 +213,24 @@ export class Session {
   /** Latest known turn state snapshot, including agent message history. */
   getState(): TurnState | undefined {
     return this.state;
+  }
+
+  /**
+   * Skills discovered for this session. Available after `start()` resolves;
+   * loading happens lazily on first call otherwise.
+   */
+  getSkills(): Promise<readonly Skill[]> {
+    return this.runner.getSkills();
+  }
+
+  /** System-prompt files (AGENTS.md by default) that resolved on disk. */
+  getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]> {
+    return this.runner.getResolvedAgentFiles();
+  }
+
+  /** Skill name collisions where one definition shadowed another during discovery. */
+  getSkillCollisions(): Promise<readonly SkillCollision[]> {
+    return this.runner.getSkillCollisions();
   }
 
   /** Force-load persisted state for resumed sessions before any command runs. */

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -10,12 +10,10 @@ import {
 } from "@opentui/core";
 import { formatCompactJson } from "../lib/compact-json.js";
 import type { Session } from "../session/session.js";
-import type { TurnRunnerConfig } from "../types/config.js";
+import type { SkillCollision } from "../turn-runner/skills.js";
 import type {
+  TurnAgentFile,
   TurnEvent,
-  TurnReadyAgentFile,
-  TurnReadySkillCollision,
-  TurnReadySkillInfo,
   TurnStep,
   TurnTerminalEvent,
   TurnTodo,
@@ -24,13 +22,15 @@ import type {
 
 export interface RunTuiInput {
   session: Session;
-  started: boolean;
   initialPrompt?: string;
-  mode: TurnRunnerConfig["mode"];
   /** Fully resolved provider:modelId string used for this CLI session. */
   modelName: string;
   /** Human-readable provenance for modelName, e.g. "inferred from ANTHROPIC_API_KEY in .env". */
   modelSource?: string;
+  /** Fully resolved provider:modelId string used for observational memory work. */
+  memoryModelName: string;
+  /** Human-readable provenance for memoryModelName. */
+  memoryModelSource?: string;
   /** Best-effort package update notice, shown in-TUI because stderr is hidden. */
   newVersionNotice?: string;
   /** Past messages to replay into the transcript on resume. */
@@ -195,7 +195,6 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   // ---- runtime state ---------------------------------------------------------
 
-  let started = input.started;
   let running = false;
   let lastTerminal: TurnTerminalEvent | undefined;
   let activeTextStream: StreamingBlock | undefined;
@@ -239,14 +238,8 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   // ---- session subscription --------------------------------------------------
 
-  let renderedReadyIntro = false;
   const unsubscribe = input.session.subscribe((event: TurnEvent) => {
-    if (event.type === "ready") {
-      if (!renderedReadyIntro) {
-        renderedReadyIntro = true;
-        renderReadyIntro(event.skills, event.agentFiles, event.skillCollisions);
-      }
-    } else if (event.type === "step") {
+    if (event.type === "step") {
       renderStep(event.step);
     } else if (event.type === "todos") {
       renderTodos(event.todos);
@@ -286,10 +279,10 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     }
   });
 
-  function renderReadyIntro(
-    skills: TurnReadySkillInfo[],
-    agentFiles: TurnReadyAgentFile[],
-    skillCollisions: TurnReadySkillCollision[],
+  function renderSetupIntro(
+    skills: ReadonlyArray<{ name: string }>,
+    agentFiles: readonly TurnAgentFile[],
+    skillCollisions: readonly SkillCollision[],
   ): void {
     if (agentFiles.length === 0) {
       appendLine("[agent file] none", COLORS.hint);
@@ -520,13 +513,9 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
       return;
     }
 
-    // Idle: just start (or follow up) a fresh turn.
-    if (!started) {
-      void input.session.start({ prompt: message, mode: input.mode }).catch(reportError);
-      started = true;
-    } else {
-      void input.session.prompt({ message, behavior: "follow_up" }).catch(reportError);
-    }
+    // Idle: dispatch a prompt against the already-set-up session. Setup
+    // happens before the TUI starts so skills are visible right away.
+    void input.session.prompt({ message, behavior: "follow_up" }).catch(reportError);
     markRunning();
   }
 
@@ -539,6 +528,19 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     ? `[model] ${input.modelName} — ${input.modelSource}`
     : `[model] ${input.modelName}`;
   appendLine(modelLine, COLORS.hint);
+  const memoryModelLine = input.memoryModelSource
+    ? `[memory model] ${input.memoryModelName} — ${input.memoryModelSource}`
+    : `[memory model] ${input.memoryModelName}`;
+  appendLine(memoryModelLine, COLORS.hint);
+
+  // Setup already ran before the TUI launched, so we can read the resolved
+  // skills/agent-files synchronously through the session getters.
+  const [skills, agentFiles, skillCollisions] = await Promise.all([
+    input.session.getSkills(),
+    input.session.getResolvedAgentFiles(),
+    input.session.getSkillCollisions(),
+  ]);
+  renderSetupIntro(skills, agentFiles, skillCollisions);
 
   if (input.history && input.history.length > 0) {
     for (const message of input.history) {
@@ -551,21 +553,13 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   if (input.initialPrompt) {
     appendBlock("you:", input.initialPrompt, COLORS.user);
-    if (!started) {
-      void input.session
-        .start({ prompt: input.initialPrompt, mode: input.mode })
-        .catch(reportError);
-      started = true;
-    } else {
-      void input.session
-        .prompt({ message: input.initialPrompt, behavior: "follow_up" })
-        .catch(reportError);
-    }
+    void input.session
+      .prompt({ message: input.initialPrompt, behavior: "follow_up" })
+      .catch(reportError);
     markRunning();
-  } else if (input.started) {
-    // Resumed session — assume nothing currently running until we see events.
-    markIdle();
   } else {
+    // No initial prompt — wait for the user. Setup already ran above, so
+    // the skill summary is rendered before the user types.
     markIdle();
   }
 

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -49,9 +49,8 @@ const COLORS = {
   border: "#374151",
 } as const;
 
-const HINT_IDLE = "Enter: send · Esc: quit · Ctrl+C: force quit";
-const HINT_RUNNING =
-  "Enter: steer · Shift+Enter: queue follow-up · Esc: interrupt · Ctrl+C: force quit";
+const HINT_IDLE = "Enter: send · Esc/Ctrl+C: quit";
+const HINT_RUNNING = "Enter: steer · Shift+Enter: queue follow-up · Esc/Ctrl+C: interrupt";
 
 /**
  * Runs the interactive TUI for a session. Resolves with the most recent
@@ -64,7 +63,7 @@ const HINT_RUNNING =
 export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | undefined> {
   const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
   const renderer = await createCliRenderer({
-    exitOnCtrlC: true,
+    exitOnCtrlC: false,
     useKittyKeyboard: {},
     targetFps: 60,
   });
@@ -473,9 +472,21 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
   // capture the modifier here and read it during the ENTER event below.
   let lastEnterShift = false;
 
-  const handleEsc = () => {
+  let closingAfterInterrupt = false;
+
+  const requestExit = async (): Promise<void> => {
     if (running) {
-      void input.session.interrupt().catch(reportError);
+      if (closingAfterInterrupt) return;
+      closingAfterInterrupt = true;
+      setStatus("● interrupting…");
+      try {
+        await input.session.interrupt();
+        await input.session.waitForTerminal();
+      } catch (error) {
+        reportError(error);
+      } finally {
+        renderer.stop();
+      }
     } else {
       renderer.stop();
     }
@@ -498,7 +509,11 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
       return;
     }
     if (key.name === "escape") {
-      handleEsc();
+      void requestExit();
+      return;
+    }
+    if (key.name === "c" && key.ctrl) {
+      void requestExit();
     }
   };
 

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -221,7 +221,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
   function markRunning(): void {
     running = true;
     setHint(true);
-    setStatus("● working… (Esc to interrupt)");
+    setStatus("● working… (Esc/Ctrl+C to interrupt)");
   }
 
   function markIdle(): void {
@@ -326,7 +326,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   function renderFollowUpQueue(prompts: string[]): void {
     if (prompts.length === 0) {
-      setStatus(running ? "● working… (Esc to interrupt)" : "");
+      setStatus(running ? "● working… (Esc/Ctrl+C to interrupt)" : "");
       return;
     }
     setStatus(`queued follow-ups: ${prompts.length}`);
@@ -457,11 +457,11 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   function renderMemoryStatus(event: Extract<TurnEvent, { type: "memory" }>): void {
     if (event.status === "running") {
-      setStatus(`● ${event.message} (Esc to interrupt)`);
+      setStatus(`● ${event.message} (Esc/Ctrl+C to interrupt)`);
       return;
     }
     if (running) {
-      setStatus("● working… (Esc to interrupt)");
+      setStatus("● working… (Esc/Ctrl+C to interrupt)");
     }
   }
 
@@ -583,8 +583,6 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
   await new Promise<void>((resolve) => {
     const onDestroy = () => resolve();
     renderer.once("destroy", onDestroy);
-    // Fallback — if the renderer is stopped without emitting destroy, settle on
-    // process exit signals which createCliRenderer already wires up.
   });
 
   unsubscribe();

--- a/src/turn-runner/skill-context.ts
+++ b/src/turn-runner/skill-context.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { toXML } from "../lib/xml.js";
 import type { TurnRunnerConfig } from "../types/config.js";
+import type { TurnAgentFile } from "../types/protocol.js";
 import type { StateMachineAgentState } from "../types/state-machine.js";
 import { createSystemPromptWithAppendedLayers } from "./prompts.js";
 import {
@@ -98,10 +99,10 @@ export class SkillContext {
   }
 
   /** System-prompt files (AGENTS.md by default) that exist on disk. */
-  getResolvedAgentFiles(): Array<{ name: string; path: string }> {
+  getResolvedAgentFiles(): TurnAgentFile[] {
     const cwd = this.config.cwd ?? process.cwd();
     const fileNames = this.config.systemPromptFiles ?? ["AGENTS.md"];
-    const resolved: Array<{ name: string; path: string }> = [];
+    const resolved: TurnAgentFile[] = [];
     for (const fileName of fileNames) {
       const path = join(cwd, fileName);
       if (existsSync(path)) {

--- a/src/turn-runner/state-machine-runtime.ts
+++ b/src/turn-runner/state-machine-runtime.ts
@@ -70,6 +70,7 @@ interface StateMachineRuntimeDeps {
   hasQueuedTurnCommands(): boolean;
   isDrainingQueuedCommandsBeforeContinuation(): boolean;
   setDrainingQueuedCommandsBeforeContinuation(value: boolean): void;
+  setCurrentState(state: TurnState): void;
   consumeInterruptedTerminal(): TurnTerminalEvent | undefined;
   setActiveAbortController(controller: AbortController | undefined): void;
   setActiveStateWork(work: ActiveStateWork | undefined): void;
@@ -364,10 +365,10 @@ export class StateMachineRuntime {
     prompt: string,
   ): void {
     if (work.promptTerminal) return;
+    this.deps.setCurrentState({ ...work.session, status: "running" });
     work.promptTerminal = this.deps
       .prompt({
         type: "prompt",
-        state: { ...work.session, status: "running" },
         message: prompt,
         behavior: command.behavior,
         options: command.options,

--- a/src/turn-runner/state-machine-runtime.ts
+++ b/src/turn-runner/state-machine-runtime.ts
@@ -432,7 +432,7 @@ export class StateMachineRuntime {
           terminal,
           history: [
             ...session.stateMachine.history,
-            { type: "session_completed" as const, timestamp: Date.now(), terminal },
+            { type: "state_machine_completed" as const, timestamp: Date.now(), terminal },
           ],
         }
       : undefined;
@@ -552,7 +552,7 @@ export class StateMachineRuntime {
         definition,
         prompt,
         currentState,
-        history: [{ type: "session_started", timestamp: now }],
+        history: [{ type: "state_machine_started", timestamp: now }],
         createdAt: now,
         updatedAt: now,
       },
@@ -688,7 +688,7 @@ export class StateMachineRuntime {
         terminal,
         history: [
           ...stateMachine.history,
-          { type: "session_completed" as const, timestamp: Date.now(), terminal },
+          { type: "state_machine_completed" as const, timestamp: Date.now(), terminal },
         ],
         updatedAt: Date.now(),
       },

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -1,6 +1,7 @@
 import { Agent, type AgentEvent, type AgentTool } from "@mariozechner/pi-agent-core";
 import { getEnvApiKey, getModel, type Model, type Usage } from "@mariozechner/pi-ai";
 import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { SkillCollision } from "./skills.js";
 import dedent from "dedent";
 
 import { isDuetGatewayModelName, resolveDuetGatewayModel } from "../duet-gateway/index.js";
@@ -10,6 +11,7 @@ import { loadStoredMemory } from "../memory/storage.js";
 import { MemoryStore } from "../memory/store.js";
 import type { TurnRunnerConfig } from "../types/config.js";
 import type {
+  TurnAgentFile,
   TurnAnswerCommand,
   TurnEditFollowUpQueueCommand,
   TurnEvent,
@@ -18,8 +20,8 @@ import type {
   TurnPromptCommand,
   TurnState,
   TurnTokenUsage,
-  TurnStartCommand,
   TurnRunnerTerminalStatus,
+  TurnStartCommand,
   TurnTerminalEvent,
   TurnCommand,
   TurnOptions,
@@ -42,7 +44,6 @@ import {
   type AgentWorkerResult,
 } from "./agent-worker.js";
 import { SkillContext } from "./skill-context.js";
-import { resolveSkillScope } from "./skills.js";
 import { StateMachineRuntime, type ActiveStateWork } from "./state-machine-runtime.js";
 import { addUsage } from "./usage-accounting.js";
 
@@ -146,13 +147,29 @@ export class TurnRunner {
     this.replaceFollowUpQueue(command.prompts);
   }
 
+  /**
+   * Set up a session before any turn runs. Loads memory and skills, emits
+   * `ready` with the resolved skill/agent-file context, and emits
+   * `session_started` with an initial empty `TurnState`. No agent work runs.
+   *
+   * Callers (CLI/TUI/session managers) call this once on launch so the user
+   * sees available skills before typing the first prompt. The returned state
+   * is the same one delivered via `session_started` and should be threaded
+   * into the first `prompt` command.
+   */
+  async start(command: TurnStartCommand): Promise<TurnState> {
+    await this.ensureMemoryLoaded();
+    await this.ensureSkillsLoaded();
+    const mode = command.mode ?? this.config.mode ?? "auto";
+    const state = command.state ?? this.stateMachineRuntime.createInitialState(mode);
+    this.emit({ type: "session_started", state });
+    return state;
+  }
+
   async turn(command: TurnCommand): Promise<TurnTerminalEvent> {
     await this.ensureMemoryLoaded();
     await this.ensureSkillsLoaded();
     if (this.activeTurnPromise) {
-      if (command.type === "start") {
-        throw new Error("Cannot start a new turn while another turn is active.");
-      }
       // turn() is the concurrency boundary: repeated calls extend or queue
       // behind the active chain instead of creating a separate parent transcript.
       this.handleCommandDuringActiveTurn(command);
@@ -173,7 +190,6 @@ export class TurnRunner {
   private async runTurnChain(command: TurnCommand): Promise<TurnTerminalEvent> {
     this.turnUsage = undefined;
     try {
-      this.emit(this.buildReadyEvent());
       let terminal: TurnTerminalEvent;
       terminal = await this.executeTurnCommand(command);
       terminal = await this.drainQueuedTurnCommands(terminal);
@@ -192,8 +208,6 @@ export class TurnRunner {
 
   private async executeTurnCommand(command: TurnCommand): Promise<TurnTerminalEvent> {
     switch (command.type) {
-      case "start":
-        return this.start(command);
       case "prompt":
         return this.prompt(command);
       case "answer":
@@ -259,14 +273,6 @@ export class TurnRunner {
 
   private rebaseQueuedCommand(command: TurnCommand, state: TurnState): TurnCommand {
     switch (command.type) {
-      case "start":
-        return {
-          type: "prompt",
-          state,
-          message: command.prompt,
-          behavior: "follow_up",
-          options: command.options,
-        };
       case "prompt":
         return { ...command, state };
       case "answer":
@@ -421,43 +427,10 @@ export class TurnRunner {
     }
   }
 
-  private buildReadyEvent(): TurnEvent {
-    const cwd = this.config.cwd ?? process.cwd();
-    return {
-      type: "ready",
-      skills: this.skillContext.getSkills().map((skill) => ({
-        name: skill.name,
-        description: skill.description,
-        path: skill.baseDir,
-        scope: resolveSkillScope(skill, cwd),
-      })),
-      agentFiles: this.skillContext.getResolvedAgentFiles(),
-      skillCollisions: [...this.skillContext.getSkillCollisions()],
-    };
-  }
-
   private consumeInterruptedTerminal(): TurnTerminalEvent | undefined {
     const terminal = this.interruptedTerminal;
     this.interruptedTerminal = undefined;
     return terminal;
-  }
-
-  protected async start(command: TurnStartCommand): Promise<TurnTerminalEvent> {
-    const mode = command.mode ?? this.config.mode ?? "auto";
-    const state = this.stateMachineRuntime.createInitialState(mode);
-    const prompt = this.skillContext.resolveSlashSkillPrompt(command.prompt);
-    this.emit({ type: "session_started", state });
-
-    if (mode === "agent") {
-      return this.runAgentMode(state, prompt, command.options);
-    }
-
-    return this.runTurnRunnerAgentWithStateMachineTools({
-      state,
-      prompt,
-      mode,
-      options: command.options,
-    });
   }
 
   protected async prompt(command: TurnPromptCommand): Promise<TurnTerminalEvent> {
@@ -727,6 +700,18 @@ export class TurnRunner {
   async getSkills(): Promise<readonly Skill[]> {
     await this.ensureSkillsLoaded();
     return this.skillContext.getSkills();
+  }
+
+  /** System-prompt files (AGENTS.md by default) that resolved on disk for this session. */
+  async getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]> {
+    await this.ensureSkillsLoaded();
+    return this.skillContext.getResolvedAgentFiles();
+  }
+
+  /** Skill name collisions where one definition shadowed another during discovery. */
+  async getSkillCollisions(): Promise<readonly SkillCollision[]> {
+    await this.ensureSkillsLoaded();
+    return this.skillContext.getSkillCollisions();
   }
 
   getSkillInstructions(skillId: string): string {

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -26,7 +26,6 @@ import type {
   TurnCommand,
   TurnOptions,
   TurnTodo,
-  TurnWakeCommand,
 } from "../types/protocol.js";
 import { createStateMachineSystemPromptLayer } from "./prompts.js";
 import {
@@ -85,6 +84,8 @@ export class TurnRunner {
   private activeTurnPromise?: Promise<TurnTerminalEvent>;
   /** Commands that could not be absorbed into the active pi agent and must run later. */
   private readonly queuedTurnCommands: TurnCommand[] = [];
+  /** Latest runner-owned state, hydrated by start() and advanced by terminal events. */
+  private state?: TurnState;
   /** User-visible mirror of follow-up prompts accepted by this runner. */
   private followUpQueuePrompts: string[] = [];
   /** Current todo list emitted through todo protocol events. */
@@ -116,6 +117,9 @@ export class TurnRunner {
         this.drainingQueuedCommandsBeforeContinuation,
       setDrainingQueuedCommandsBeforeContinuation: (value) => {
         this.drainingQueuedCommandsBeforeContinuation = value;
+      },
+      setCurrentState: (state) => {
+        this.state = state;
       },
       consumeInterruptedTerminal: () => this.consumeInterruptedTerminal(),
       setActiveAbortController: (controller) => {
@@ -153,15 +157,14 @@ export class TurnRunner {
    * `session_started` with an initial empty `TurnState`. No agent work runs.
    *
    * Callers (CLI/TUI/session managers) call this once on launch so the user
-   * sees available skills before typing the first prompt. The returned state
-   * is the same one delivered via `session_started` and should be threaded
-   * into the first `prompt` command.
+   * sees available skills before typing the first prompt.
    */
   async start(command: TurnStartCommand): Promise<TurnState> {
     await this.ensureMemoryLoaded();
     await this.ensureSkillsLoaded();
     const mode = command.mode ?? this.config.mode ?? "auto";
     const state = command.state ?? this.stateMachineRuntime.createInitialState(mode);
+    this.state = state;
     this.emit({ type: "session_started", state });
     return state;
   }
@@ -194,6 +197,7 @@ export class TurnRunner {
       terminal = await this.executeTurnCommand(command);
       terminal = await this.drainQueuedTurnCommands(terminal);
       terminal = this.withTurnUsage(terminal);
+      this.state = terminal.state;
       this.emit(terminal);
       return terminal;
     } finally {
@@ -213,7 +217,7 @@ export class TurnRunner {
       case "answer":
         return this.answer(command);
       case "wake":
-        return this.wake(command);
+        return this.wake();
     }
   }
 
@@ -265,21 +269,10 @@ export class TurnRunner {
       }
       const queued = this.queuedTurnCommands.shift()!;
       this.removeQueuedFollowUpPrompt(queued);
-      const command = this.rebaseQueuedCommand(queued, latest.state);
-      latest = await this.executeTurnCommand(command);
+      this.state = latest.state;
+      latest = await this.executeTurnCommand(queued);
     }
     return latest;
-  }
-
-  private rebaseQueuedCommand(command: TurnCommand, state: TurnState): TurnCommand {
-    switch (command.type) {
-      case "prompt":
-        return { ...command, state };
-      case "answer":
-        return { ...command, state };
-      case "wake":
-        return { ...command, state };
-    }
   }
 
   private runPromptDuringActivePoll(
@@ -332,27 +325,23 @@ export class TurnRunner {
   }
 
   private replaceQueuedFollowUpCommands(prompts: string[]): void {
-    const replacementState = this.removeQueuedFollowUpCommands();
-    if (!replacementState || this.activeAgent) return;
+    this.removeQueuedFollowUpCommands();
+    if (!this.state || this.activeAgent) return;
     for (const prompt of prompts) {
       this.queuedTurnCommands.push({
         type: "prompt",
-        state: replacementState,
         message: prompt,
         behavior: "follow_up",
       });
     }
   }
 
-  private removeQueuedFollowUpCommands(): TurnState | undefined {
-    let replacementState: TurnState | undefined;
+  private removeQueuedFollowUpCommands(): void {
     for (let index = this.queuedTurnCommands.length - 1; index >= 0; index--) {
       const command = this.queuedTurnCommands[index]!;
       if (!this.isFollowUpQueueCommand(command)) continue;
-      replacementState = replacementState ?? command.state;
       this.queuedTurnCommands.splice(index, 1);
     }
-    return replacementState;
   }
 
   private isFollowUpQueueCommand(
@@ -390,9 +379,10 @@ export class TurnRunner {
     this.emit({ type: "follow_up_queue", prompts: [...this.followUpQueuePrompts] });
   }
 
-  interrupt(command: TurnInterruptCommand): void {
+  interrupt(_command: TurnInterruptCommand): void {
+    if (!this.state) return;
     const interruptedState = this.stateMachineRuntime.recordStateInterrupted(
-      command.state,
+      this.state,
       "Interrupted",
     );
     const terminal: TurnTerminalEvent = {
@@ -403,6 +393,7 @@ export class TurnRunner {
         agent: { ...interruptedState.agent, status: "cancelled" },
       },
     };
+    this.state = terminal.state;
     if (this.activeAgent || this.activeChildAgent || this.activeAbortController) {
       // The active turn emits this terminal event after agent.prompt() unwinds.
       // interrupt() only aborts out-of-band; it does not own turn completion.
@@ -434,7 +425,8 @@ export class TurnRunner {
   }
 
   protected async prompt(command: TurnPromptCommand): Promise<TurnTerminalEvent> {
-    const state: TurnState = { ...command.state, status: "running" };
+    const originalState = this.requireRunnerState();
+    const state: TurnState = { ...originalState, status: "running" };
     const prompt = this.skillContext.resolveSlashSkillPrompt(command.message);
     let terminal: TurnTerminalEvent;
     if (state.mode === "agent") {
@@ -448,7 +440,7 @@ export class TurnRunner {
       });
     }
 
-    return this.stateMachineRuntime.restoreSleepAfterPromptIfNeeded(command.state, terminal);
+    return this.stateMachineRuntime.restoreSleepAfterPromptIfNeeded(originalState, terminal);
   }
 
   protected async answer(command: TurnAnswerCommand): Promise<TurnTerminalEvent> {
@@ -458,14 +450,15 @@ export class TurnRunner {
       ${toXML([{ questions: command.questions }, { answers: command.answers }])}
     `;
 
-    const stateMachine = command.state.stateMachine;
+    const currentRunnerState = this.requireRunnerState();
+    const stateMachine = currentRunnerState.stateMachine;
     const currentState = stateMachine?.currentState
       ? this.stateMachineRuntime.findState(stateMachine, stateMachine.currentState)
       : undefined;
 
-    if (command.state.status === "waiting_for_human" && currentState?.kind === "agent") {
+    if (currentRunnerState.status === "waiting_for_human" && currentState?.kind === "agent") {
       const session = this.stateMachineRuntime.appendUserMessage(
-        { ...command.state, status: "running" },
+        { ...currentRunnerState, status: "running" },
         message,
       );
       return this.stateMachineRuntime.runAgentState(session, currentState);
@@ -473,30 +466,37 @@ export class TurnRunner {
 
     return this.prompt({
       type: "prompt",
-      state: command.state,
       message,
       behavior: command.behavior,
       options: command.options,
     });
   }
 
-  protected async wake(command: TurnWakeCommand): Promise<TurnTerminalEvent> {
-    const state: TurnState = { ...command.state, status: "running" };
+  protected async wake(): Promise<TurnTerminalEvent> {
+    const originalState = this.requireRunnerState();
+    const state: TurnState = { ...originalState, status: "running" };
     const stateMachine = state.stateMachine;
     const currentState = stateMachine?.currentState
       ? this.stateMachineRuntime.findState(stateMachine, stateMachine.currentState)
       : undefined;
 
-    if (command.state.status === "sleeping" && currentState?.kind === "poll") {
+    if (originalState.status === "sleeping" && currentState?.kind === "poll") {
       return this.stateMachineRuntime.runPollState(state, currentState, { woke: true });
     }
 
     return {
       type: "complete",
       status: "completed",
-      state: command.state,
+      state: originalState,
       result: "Nothing to wake.",
     };
+  }
+
+  private requireRunnerState(): TurnState {
+    if (!this.state) {
+      throw new Error("Turn runner has not been started.");
+    }
+    return this.state;
   }
 
   protected async runTurnRunnerAgentWithStateMachineTools(input: {

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -153,8 +153,7 @@ export class TurnRunner {
 
   /**
    * Set up a session before any turn runs. Loads memory and skills, emits
-   * `ready` with the resolved skill/agent-file context, and emits
-   * `session_started` with an initial empty `TurnState`. No agent work runs.
+   * `turn_started` with an initial empty `TurnState`. No agent work runs.
    *
    * Callers (CLI/TUI/session managers) call this once on launch so the user
    * sees available skills before typing the first prompt.
@@ -165,7 +164,7 @@ export class TurnRunner {
     const mode = command.mode ?? this.config.mode ?? "auto";
     const state = command.state ?? this.stateMachineRuntime.createInitialState(mode);
     this.state = state;
-    this.emit({ type: "session_started", state });
+    this.emit({ type: "turn_started", state });
     return state;
   }
 

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -19,11 +19,11 @@ import type { StateMachineDefinition, StateMachineSession } from "./state-machin
  *
  * ## Turn Model
  *
- * The runner is a stateless turn executor: every command carries the full
- * `TurnState` snapshot needed to resume work, and every terminal event returns
- * the next snapshot. The session is the long-lived session owner. It assigns
- * session ids, persists snapshots, schedules wakeups, and can run an unbounded
- * number of turn-runner turns for the same user session.
+ * The runner is a stateful turn executor: `start` bootstraps the current
+ * `TurnState`, and each terminal event returns the next snapshot. The session
+ * is the persistence owner. It assigns session ids, hydrates stored snapshots
+ * before start, persists terminal snapshots, schedules wakeups, and can run an
+ * unbounded number of turn-runner turns for the same user session.
  *
  * A caller initializes a session by sending `start`. This is a setup command,
  * not a turn: the runner loads memory and skills, emits `session_started`
@@ -45,8 +45,8 @@ import type { StateMachineDefinition, StateMachineSession } from "./state-machin
  * Terminal events carry the turn runner-owned state needed to continue a later turn.
  * `complete` means this turn-runner turn ended; it does not mean the session
  * session is finished. A user can follow up with another prompt for the same
- * session, and the session will pass the latest `TurnState`
- * back into the runner. The agent session is always present because the agent owns the conversation
+ * session; the runner continues from its internally held `TurnState`. The
+ * agent session is always present because the agent owns the conversation
  * history and, for state-machine mode, drives state transitions.
  *
  * ## Scenario 1: One-Shot Agent Task
@@ -264,9 +264,11 @@ export type TurnStep =
  * Set up a new turn-runner session.
  *
  * `start` is a setup command, not a turn. The runner loads memory and skills,
- * emits `ready` with the resolved skill/agent-file context, and emits
- * `session_started` with an empty `TurnState`. No agent work runs. The caller
- * sends `prompt` afterwards to actually run a turn.
+ * stores its initial `TurnState` (either fresh or the resumed one passed via
+ * `state`), and emits `session_started`. No agent work runs. The caller sends
+ * `prompt` afterwards to actually run a turn. Skills, agent files, and skill
+ * collisions are exposed through dedicated runner methods so callers can
+ * render the setup summary without subscribing to a dedicated event.
  *
  * The CLI/TUI sends this on launch so the user sees the available skills
  * before typing the first prompt.
@@ -285,16 +287,16 @@ export interface TurnStartCommand {
 }
 
 /**
- * Send a new user prompt while turn state exists.
+ * Send a new user prompt against the runner's current state.
  *
  * Callers may send prompt commands even while a previous `turn()` call is
  * active. The turn runner maps `behavior` onto the active pi agent when it can
- * and otherwise queues the command behind active non-agent work.
+ * and otherwise queues the command behind active non-agent work. State is held
+ * inside the runner; it was bootstrapped at `start` and is updated from the
+ * runner's own terminal events.
  */
 export interface TurnPromptCommand {
   type: "prompt";
-  /** Existing turn state to continue. */
-  state: TurnState;
   message: string;
   /** Pi handles the underlying interruption/follow-up behavior. */
   behavior: TurnPromptBehavior;
@@ -310,8 +312,6 @@ export interface TurnPromptCommand {
  */
 export interface TurnAnswerCommand {
   type: "answer";
-  /** Existing turn state to continue. */
-  state: TurnState;
   questions: TurnQuestion[];
   answers: Record<string, string>;
   /** Pi handles the underlying interruption/follow-up behavior. */
@@ -319,11 +319,9 @@ export interface TurnAnswerCommand {
   options?: TurnOptions;
 }
 
-/** Wake sleeping turn state. If the state is not sleeping on a poll state, this is a no-op. */
+/** Wake the runner's sleeping state. If the state is not sleeping on a poll state, this is a no-op. */
 export interface TurnWakeCommand {
   type: "wake";
-  /** Existing turn state to wake. */
-  state: TurnState;
   options?: TurnOptions;
 }
 
@@ -342,15 +340,13 @@ export interface TurnEditFollowUpQueueCommand {
 
 /**
  * Commands that drive a single turn-runner turn. `start` is excluded because
- * setup is not a turn; it is handled separately and emits `ready` only.
+ * setup is not a turn and is handled by `TurnRunner.start()` directly.
  */
 export type TurnCommand = TurnPromptCommand | TurnAnswerCommand | TurnWakeCommand;
 
 /** Out-of-band control message that interrupts the currently running turn. */
 export interface TurnInterruptCommand {
   type: "interrupt";
-  /** Current turn state known by the caller at the time of interruption. */
-  state: TurnState;
 }
 
 export type TurnRunnerCommand =

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -25,17 +25,22 @@ import type { StateMachineDefinition, StateMachineSession } from "./state-machin
  * session ids, persists snapshots, schedules wakeups, and can run an unbounded
  * number of turn-runner turns for the same user session.
  *
- * A caller starts a turn-runner turn by sending one of:
+ * A caller initializes a session by sending `start`. This is a setup command,
+ * not a turn: the runner loads memory and skills, emits `session_started`
+ * with the initial empty `TurnState`, and returns. Skills, agent files, and
+ * skill collisions are exposed through `getSkills()`, `getResolvedAgentFiles()`,
+ * and `getSkillCollisions()` for callers (CLI/TUI) that want to render a
+ * setup summary; no agent work runs until the caller sends a follow-up.
  *
- * - `start`: begin a new turn state from a prompt
- * - `prompt`: send a follow-up prompt while state exists
+ * Once the session is set up, callers run turns by sending one of:
+ *
+ * - `prompt`: send a user prompt against the current state
  * - `answer`: answer questions from the previous terminal `ask` event
  * - `wake`: resume a sleeping session for one scheduled polling attempt
  *
- * The turn runner must emit `ready` before any other event. A turn runner that is not
- * ready should not emit session, progress, or terminal events. After `ready`, the
- * runner emits any number of during-turn events (`step`, `todos`, `follow_up_queue`,
- * `state_machine`, `log`). The turn ends with exactly one terminal event:
+ * Each turn emits any number of during-turn events (`step`, `todos`,
+ * `follow_up_queue`, `state_machine`, `log`). The turn ends with exactly one
+ * terminal event:
  * `complete`, `ask`, `interrupted`, or `sleep`.
  * Terminal events carry the turn runner-owned state needed to continue a later turn.
  * `complete` means this turn-runner turn ended; it does not mean the session
@@ -47,13 +52,13 @@ import type { StateMachineDefinition, StateMachineSession } from "./state-machin
  * ## Scenario 1: One-Shot Agent Task
  *
  * The user asks for a normal task, such as "summarize this file" or "fix this
- * bug." The start command omits `mode` or sets `mode: "auto"`. The turn runner
- * classifies the prompt as agent mode and emits:
+ * bug." The caller sends `start` (omitting `mode` or setting `mode: "auto"`)
+ * to set the session up; the runner emits `session_started` with an empty
+ * `state.agent`. When the user types their first prompt, the caller sends a
+ * `prompt` command and the runner classifies it as agent mode and emits:
  *
- * 1. `ready`
- * 2. `session_started` with `state.agent` populated
- * 3. zero or more `step`, `todos`, `follow_up_queue`, or `log` events
- * 4. `complete` with the final answer and updated `state.agent`
+ * 1. zero or more `step`, `todos`, `follow_up_queue`, or `log` events
+ * 2. `complete` with the final answer and updated `state.agent`
  *
  * This behaves like a normal agent runner. There is no state-machine UI because
  * the session is not a long-running business process.
@@ -62,9 +67,9 @@ import type { StateMachineDefinition, StateMachineSession } from "./state-machin
  *
  * The user asks for a task with a complex lifecycle, such as "prospect this
  * customer until they book a meeting" or "implement this change, open a PR, and
- * watch it until merge." With `mode: "auto"`, the runner chooses a state
- * machine and emits `session_started` with `state.agent` and `state.stateMachine`
- * populated.
+ * watch it until merge." With `mode: "auto"`, the first `prompt` after `start`
+ * routes through the runner, which chooses a state machine and populates
+ * `state.stateMachine` on the next emitted state.
  *
  * During the turn, the runner emits events that the UI can render directly:
  *
@@ -256,16 +261,26 @@ export type TurnStep =
   | { type: "system"; message: string };
 
 /**
- * Start a new turn state.
+ * Set up a new turn-runner session.
  *
- * The mode decides routing. Omit it to use the turn runner's configured default.
+ * `start` is a setup command, not a turn. The runner loads memory and skills,
+ * emits `ready` with the resolved skill/agent-file context, and emits
+ * `session_started` with an empty `TurnState`. No agent work runs. The caller
+ * sends `prompt` afterwards to actually run a turn.
+ *
+ * The CLI/TUI sends this on launch so the user sees the available skills
+ * before typing the first prompt.
  */
 export interface TurnStartCommand {
   type: "start";
-  /** User prompt to route through the runner. */
-  prompt: string;
-  /** Routing mode. Omit to use the turn runner's configured default. */
+  /** Routing mode for subsequent prompts. Omit to use the turn runner's configured default. */
   mode?: TurnMode;
+  /**
+   * Existing state to resume. When provided, the runner emits `session_started`
+   * with this state instead of creating a fresh one. Resumed sessions keep
+   * their persisted agent and state-machine history.
+   */
+  state?: TurnState;
   options?: TurnOptions;
 }
 
@@ -325,11 +340,11 @@ export interface TurnEditFollowUpQueueCommand {
   prompts: string[];
 }
 
-export type TurnCommand =
-  | TurnStartCommand
-  | TurnPromptCommand
-  | TurnAnswerCommand
-  | TurnWakeCommand;
+/**
+ * Commands that drive a single turn-runner turn. `start` is excluded because
+ * setup is not a turn; it is handled separately and emits `ready` only.
+ */
+export type TurnCommand = TurnPromptCommand | TurnAnswerCommand | TurnWakeCommand;
 
 /** Out-of-band control message that interrupts the currently running turn. */
 export interface TurnInterruptCommand {
@@ -338,43 +353,18 @@ export interface TurnInterruptCommand {
   state: TurnState;
 }
 
-export type TurnRunnerCommand = TurnCommand | TurnInterruptCommand | TurnEditFollowUpQueueCommand;
+export type TurnRunnerCommand =
+  | TurnStartCommand
+  | TurnCommand
+  | TurnInterruptCommand
+  | TurnEditFollowUpQueueCommand;
 
-export interface TurnReadySkillInfo {
-  /** Skill name (from frontmatter or directory). */
-  name: string;
-  /** Skill description (from frontmatter, raw — no shell expansion). */
-  description: string;
-  /** Absolute path to the skill directory. */
-  path: string;
-  /** Where the skill was discovered. */
-  scope: "user" | "project" | "temporary";
-}
-
-export interface TurnReadyAgentFile {
+/** A system-prompt file that was resolved on disk for the session. */
+export interface TurnAgentFile {
   /** Configured file name relative to the working directory, e.g. "AGENTS.md". */
   name: string;
   /** Absolute path on disk. */
   path: string;
-}
-
-export interface TurnReadySkillCollision {
-  /** Skill name that collided. */
-  name: string;
-  /** Path that won (this is the skill that was actually loaded). */
-  winnerPath: string;
-  /** Path that was skipped due to the collision. */
-  loserPath: string;
-}
-
-export interface TurnReadyEvent {
-  type: "ready";
-  /** Skills discovered for this session. */
-  skills: TurnReadySkillInfo[];
-  /** System-prompt files that were resolved on disk for this session. */
-  agentFiles: TurnReadyAgentFile[];
-  /** Skill name collisions where one definition shadowed another. */
-  skillCollisions: TurnReadySkillCollision[];
 }
 
 export interface TurnStateStartedEvent {
@@ -458,8 +448,4 @@ export type TurnTerminalEvent =
   | TurnInterruptedEvent
   | TurnSleepEvent;
 
-export type TurnEvent =
-  | TurnReadyEvent
-  | TurnStateStartedEvent
-  | TurnDuringEvent
-  | TurnTerminalEvent;
+export type TurnEvent = TurnStateStartedEvent | TurnDuringEvent | TurnTerminalEvent;

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -26,7 +26,7 @@ import type { StateMachineDefinition, StateMachineSession } from "./state-machin
  * unbounded number of turn-runner turns for the same user session.
  *
  * A caller initializes a session by sending `start`. This is a setup command,
- * not a turn: the runner loads memory and skills, emits `session_started`
+ * not a turn: the runner loads memory and skills, emits `turn_started`
  * with the initial empty `TurnState`, and returns. Skills, agent files, and
  * skill collisions are exposed through `getSkills()`, `getResolvedAgentFiles()`,
  * and `getSkillCollisions()` for callers (CLI/TUI) that want to render a
@@ -53,7 +53,7 @@ import type { StateMachineDefinition, StateMachineSession } from "./state-machin
  *
  * The user asks for a normal task, such as "summarize this file" or "fix this
  * bug." The caller sends `start` (omitting `mode` or setting `mode: "auto"`)
- * to set the session up; the runner emits `session_started` with an empty
+ * to set the session up; the runner emits `turn_started` with an empty
  * `state.agent`. When the user types their first prompt, the caller sends a
  * `prompt` command and the runner classifies it as agent mode and emits:
  *
@@ -265,7 +265,7 @@ export type TurnStep =
  *
  * `start` is a setup command, not a turn. The runner loads memory and skills,
  * stores its initial `TurnState` (either fresh or the resumed one passed via
- * `state`), and emits `session_started`. No agent work runs. The caller sends
+ * `state`), and emits `turn_started`. No agent work runs. The caller sends
  * `prompt` afterwards to actually run a turn. Skills, agent files, and skill
  * collisions are exposed through dedicated runner methods so callers can
  * render the setup summary without subscribing to a dedicated event.
@@ -278,7 +278,7 @@ export interface TurnStartCommand {
   /** Routing mode for subsequent prompts. Omit to use the turn runner's configured default. */
   mode?: TurnMode;
   /**
-   * Existing state to resume. When provided, the runner emits `session_started`
+   * Existing state to resume. When provided, the runner emits `turn_started`
    * with this state instead of creating a fresh one. Resumed sessions keep
    * their persisted agent and state-machine history.
    */
@@ -363,8 +363,8 @@ export interface TurnAgentFile {
   path: string;
 }
 
-export interface TurnStateStartedEvent {
-  type: "session_started";
+export interface TurnStartedEvent {
+  type: "turn_started";
   /** Full turn state after applying config/options/auto routing. */
   state: TurnState;
 }
@@ -444,4 +444,4 @@ export type TurnTerminalEvent =
   | TurnInterruptedEvent
   | TurnSleepEvent;
 
-export type TurnEvent = TurnStateStartedEvent | TurnDuringEvent | TurnTerminalEvent;
+export type TurnEvent = TurnStartedEvent | TurnDuringEvent | TurnTerminalEvent;

--- a/src/types/state-machine.ts
+++ b/src/types/state-machine.ts
@@ -296,7 +296,7 @@ export interface StateMachineTerminalResult {
 }
 
 export type StateMachineSessionEvent =
-  | { type: "session_started"; timestamp: number }
+  | { type: "state_machine_started"; timestamp: number }
   | { type: "runner_decided"; timestamp: number; decision: unknown }
   | {
       type: "state_started";
@@ -306,4 +306,4 @@ export type StateMachineSessionEvent =
     }
   | { type: "state_completed"; timestamp: number; state: string; output?: unknown }
   | { type: "state_failed"; timestamp: number; state: string; error: string }
-  | { type: "session_completed"; timestamp: number; terminal: StateMachineTerminalResult };
+  | { type: "state_machine_completed"; timestamp: number; terminal: StateMachineTerminalResult };

--- a/test/cli-skills.test.ts
+++ b/test/cli-skills.test.ts
@@ -1,0 +1,97 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect } from "bun:test";
+import dedent from "dedent";
+import { discoverInstalledSkills, resolveSkillScope } from "../src/turn-runner/skills.js";
+import { testIfDocker } from "./helpers/docker-only.js";
+
+let projectRoot: string | undefined;
+
+afterEach(async () => {
+  if (projectRoot) {
+    await rm(projectRoot, { recursive: true, force: true });
+    projectRoot = undefined;
+  }
+});
+
+async function writeSkill(
+  root: string,
+  name: string,
+  description: string,
+  body = "Skill body",
+): Promise<string> {
+  const skillDir = join(root, name);
+  await mkdir(skillDir, { recursive: true });
+  const filePath = join(skillDir, "SKILL.md");
+  await writeFile(
+    filePath,
+    dedent`
+      ---
+      name: ${name}
+      description: ${description}
+      ---
+
+      ${body}
+    `,
+  );
+  return skillDir;
+}
+
+describe("CLI skills command", () => {
+  // The `duet skills` command serializes each discovered skill with these four
+  // fields. Locking the shape here keeps the JSON output stable for any tool
+  // that consumes it.
+  testIfDocker("returns name, description, path, and scope for project skills", async () => {
+    const root = (projectRoot = await mkdtemp(join(tmpdir(), "duet-cli-skills-")));
+    const skillDir = await writeSkill(
+      join(root, ".duet", "skills"),
+      "release",
+      "Bump the version and push tags.",
+    );
+
+    const { skills, collisions } = discoverInstalledSkills(root);
+    const output = skills.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      path: skill.baseDir,
+      scope: resolveSkillScope(skill, root),
+    }));
+
+    expect(collisions).toEqual([]);
+    expect(output).toEqual([
+      {
+        name: "release",
+        description: "Bump the version and push tags.",
+        path: skillDir,
+        scope: "project",
+      },
+    ]);
+  });
+
+  testIfDocker("reports the project scope for .agents skills too", async () => {
+    const root = (projectRoot = await mkdtemp(join(tmpdir(), "duet-cli-skills-")));
+    const skillDir = await writeSkill(
+      join(root, ".agents", "skills"),
+      "review",
+      "Review code before committing.",
+    );
+
+    const { skills } = discoverInstalledSkills(root);
+    const summary = skills.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      path: skill.baseDir,
+      scope: resolveSkillScope(skill, root),
+    }));
+
+    expect(summary).toEqual([
+      {
+        name: "review",
+        description: "Review code before committing.",
+        path: skillDir,
+        scope: "project",
+      },
+    ]);
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -52,7 +52,7 @@ describe("CLI model inference", () => {
       fromDotenv: false,
     });
     expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
-      modelName: "anthropic:claude-sonnet-4-6",
+      modelName: "anthropic:claude-haiku-4-5",
       source: "inferred",
       envVar: "ANTHROPIC_API_KEY",
       fromDotenv: false,
@@ -75,7 +75,7 @@ describe("CLI model inference", () => {
       fromDotenv: false,
     });
     expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
-      modelName: "duet-gateway:anthropic/claude-sonnet-4.6",
+      modelName: "duet-gateway:anthropic/claude-haiku-4.5",
       source: "inferred",
       envVar: "DUET_API_KEY",
       fromDotenv: false,
@@ -93,7 +93,7 @@ describe("CLI model inference", () => {
       fromDotenv: false,
     });
     expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
-      modelName: "vercel-ai-gateway:anthropic/claude-sonnet-4.6",
+      modelName: "vercel-ai-gateway:anthropic/claude-haiku-4.5",
       source: "inferred",
       envVar: "AI_GATEWAY_API_KEY",
       fromDotenv: false,
@@ -112,7 +112,7 @@ describe("CLI model inference", () => {
       fromDotenv: false,
     });
     expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
-      modelName: "openrouter:anthropic/claude-sonnet-4.6",
+      modelName: "openrouter:anthropic/claude-haiku-4.5",
       source: "inferred",
       envVar: "OPENROUTER_API_KEY",
       fromDotenv: false,
@@ -145,7 +145,7 @@ describe("CLI model inference", () => {
       source: "default",
     });
     expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
-      modelName: "anthropic:claude-sonnet-4-6",
+      modelName: "anthropic:claude-haiku-4-5",
       source: "default",
     });
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -4,6 +4,8 @@ import {
   detectPackageManagerFromContext,
   formatNewVersionNotice,
   inferDefaultModelName,
+  resolveCliMemoryModel,
+  resolveCliMemoryModelName,
   resolveCliModelName,
 } from "../src/cli.js";
 
@@ -98,6 +100,38 @@ describe("CLI model inference", () => {
     clearModelEnv();
 
     expect(resolveCliModelName("openai:gpt-5.5")).toBe("openai:gpt-5.5");
+  });
+
+  test("infers default memory from Duet gateway credentials", () => {
+    clearModelEnv();
+    process.env.DUET_API_KEY = "duet_gt_test";
+
+    expect(resolveCliMemoryModelName(undefined)).toBe("duet-gateway:anthropic/claude-sonnet-4.6");
+    expect(resolveCliMemoryModel(undefined)).toEqual({
+      modelName: "duet-gateway:anthropic/claude-sonnet-4.6",
+      source: "inferred",
+      envVar: "DUET_API_KEY",
+      fromDotenv: false,
+    });
+  });
+
+  test("infers default memory from OpenAI credentials", () => {
+    clearModelEnv();
+    process.env.OPENAI_API_KEY = "test-openai";
+
+    expect(resolveCliMemoryModelName(undefined)).toBe("openai:gpt-5.4-mini");
+  });
+
+  test("uses the Anthropic memory default when no provider credentials exist", () => {
+    clearModelEnv();
+
+    expect(resolveCliMemoryModelName(undefined)).toBe("anthropic:claude-sonnet-4-6");
+  });
+
+  test("keeps an explicitly provided memory model", () => {
+    expect(resolveCliMemoryModelName("anthropic:claude-3-5-haiku-latest")).toBe(
+      "anthropic:claude-3-5-haiku-latest",
+    );
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3,11 +3,8 @@ import {
   compareSemverVersions,
   detectPackageManagerFromContext,
   formatNewVersionNotice,
-  inferDefaultModelName,
-  resolveCliMemoryModel,
-  resolveCliMemoryModelName,
-  resolveCliModelName,
 } from "../src/cli.js";
+import { resolveCliMemoryModel, resolveCliModel } from "../src/model-resolution/index.js";
 
 const MODEL_ENV_KEYS = [
   "ANTHROPIC_API_KEY",
@@ -19,6 +16,7 @@ const MODEL_ENV_KEYS = [
 ] as const;
 
 const originalEnv = new Map<string, string | undefined>();
+const EMPTY_DOTENV_KEYS = new Set<string>();
 
 for (const key of MODEL_ENV_KEYS) {
   originalEnv.set(key, process.env[key]);
@@ -47,7 +45,18 @@ describe("CLI model inference", () => {
     process.env.ANTHROPIC_API_KEY = "test-anthropic";
     process.env.OPENAI_API_KEY = "test-openai";
 
-    expect(inferDefaultModelName()).toBe("anthropic:claude-opus-4-7");
+    expect(resolveCliModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "anthropic:claude-opus-4-7",
+      source: "inferred",
+      envVar: "ANTHROPIC_API_KEY",
+      fromDotenv: false,
+    });
+    expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "anthropic:claude-sonnet-4-6",
+      source: "inferred",
+      envVar: "ANTHROPIC_API_KEY",
+      fromDotenv: false,
+    });
   });
 
   test("uses Duet sandbox credentials when only DUET_API_KEY is set", () => {
@@ -59,55 +68,13 @@ describe("CLI model inference", () => {
     clearModelEnv();
     process.env.DUET_API_KEY = "duet_gt_test";
 
-    expect(inferDefaultModelName()).toBe("duet-gateway:anthropic/claude-opus-4.7");
-  });
-
-  test("uses AI Gateway credentials for Opus when Anthropic and Duet are absent", () => {
-    clearModelEnv();
-    process.env.AI_GATEWAY_API_KEY = "test-gateway";
-
-    expect(inferDefaultModelName()).toBe("vercel-ai-gateway:anthropic/claude-opus-4.7");
-  });
-
-  test("uses OpenRouter credentials for Opus when Anthropic and AI Gateway are absent", () => {
-    clearModelEnv();
-    process.env.OPENROUTER_API_KEY = "test-openrouter";
-    process.env.OPENAI_API_KEY = "test-openai";
-
-    expect(inferDefaultModelName()).toBe("openrouter:anthropic/claude-opus-4.7");
-  });
-
-  test("uses OpenAI credentials when higher-priority providers are absent", () => {
-    clearModelEnv();
-    process.env.OPENAI_API_KEY = "test-openai";
-
-    expect(inferDefaultModelName()).toBe("openai:gpt-5.5");
-  });
-
-  test("leaves model unset when no supported provider credentials exist", () => {
-    clearModelEnv();
-
-    expect(inferDefaultModelName()).toBeUndefined();
-  });
-
-  test("falls back to the built-in default when no model or provider key is configured", () => {
-    clearModelEnv();
-
-    expect(resolveCliModelName(undefined)).toBe("anthropic:claude-opus-4-7");
-  });
-
-  test("keeps an explicitly provided model", () => {
-    clearModelEnv();
-
-    expect(resolveCliModelName("openai:gpt-5.5")).toBe("openai:gpt-5.5");
-  });
-
-  test("infers default memory from Duet gateway credentials", () => {
-    clearModelEnv();
-    process.env.DUET_API_KEY = "duet_gt_test";
-
-    expect(resolveCliMemoryModelName(undefined)).toBe("duet-gateway:anthropic/claude-sonnet-4.6");
-    expect(resolveCliMemoryModel(undefined)).toEqual({
+    expect(resolveCliModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "duet-gateway:anthropic/claude-opus-4.7",
+      source: "inferred",
+      envVar: "DUET_API_KEY",
+      fromDotenv: false,
+    });
+    expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
       modelName: "duet-gateway:anthropic/claude-sonnet-4.6",
       source: "inferred",
       envVar: "DUET_API_KEY",
@@ -115,23 +82,88 @@ describe("CLI model inference", () => {
     });
   });
 
-  test("infers default memory from OpenAI credentials", () => {
+  test("uses AI Gateway credentials for Opus when Anthropic and Duet are absent", () => {
+    clearModelEnv();
+    process.env.AI_GATEWAY_API_KEY = "test-gateway";
+
+    expect(resolveCliModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "vercel-ai-gateway:anthropic/claude-opus-4.7",
+      source: "inferred",
+      envVar: "AI_GATEWAY_API_KEY",
+      fromDotenv: false,
+    });
+    expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "vercel-ai-gateway:anthropic/claude-sonnet-4.6",
+      source: "inferred",
+      envVar: "AI_GATEWAY_API_KEY",
+      fromDotenv: false,
+    });
+  });
+
+  test("uses OpenRouter credentials for Opus when Anthropic and AI Gateway are absent", () => {
+    clearModelEnv();
+    process.env.OPENROUTER_API_KEY = "test-openrouter";
+    process.env.OPENAI_API_KEY = "test-openai";
+
+    expect(resolveCliModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "openrouter:anthropic/claude-opus-4.7",
+      source: "inferred",
+      envVar: "OPENROUTER_API_KEY",
+      fromDotenv: false,
+    });
+    expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "openrouter:anthropic/claude-sonnet-4.6",
+      source: "inferred",
+      envVar: "OPENROUTER_API_KEY",
+      fromDotenv: false,
+    });
+  });
+
+  test("uses OpenAI credentials when higher-priority providers are absent", () => {
     clearModelEnv();
     process.env.OPENAI_API_KEY = "test-openai";
 
-    expect(resolveCliMemoryModelName(undefined)).toBe("openai:gpt-5.4-mini");
+    expect(resolveCliModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "openai:gpt-5.5",
+      source: "inferred",
+      envVar: "OPENAI_API_KEY",
+      fromDotenv: false,
+    });
+    expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "openai:gpt-5.4-mini",
+      source: "inferred",
+      envVar: "OPENAI_API_KEY",
+      fromDotenv: false,
+    });
   });
 
-  test("uses the Anthropic memory default when no provider credentials exist", () => {
+  test("falls back to built-in model defaults when no supported provider credentials exist", () => {
     clearModelEnv();
 
-    expect(resolveCliMemoryModelName(undefined)).toBe("anthropic:claude-sonnet-4-6");
+    expect(resolveCliModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "anthropic:claude-opus-4-7",
+      source: "default",
+    });
+    expect(resolveCliMemoryModel(undefined, EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "anthropic:claude-sonnet-4-6",
+      source: "default",
+    });
+  });
+
+  test("keeps an explicitly provided model", () => {
+    clearModelEnv();
+
+    expect(resolveCliModel("openai:gpt-5.5", EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "openai:gpt-5.5",
+      source: "explicit",
+    });
   });
 
   test("keeps an explicitly provided memory model", () => {
-    expect(resolveCliMemoryModelName("anthropic:claude-3-5-haiku-latest")).toBe(
-      "anthropic:claude-3-5-haiku-latest",
-    );
+    expect(resolveCliMemoryModel("anthropic:claude-3-5-haiku-latest", EMPTY_DOTENV_KEYS)).toEqual({
+      modelName: "anthropic:claude-3-5-haiku-latest",
+      source: "explicit",
+    });
   });
 });
 

--- a/test/helpers/skills-turn-runner.ts
+++ b/test/helpers/skills-turn-runner.ts
@@ -1,5 +1,5 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { TurnRunner } from "../../src/turn-runner/turn-runner.js";
 
@@ -11,6 +11,8 @@ export interface TestSkillInput {
 
 export interface TestTurnRunnerApp {
   runner: TurnRunner;
+  /** Project root used as the runner's cwd. Tests can write skills under this path freely. */
+  projectRoot: string;
   addProjectDuetSkill(input: TestSkillInput): Promise<string>;
   addProjectAgentSkill(input: TestSkillInput): Promise<string>;
   addGlobalDuetSkill(input: TestSkillInput): Promise<string>;
@@ -18,37 +20,55 @@ export interface TestTurnRunnerApp {
   cleanup(): Promise<void>;
 }
 
-export function createTestTurnRunner(): TestTurnRunnerApp {
-  const root = process.cwd();
+/**
+ * Build a runner whose project root is an isolated temp directory. Without
+ * this, `process.cwd()` would be the repo (or `/work` inside Docker), and
+ * any skill the project ships under `.duet/skills` or `.agents/skills`
+ * would leak into every skill-discovery test.
+ *
+ * Global-skill scopes still come from `homedir()`. Skill-discovery tests that
+ * touch the global scope are gated on `testIfDocker`, which runs with a clean
+ * `HOME=/tmp/home`, so they stay isolated from the developer's real home.
+ */
+export async function createTestTurnRunner(): Promise<TestTurnRunnerApp> {
+  const projectRoot = await mkdtemp(join(tmpdir(), "duet-skill-project-"));
   const runner = new TurnRunner({
     model: "anthropic:claude-opus-4-7",
-    cwd: root,
+    cwd: projectRoot,
   });
 
-  const createdPaths: string[] = [];
+  const createdGlobalPaths: string[] = [];
 
   return {
     runner,
-    addProjectDuetSkill: (input) => writeSkill(join(root, ".duet", "skills"), input, createdPaths),
-    addProjectAgentSkill: (input) =>
-      writeSkill(join(root, ".agents", "skills"), input, createdPaths),
+    projectRoot,
+    addProjectDuetSkill: (input) => writeSkill(join(projectRoot, ".duet", "skills"), input),
+    addProjectAgentSkill: (input) => writeSkill(join(projectRoot, ".agents", "skills"), input),
     addGlobalDuetSkill: (input) =>
-      writeSkill(join(homedir(), ".duet", "skills"), input, createdPaths),
+      writeSkillTracked(join(homedir(), ".duet", "skills"), input, createdGlobalPaths),
     addGlobalAgentSkill: (input) =>
-      writeSkill(join(homedir(), ".agents", "skills"), input, createdPaths),
+      writeSkillTracked(join(homedir(), ".agents", "skills"), input, createdGlobalPaths),
     cleanup: async () => {
-      await Promise.all(createdPaths.map((path) => rm(path, { recursive: true, force: true })));
+      await rm(projectRoot, { recursive: true, force: true });
+      await Promise.all(
+        createdGlobalPaths.map((path) => rm(path, { recursive: true, force: true })),
+      );
     },
   };
 }
 
-async function writeSkill(
+async function writeSkillTracked(
   root: string,
   input: TestSkillInput,
   createdPaths: string[],
 ): Promise<string> {
   const skillDir = join(root, input.name);
   createdPaths.push(skillDir);
+  return writeSkill(root, input);
+}
+
+async function writeSkill(root: string, input: TestSkillInput): Promise<string> {
+  const skillDir = join(root, input.name);
   await mkdir(skillDir, { recursive: true });
   const skillPath = join(skillDir, "SKILL.md");
   await writeFile(

--- a/test/helpers/turn-runner-protocol.ts
+++ b/test/helpers/turn-runner-protocol.ts
@@ -92,7 +92,6 @@ export async function startTurn<
   });
   const turn = runner.turn({
     type: "prompt",
-    state,
     message: args.prompt,
     behavior: "follow_up",
   });

--- a/test/helpers/turn-runner-protocol.ts
+++ b/test/helpers/turn-runner-protocol.ts
@@ -5,7 +5,12 @@ import {
 } from "../../src/turn-runner/turn-runner.js";
 import type { TurnRunnerControlResult } from "../../src/turn-runner/tools.js";
 import type { TurnRunnerConfig } from "../../src/types/config.js";
-import type { TurnEvent, TurnState } from "../../src/types/protocol.js";
+import type {
+  TurnEvent,
+  TurnMode,
+  TurnState,
+  TurnTerminalEvent,
+} from "../../src/types/protocol.js";
 import type { StateMachineDefinition } from "../../src/types/state-machine.js";
 import { createAssistantMessage } from "./messages.js";
 
@@ -65,6 +70,33 @@ export function createTurnRunner(config?: Partial<TurnRunnerConfig>): {
   const events: TurnEvent[] = [];
   runner.subscribe((event) => events.push(event));
   return { runner, events };
+}
+
+/**
+ * Run setup and dispatch the first prompt against a runner. Mirrors the
+ * common test pattern of "create a session and start the user's first turn"
+ * now that `start` is a setup-only command.
+ */
+export async function startTurn<
+  T extends {
+    start: (input: any) => Promise<TurnState>;
+    turn: (input: any) => Promise<TurnTerminalEvent>;
+  },
+>(
+  runner: T,
+  args: { mode?: TurnMode; prompt: string },
+): Promise<{ state: TurnState; turn: Promise<TurnTerminalEvent> }> {
+  const state = await runner.start({
+    type: "start",
+    ...(args.mode !== undefined ? { mode: args.mode } : {}),
+  });
+  const turn = runner.turn({
+    type: "prompt",
+    state,
+    message: args.prompt,
+    behavior: "follow_up",
+  });
+  return { state, turn };
 }
 
 export function createStateMachineState(currentState: string): TurnState {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -8,10 +8,14 @@ import {
   DEFAULT_SESSION_STORAGE_DIR,
   SessionManager,
 } from "../src/session/session-manager.js";
+import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { SkillCollision } from "../src/turn-runner/skills.js";
 import type {
+  TurnAgentFile,
   TurnEvent,
   TurnEditFollowUpQueueCommand,
   TurnInterruptCommand,
+  TurnStartCommand,
   TurnState,
   TurnTerminalEvent,
   TurnCommand,
@@ -25,7 +29,7 @@ class FakeTurnRunner implements SessionTurnRunner {
   readonly interrupts: TurnInterruptCommand[] = [];
   readonly followUpQueueEdits: TurnEditFollowUpQueueCommand[] = [];
   readonly handlers = new Set<(event: TurnEvent) => void>();
-  skills: readonly { name: string }[] = [];
+  skills: readonly Skill[] = [];
   skillInstructions = new Map<string, string>();
   disposed = false;
   terminals: TurnTerminalEvent[];
@@ -38,12 +42,13 @@ class FakeTurnRunner implements SessionTurnRunner {
     this.terminals = [...terminals];
   }
 
+  async start(_command: TurnStartCommand): Promise<TurnState> {
+    this.emit({ type: "session_started", state: turnState });
+    return turnState;
+  }
+
   async turn(command: TurnCommand): Promise<TurnTerminalEvent> {
     this.commands.push(command);
-    this.emit({ type: "ready", skills: [], agentFiles: [], skillCollisions: [] });
-    if (command.type === "start") {
-      this.emit({ type: "session_started", state: turnState });
-    }
     if (command.type === "wake" && this.terminals.length === 0) {
       const terminal: TurnTerminalEvent = {
         type: "complete",
@@ -101,8 +106,16 @@ class FakeTurnRunner implements SessionTurnRunner {
     return () => this.handlers.delete(handler);
   }
 
-  async getSkills(): Promise<readonly { name: string }[]> {
+  async getSkills(): Promise<readonly Skill[]> {
     return this.skills;
+  }
+
+  async getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]> {
+    return [];
+  }
+
+  async getSkillCollisions(): Promise<readonly SkillCollision[]> {
+    return [];
   }
 
   getSkillInstructions(skillId: string): string {
@@ -160,11 +173,14 @@ describe("Session", () => {
     const runner = new FakeTurnRunner([complete()]);
     const session = await createSession(runner);
 
-    await session.start({ prompt: "hello" });
+    await session.start();
+    await session.prompt({ message: "hello" });
     await session.waitForTerminal();
 
     expect(session.id).toStartWith("session_");
-    expect(runner.commands).toEqual([{ type: "start", mode: undefined, prompt: "hello" }]);
+    expect(runner.commands).toEqual([
+      { type: "prompt", state: turnState, message: "hello", behavior: "follow_up" },
+    ]);
   });
 
   testIfDocker("forwards follow-up queue edits to the runner", async () => {
@@ -187,17 +203,14 @@ describe("Session", () => {
     const events: TurnEvent[] = [];
 
     const unsubscribe = session.subscribe((event) => events.push(event));
-    await session.start({ prompt: "hello" });
+    await session.start();
+    await session.prompt({ message: "hello" });
     await session.waitForTerminal();
     unsubscribe();
     runner.emit({ type: "system", level: "info", message: "ignored" });
 
-    expect(events[0]).toEqual({
-      type: "ready",
-      skills: [],
-      agentFiles: [],
-      skillCollisions: [],
-    });
+    expect(events[0]).toMatchObject({ type: "session_started" });
+    expect(events.at(-1)).toMatchObject({ type: "complete" });
   });
 
   testIfDocker("schedules wake after sleep without blocking command submission", async () => {
@@ -211,11 +224,12 @@ describe("Session", () => {
     ]);
     const session = await createSession(runner);
 
-    await session.start({ prompt: "poll" });
+    await session.start();
+    await session.prompt({ message: "poll" });
     await waitFor(() => runner.commands.length >= 2);
 
     expect(runner.commands).toEqual([
-      { type: "start", mode: undefined, prompt: "poll" },
+      { type: "prompt", state: turnState, message: "poll", behavior: "follow_up" },
       { type: "wake", state: sleeping },
     ]);
   });
@@ -230,7 +244,8 @@ describe("Session", () => {
       { id: "existing-session", runner: runner, sessionPath: join(tempDir, "existing-session") },
     );
 
-    await session.start({ prompt: "remember me" });
+    await session.start();
+    await session.prompt({ message: "remember me" });
     await session.waitForTerminal();
     const content = await readFile(join(tempDir, "existing-session", "state.json"), "utf-8");
     const stored = JSON.parse(content);
@@ -257,7 +272,8 @@ describe("Session", () => {
       { model: "anthropic:claude-opus-4-7" },
       { id: "continuable", runner: firstTurnRunner, sessionPath: join(tempDir, "continuable") },
     );
-    await first.start({ prompt: "start" });
+    await first.start();
+    await first.prompt({ message: "start" });
     await first.waitForTerminal();
     const secondTurnRunner = new FakeTurnRunner([complete("second")]);
 
@@ -265,7 +281,8 @@ describe("Session", () => {
       { model: "anthropic:claude-opus-4-7" },
       { id: "continuable", runner: secondTurnRunner, sessionPath: join(tempDir, "continuable") },
     );
-    await second.start({ prompt: "continue" });
+    await second.start();
+    await second.prompt({ message: "continue" });
     await second.waitForTerminal();
 
     expect(secondTurnRunner.commands).toEqual([
@@ -277,12 +294,13 @@ describe("Session", () => {
     const runner = new FakeTurnRunner([]);
     const session = await createSession(runner);
 
-    await session.start({ prompt: "start" });
+    await session.start();
+    await session.prompt({ message: "start" });
     await waitFor(() => runner.commands.length === 1);
     await session.prompt({ message: "steer now", behavior: "steer" });
 
     expect(runner.commands).toEqual([
-      { type: "start", mode: undefined, prompt: "start" },
+      { type: "prompt", state: turnState, message: "start", behavior: "follow_up" },
       { type: "prompt", state: turnState, message: "steer now", behavior: "steer" },
     ]);
   });
@@ -291,12 +309,13 @@ describe("Session", () => {
     const runner = new FakeTurnRunner([]);
     const session = await createSession(runner);
 
-    await session.start({ prompt: "start" });
+    await session.start();
+    await session.prompt({ message: "start" });
     await waitFor(() => runner.commands.length === 1);
     await session.prompt({ message: "queue later", behavior: "follow_up" });
 
     expect(runner.commands).toEqual([
-      { type: "start", mode: undefined, prompt: "start" },
+      { type: "prompt", state: turnState, message: "start", behavior: "follow_up" },
       { type: "prompt", state: turnState, message: "queue later", behavior: "follow_up" },
     ]);
   });
@@ -306,7 +325,8 @@ describe("Session", () => {
     const runner = new FakeTurnRunner([{ type: "ask", questions: [], state: waiting }]);
     const session = await createSession(runner);
 
-    await session.start({ prompt: "question" });
+    await session.start();
+    await session.prompt({ message: "question" });
     await session.waitForTerminal();
     await session.answer({
       questions: [{ question: "Pick one", options: [{ label: "A" }] }],
@@ -326,7 +346,8 @@ describe("Session", () => {
       const runner = new FakeTurnRunner([]);
       const session = await createSession(runner);
 
-      await session.start({ prompt: "start" });
+      await session.start();
+      await session.prompt({ message: "start" });
       await waitFor(() => runner.commands.length === 1);
       await session.interrupt();
       const terminal = await session.waitForTerminal();
@@ -351,7 +372,8 @@ describe("Session", () => {
     const events: TurnEvent[] = [];
     session.subscribe((event) => events.push(event));
 
-    await session.start({ prompt: "poll" });
+    await session.start();
+    await session.prompt({ message: "poll" });
     await session.waitForTerminal();
     await session.interrupt();
     await waitFor(() => events.some((event) => event.type === "interrupted"));
@@ -386,7 +408,8 @@ describe("Session", () => {
       ]);
       const session = await createSession(runner);
 
-      await session.start({ prompt: "poll" });
+      await session.start();
+      await session.prompt({ message: "poll" });
       await session.waitForTerminal();
       await session.prompt({ message: "anything new?" });
       runner.terminals.push({
@@ -410,12 +433,13 @@ describe("Session", () => {
       const runner = new FakeTurnRunner([complete("first"), complete("second")]);
       const session = await createSession(runner);
 
-      await session.start({ prompt: "start" });
+      await session.start();
+      await session.prompt({ message: "start" });
       await session.waitForTerminal();
       await session.prompt({ message: "next" });
 
       expect(runner.commands).toEqual([
-        { type: "start", mode: undefined, prompt: "start" },
+        { type: "prompt", state: turnState, message: "start", behavior: "follow_up" },
         { type: "prompt", state: turnState, message: "next", behavior: "follow_up" },
       ]);
     },
@@ -458,16 +482,18 @@ describe("SessionManager", () => {
     expect(manager.get("first")).toBe(first);
     expect(manager.get("second")).toBe(second);
     expect(runners.get("first")?.commands).toEqual([
-      { type: "start", mode: undefined, prompt: "one" },
+      { type: "prompt", state: turnState, message: "one", behavior: "follow_up" },
     ]);
     expect(runners.get("second")?.commands).toEqual([
-      { type: "start", mode: undefined, prompt: "two" },
+      { type: "prompt", state: turnState, message: "two", behavior: "follow_up" },
     ]);
     expect(
-      events.some((event) => event.sessionId === "first" && event.event.type === "ready"),
+      events.some((event) => event.sessionId === "first" && event.event.type === "session_started"),
     ).toBe(true);
     expect(
-      events.some((event) => event.sessionId === "second" && event.event.type === "ready"),
+      events.some(
+        (event) => event.sessionId === "second" && event.event.type === "session_started",
+      ),
     ).toBe(true);
     expect(manager.config.memoryDbPath).toBe(join(homedir(), ".duet", "memory.db"));
 
@@ -492,7 +518,8 @@ describe("SessionManager", () => {
     manager.subscribe((event) => events.push(event));
 
     const session = manager.resume("resumable");
-    await session.start({ prompt: "resume" });
+    await session.start();
+    await session.prompt({ message: "resume" });
     await session.waitForTerminal();
 
     expect(manager.get("resumable")).toBe(session);

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -44,7 +44,7 @@ class FakeTurnRunner implements SessionTurnRunner {
   }
 
   async start(_command: TurnStartCommand): Promise<TurnState> {
-    this.emit({ type: "session_started", state: turnState });
+    this.emit({ type: "turn_started", state: turnState });
     return turnState;
   }
 
@@ -210,7 +210,7 @@ describe("Session", () => {
     unsubscribe();
     runner.emit({ type: "system", level: "info", message: "ignored" });
 
-    expect(events[0]).toMatchObject({ type: "session_started" });
+    expect(events[0]).toMatchObject({ type: "turn_started" });
     expect(events.at(-1)).toMatchObject({ type: "complete" });
   });
 
@@ -488,12 +488,10 @@ describe("SessionManager", () => {
       { type: "prompt", message: "two", behavior: "follow_up" },
     ]);
     expect(
-      events.some((event) => event.sessionId === "first" && event.event.type === "session_started"),
+      events.some((event) => event.sessionId === "first" && event.event.type === "turn_started"),
     ).toBe(true);
     expect(
-      events.some(
-        (event) => event.sessionId === "second" && event.event.type === "session_started",
-      ),
+      events.some((event) => event.sessionId === "second" && event.event.type === "turn_started"),
     ).toBe(true);
     expect(manager.config.memoryDbPath).toBe(join(homedir(), ".duet", "memory.db"));
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -83,7 +83,7 @@ class FakeTurnRunner implements SessionTurnRunner {
               history: [
                 ...this.state.stateMachine.history,
                 {
-                  type: "session_completed",
+                  type: "state_machine_completed",
                   timestamp: Date.now(),
                   terminal: { state: "interrupted", status: "cancelled" },
                 },

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -29,6 +29,7 @@ class FakeTurnRunner implements SessionTurnRunner {
   readonly interrupts: TurnInterruptCommand[] = [];
   readonly followUpQueueEdits: TurnEditFollowUpQueueCommand[] = [];
   readonly handlers = new Set<(event: TurnEvent) => void>();
+  state = turnState;
   skills: readonly Skill[] = [];
   skillInstructions = new Map<string, string>();
   disposed = false;
@@ -54,7 +55,7 @@ class FakeTurnRunner implements SessionTurnRunner {
         type: "complete",
         status: "completed",
         result: "Nothing to wake.",
-        state: command.state,
+        state: this.state,
       };
       this.emit(terminal);
       return terminal;
@@ -72,15 +73,15 @@ class FakeTurnRunner implements SessionTurnRunner {
     const terminal: TurnTerminalEvent = {
       type: "interrupted",
       state: {
-        ...command.state,
+        ...this.state,
         status: "interrupted",
-        agent: { ...command.state.agent, status: "cancelled" },
-        stateMachine: command.state.stateMachine
+        agent: { ...this.state.agent, status: "cancelled" },
+        stateMachine: this.state.stateMachine
           ? {
-              ...command.state.stateMachine,
+              ...this.state.stateMachine,
               terminal: { state: "interrupted", status: "cancelled" },
               history: [
-                ...command.state.stateMachine.history,
+                ...this.state.stateMachine.history,
                 {
                   type: "session_completed",
                   timestamp: Date.now(),
@@ -91,6 +92,7 @@ class FakeTurnRunner implements SessionTurnRunner {
           : undefined,
       },
     };
+    this.state = terminal.state;
     this.terminals.push(terminal);
     this.emit(terminal);
     this.resolveNext();
@@ -129,6 +131,7 @@ class FakeTurnRunner implements SessionTurnRunner {
   resolveNext(terminal = this.terminals.shift()): void {
     const pending = this.pendingTurns.shift();
     if (!pending || !terminal) return;
+    this.state = terminal.state;
     this.emit(terminal);
     pending.resolve(terminal);
   }
@@ -178,9 +181,7 @@ describe("Session", () => {
     await session.waitForTerminal();
 
     expect(session.id).toStartWith("session_");
-    expect(runner.commands).toEqual([
-      { type: "prompt", state: turnState, message: "hello", behavior: "follow_up" },
-    ]);
+    expect(runner.commands).toEqual([{ type: "prompt", message: "hello", behavior: "follow_up" }]);
   });
 
   testIfDocker("forwards follow-up queue edits to the runner", async () => {
@@ -229,8 +230,8 @@ describe("Session", () => {
     await waitFor(() => runner.commands.length >= 2);
 
     expect(runner.commands).toEqual([
-      { type: "prompt", state: turnState, message: "poll", behavior: "follow_up" },
-      { type: "wake", state: sleeping },
+      { type: "prompt", message: "poll", behavior: "follow_up" },
+      { type: "wake" },
     ]);
   });
 
@@ -286,7 +287,7 @@ describe("Session", () => {
     await second.waitForTerminal();
 
     expect(secondTurnRunner.commands).toEqual([
-      { type: "prompt", state: turnState, message: "continue", behavior: "follow_up" },
+      { type: "prompt", message: "continue", behavior: "follow_up" },
     ]);
   });
 
@@ -300,8 +301,8 @@ describe("Session", () => {
     await session.prompt({ message: "steer now", behavior: "steer" });
 
     expect(runner.commands).toEqual([
-      { type: "prompt", state: turnState, message: "start", behavior: "follow_up" },
-      { type: "prompt", state: turnState, message: "steer now", behavior: "steer" },
+      { type: "prompt", message: "start", behavior: "follow_up" },
+      { type: "prompt", message: "steer now", behavior: "steer" },
     ]);
   });
 
@@ -315,8 +316,8 @@ describe("Session", () => {
     await session.prompt({ message: "queue later", behavior: "follow_up" });
 
     expect(runner.commands).toEqual([
-      { type: "prompt", state: turnState, message: "start", behavior: "follow_up" },
-      { type: "prompt", state: turnState, message: "queue later", behavior: "follow_up" },
+      { type: "prompt", message: "start", behavior: "follow_up" },
+      { type: "prompt", message: "queue later", behavior: "follow_up" },
     ]);
   });
 
@@ -335,7 +336,6 @@ describe("Session", () => {
 
     expect(runner.commands.at(-1)).toMatchObject({
       type: "answer",
-      state: waiting,
       behavior: "follow_up",
     });
   });
@@ -381,7 +381,7 @@ describe("Session", () => {
     if (!interrupted || interrupted.type !== "interrupted") {
       throw new Error("Expected interrupted event");
     }
-    const staleWake = await runner.turn({ type: "wake", state: interrupted.state });
+    const staleWake = await runner.turn({ type: "wake" });
 
     expect(staleWake).toMatchObject({
       type: "complete",
@@ -439,8 +439,8 @@ describe("Session", () => {
       await session.prompt({ message: "next" });
 
       expect(runner.commands).toEqual([
-        { type: "prompt", state: turnState, message: "start", behavior: "follow_up" },
-        { type: "prompt", state: turnState, message: "next", behavior: "follow_up" },
+        { type: "prompt", message: "start", behavior: "follow_up" },
+        { type: "prompt", message: "next", behavior: "follow_up" },
       ]);
     },
   );
@@ -482,10 +482,10 @@ describe("SessionManager", () => {
     expect(manager.get("first")).toBe(first);
     expect(manager.get("second")).toBe(second);
     expect(runners.get("first")?.commands).toEqual([
-      { type: "prompt", state: turnState, message: "one", behavior: "follow_up" },
+      { type: "prompt", message: "one", behavior: "follow_up" },
     ]);
     expect(runners.get("second")?.commands).toEqual([
-      { type: "prompt", state: turnState, message: "two", behavior: "follow_up" },
+      { type: "prompt", message: "two", behavior: "follow_up" },
     ]);
     expect(
       events.some((event) => event.sessionId === "first" && event.event.type === "session_started"),

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -6,7 +6,7 @@ import type { Skill } from "@mariozechner/pi-coding-agent";
 import dedent from "dedent";
 import { TurnRunner } from "../src/turn-runner/turn-runner.js";
 import { testIfDocker } from "./helpers/docker-only.js";
-import { createTurnRunner } from "./helpers/turn-runner-protocol.js";
+import { createTurnRunner, startTurn } from "./helpers/turn-runner-protocol.js";
 import { createTestTurnRunner, type TestTurnRunnerApp } from "./helpers/skills-turn-runner.js";
 
 let app: TestTurnRunnerApp | undefined;
@@ -206,7 +206,9 @@ describe("TurnRunner skills", () => {
         ],
       });
 
-      await runner.turn({ type: "start", prompt: "/review audit this diff" });
+      await (
+        await startTurn(runner, { prompt: "/review audit this diff" })
+      ).turn;
 
       expect(runner.workerInputs[0]?.prompt).toBe(dedent`
       /review audit this diff
@@ -280,7 +282,9 @@ describe("TurnRunner skills", () => {
       ],
     });
 
-    await runner.turn({ type: "start", prompt: "/review /repo-map audit this diff" });
+    await (
+      await startTurn(runner, { prompt: "/review /repo-map audit this diff" })
+    ).turn;
 
     expect(runner.workerInputs[0]?.prompt).toBe(dedent`
       /review /repo-map audit this diff
@@ -343,7 +347,9 @@ describe("TurnRunner skills", () => {
       ],
     });
 
-    await runner.turn({ type: "start", prompt: "audit this diff /review carefully" });
+    await (
+      await startTurn(runner, { prompt: "audit this diff /review carefully" })
+    ).turn;
 
     expect(runner.workerInputs[0]?.prompt).toBe(dedent`
       audit this diff /review carefully
@@ -390,7 +396,9 @@ describe("TurnRunner skills", () => {
       ],
     });
 
-    await runner.turn({ type: "start", prompt: "/missing /review audit this diff" });
+    await (
+      await startTurn(runner, { prompt: "/missing /review audit this diff" })
+    ).turn;
 
     expect(runner.workerInputs[0]?.prompt).toBe(dedent`
       /missing /review audit this diff
@@ -412,13 +420,15 @@ describe("TurnRunner skills", () => {
   test("leaves unknown slash command prompts unchanged at runner level", async () => {
     const { runner } = createTurnRunner({ mode: "agent" });
 
-    await runner.turn({ type: "start", prompt: "/missing do work" });
+    await (
+      await startTurn(runner, { prompt: "/missing do work" })
+    ).turn;
 
     expect(runner.workerInputs[0]?.prompt).toBe("/missing do work");
   });
 
   testIfDocker("discovers project skills from .duet in the configured cwd", async () => {
-    app = createTestTurnRunner();
+    app = await createTestTurnRunner();
     const skillPath = await app.addProjectDuetSkill({
       name: "code-review",
       description: "Review changed code for correctness and simplicity.",
@@ -437,7 +447,7 @@ describe("TurnRunner skills", () => {
   });
 
   testIfDocker("discovers standard project skills from .agents in the configured cwd", async () => {
-    app = createTestTurnRunner();
+    app = await createTestTurnRunner();
     const skillPath = await app.addProjectAgentSkill({
       name: "standard-review",
       description: "Review changed code from the standard skill directory.",
@@ -454,7 +464,7 @@ describe("TurnRunner skills", () => {
   });
 
   testIfDocker("discovers project skills from both .duet and .agents", async () => {
-    app = createTestTurnRunner();
+    app = await createTestTurnRunner();
     const duetSkillPath = await app.addProjectDuetSkill({
       name: "duet-docs",
       description: "Document Duet-specific workflows.",
@@ -486,7 +496,7 @@ describe("TurnRunner skills", () => {
   });
 
   testIfDocker("discovers global skills from .duet in the home directory", async () => {
-    app = createTestTurnRunner();
+    app = await createTestTurnRunner();
     const skillPath = await app.addGlobalDuetSkill({
       name: "release-notes",
       description: "Draft concise release notes from completed work.",
@@ -502,7 +512,7 @@ describe("TurnRunner skills", () => {
   });
 
   testIfDocker("discovers standard global skills from .agents in the home directory", async () => {
-    app = createTestTurnRunner();
+    app = await createTestTurnRunner();
     const skillPath = await app.addGlobalAgentSkill({
       name: "standard-release-notes",
       description: "Draft release notes from the standard skill directory.",
@@ -519,7 +529,7 @@ describe("TurnRunner skills", () => {
   });
 
   testIfDocker("parses block scalar skill descriptions", async () => {
-    app = createTestTurnRunner();
+    app = await createTestTurnRunner();
     await app.addProjectDuetSkill({
       name: "browser-qa",
       description: "|\n  Fast headless browser for QA testing.\n  Use when checking UI flows.",
@@ -534,7 +544,7 @@ describe("TurnRunner skills", () => {
   });
 
   testIfDocker("expands bash commands when injecting selected skill instructions", async () => {
-    app = createTestTurnRunner();
+    app = await createTestTurnRunner();
     await app.addProjectDuetSkill({
       name: "repo-map",
       description: "Summarize the files in the current repository.",

--- a/test/turn-runner-active-turns.test.ts
+++ b/test/turn-runner-active-turns.test.ts
@@ -62,12 +62,11 @@ class StreamingTurnRunner extends TurnRunner {
 describe("TurnRunner active turns", () => {
   test("repeated prompt turns join the active agent chain and emit one terminal", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn: first } = await startTurn(runner, { mode: "agent", prompt: "first" });
+    const { turn: first } = await startTurn(runner, { mode: "agent", prompt: "first" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const second = runner.turn({
       type: "prompt",
-      state,
       message: "second",
       behavior: "follow_up",
     });
@@ -93,12 +92,11 @@ describe("TurnRunner active turns", () => {
 
   test("editing active follow-up queue replaces queued prompts", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn: first } = await startTurn(runner, { mode: "agent", prompt: "first" });
+    const { turn: first } = await startTurn(runner, { mode: "agent", prompt: "first" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const queued = runner.turn({
       type: "prompt",
-      state,
       message: "queued before edit",
       behavior: "follow_up",
     });
@@ -125,12 +123,11 @@ describe("TurnRunner active turns", () => {
 
   test("steer is handled through turn and still shares the active terminal", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn: first } = await startTurn(runner, { mode: "agent", prompt: "first" });
+    const { turn: first } = await startTurn(runner, { mode: "agent", prompt: "first" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const steer = runner.turn({
       type: "prompt",
-      state,
       message: "steer now",
       behavior: "steer",
     });
@@ -147,7 +144,7 @@ describe("TurnRunner active turns", () => {
 
   test("answers behave like prompts after serialization during active turns", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn: first } = await startTurn(runner, {
+    const { turn: first } = await startTurn(runner, {
       mode: "agent",
       prompt: "ask me later",
     });
@@ -155,7 +152,6 @@ describe("TurnRunner active turns", () => {
 
     const answer = runner.turn({
       type: "answer",
-      state,
       questions: [{ question: "Pick one", options: [{ label: "A" }] }],
       answers: { choice: "A" },
       behavior: "follow_up",
@@ -178,7 +174,6 @@ describe("TurnRunner active turns", () => {
 
     const wake = runner.turn({
       type: "wake",
-      state: { ...createStateMachineState("poll_email_reply"), status: "sleeping" },
     });
 
     runner.completeNext("done");
@@ -195,7 +190,7 @@ describe("TurnRunner active turns", () => {
 
   test("prompts sent during script work run before state-machine continuation", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, {
+    const { turn } = await startTurn(runner, {
       mode: scriptThenTerminalDefinition(),
       prompt: "run script flow",
     });
@@ -212,7 +207,6 @@ describe("TurnRunner active turns", () => {
 
     const prompt = runner.turn({
       type: "prompt",
-      state,
       message: "question during script",
       behavior: "follow_up",
     });
@@ -236,7 +230,7 @@ describe("TurnRunner active turns", () => {
 
   test("answers sent during script work run before state-machine continuation", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, {
+    const { turn } = await startTurn(runner, {
       mode: scriptThenTerminalDefinition(),
       prompt: "run script flow",
     });
@@ -253,7 +247,6 @@ describe("TurnRunner active turns", () => {
 
     const answer = runner.turn({
       type: "answer",
-      state,
       questions: [{ question: "Pick one", options: [{ label: "A" }] }],
       answers: { choice: "A" },
       behavior: "follow_up",
@@ -277,7 +270,7 @@ describe("TurnRunner active turns", () => {
 
   test("steer prompts sent during script work run before state-machine continuation", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, {
+    const { turn } = await startTurn(runner, {
       mode: scriptThenTerminalDefinition(),
       prompt: "run script flow",
     });
@@ -294,7 +287,6 @@ describe("TurnRunner active turns", () => {
 
     const steer = runner.turn({
       type: "prompt",
-      state,
       message: "steer during script",
       behavior: "steer",
     });
@@ -317,7 +309,7 @@ describe("TurnRunner active turns", () => {
 
   test("prompts sent during poll checks run immediately and return to sleep when unresolved", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, {
+    const { turn } = await startTurn(runner, {
       mode: unresolvedPollDefinition(),
       prompt: "run poll flow",
     });
@@ -332,7 +324,6 @@ describe("TurnRunner active turns", () => {
 
     const prompt = runner.turn({
       type: "prompt",
-      state,
       message: "question during poll",
       behavior: "follow_up",
     });
@@ -349,7 +340,7 @@ describe("TurnRunner active turns", () => {
 
   test("steer prompts sent during poll checks run immediately and return to sleep", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, {
+    const { turn } = await startTurn(runner, {
       mode: unresolvedPollDefinition(),
       prompt: "run poll flow",
     });
@@ -364,7 +355,6 @@ describe("TurnRunner active turns", () => {
 
     const steer = runner.turn({
       type: "prompt",
-      state,
       message: "steer during poll",
       behavior: "steer",
     });
@@ -389,7 +379,6 @@ describe("TurnRunner active turns", () => {
 
     const wake = runner.turn({
       type: "wake",
-      state: { ...createStateMachineState("poll_email_reply"), status: "sleeping" },
     });
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -405,7 +394,7 @@ describe("TurnRunner active turns", () => {
 
   test("additional prompts during a mid-poll answer join the active parent agent", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, {
+    const { turn } = await startTurn(runner, {
       mode: unresolvedPollDefinition(),
       prompt: "run poll flow",
     });
@@ -420,7 +409,6 @@ describe("TurnRunner active turns", () => {
 
     const firstPrompt = runner.turn({
       type: "prompt",
-      state,
       message: "first question during poll",
       behavior: "follow_up",
     });
@@ -428,7 +416,6 @@ describe("TurnRunner active turns", () => {
 
     const secondPrompt = runner.turn({
       type: "prompt",
-      state,
       message: "second question during poll",
       behavior: "follow_up",
     });
@@ -451,7 +438,7 @@ describe("TurnRunner active turns", () => {
 
   test("resolved polls enqueue state-machine continuation after the mid-poll agent answer", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, {
+    const { turn } = await startTurn(runner, {
       mode: resolvedPollDefinition(),
       prompt: "run resolved poll flow",
     });
@@ -466,7 +453,6 @@ describe("TurnRunner active turns", () => {
 
     const prompt = runner.turn({
       type: "prompt",
-      state,
       message: "question during resolving poll",
       behavior: "follow_up",
     });
@@ -495,10 +481,10 @@ describe("TurnRunner active turns", () => {
       ...createStateMachineState("poll_email_reply"),
       status: "sleeping" as const,
     };
+    await runner.start({ type: "start", state: sleeping });
 
     const turn = runner.turn({
       type: "prompt",
-      state: sleeping,
       message: "anything new?",
       behavior: "follow_up",
     });
@@ -525,7 +511,6 @@ describe("TurnRunner active turns", () => {
 
     const wake = runner.turn({
       type: "wake",
-      state: { ...createStateMachineState("poll_email_reply"), status: "sleeping" },
     });
 
     runner.completeNext("", { error: "model failed" });
@@ -541,18 +526,17 @@ describe("TurnRunner active turns", () => {
 
   test("interrupt drops queued work and emits one interrupted terminal", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn: first } = await startTurn(runner, { mode: "agent", prompt: "start" });
+    const { turn: first } = await startTurn(runner, { mode: "agent", prompt: "start" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const followUp = runner.turn({
       type: "prompt",
-      state,
       message: "queued",
       behavior: "follow_up",
     });
     await waitFor(() => followUpQueueEvents(events).some((queue) => queue[0] === "queued"));
     expect(followUpQueueEvents(events)).toContainEqual(["queued"]);
-    runner.interrupt({ type: "interrupt", state });
+    runner.interrupt({ type: "interrupt" });
     runner.completeNext("", { error: "aborted" });
 
     const [firstTerminal, followUpTerminal] = await Promise.all([first, followUp]);
@@ -565,16 +549,14 @@ describe("TurnRunner active turns", () => {
 
   test("dispose drops queued work without starting another command", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, { mode: "agent", prompt: "start" });
+    const { turn } = await startTurn(runner, { mode: "agent", prompt: "start" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const wake = runner.turn({
       type: "wake",
-      state: { ...createStateMachineState("poll_email_reply"), status: "sleeping" },
     });
     void runner.turn({
       type: "prompt",
-      state,
       message: "queued before dispose",
       behavior: "follow_up",
     });
@@ -599,7 +581,7 @@ describe("TurnRunner active turns", () => {
 
   test("answers can follow up the active child agent directly", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, {
+    const { turn } = await startTurn(runner, {
       mode: childAgentDefinition(),
       prompt: "run child flow",
     });
@@ -617,7 +599,6 @@ describe("TurnRunner active turns", () => {
 
     const answer = runner.turn({
       type: "answer",
-      state,
       questions: [{ question: "Child question", options: [{ label: "A" }] }],
       answers: { choice: "A" },
       behavior: "follow_up",
@@ -639,7 +620,7 @@ describe("TurnRunner active turns", () => {
 
   test("prompts during active child agent work queue for the parent", async () => {
     const { runner, events } = createStreamingRunner();
-    const { state, turn } = await startTurn(runner, {
+    const { turn } = await startTurn(runner, {
       mode: childAgentDefinition(),
       prompt: "run child flow",
     });
@@ -657,7 +638,6 @@ describe("TurnRunner active turns", () => {
 
     const prompt = runner.turn({
       type: "prompt",
-      state,
       message: "parent should handle this",
       behavior: "follow_up",
     });

--- a/test/turn-runner-active-turns.test.ts
+++ b/test/turn-runner-active-turns.test.ts
@@ -6,7 +6,7 @@ import type { TurnEvent, TurnState, TurnTerminalEvent } from "../src/types/proto
 import type { StateMachineDefinition } from "../src/types/state-machine.js";
 import { delay, waitFor } from "./helpers/async.js";
 import { createAssistantMessage } from "./helpers/messages.js";
-import { createStateMachineState } from "./helpers/turn-runner-protocol.js";
+import { createStateMachineState, startTurn } from "./helpers/turn-runner-protocol.js";
 
 class StreamingTurnRunner extends TurnRunner {
   readonly contexts: Context[] = [];
@@ -62,8 +62,7 @@ class StreamingTurnRunner extends TurnRunner {
 describe("TurnRunner active turns", () => {
   test("repeated prompt turns join the active agent chain and emit one terminal", async () => {
     const { runner, events } = createStreamingRunner();
-    const first = runner.turn({ type: "start", mode: "agent", prompt: "first" });
-    const state = await waitForStartedState(events);
+    const { state, turn: first } = await startTurn(runner, { mode: "agent", prompt: "first" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const second = runner.turn({
@@ -94,8 +93,7 @@ describe("TurnRunner active turns", () => {
 
   test("editing active follow-up queue replaces queued prompts", async () => {
     const { runner, events } = createStreamingRunner();
-    const first = runner.turn({ type: "start", mode: "agent", prompt: "first" });
-    const state = await waitForStartedState(events);
+    const { state, turn: first } = await startTurn(runner, { mode: "agent", prompt: "first" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const queued = runner.turn({
@@ -127,8 +125,7 @@ describe("TurnRunner active turns", () => {
 
   test("steer is handled through turn and still shares the active terminal", async () => {
     const { runner, events } = createStreamingRunner();
-    const first = runner.turn({ type: "start", mode: "agent", prompt: "first" });
-    const state = await waitForStartedState(events);
+    const { state, turn: first } = await startTurn(runner, { mode: "agent", prompt: "first" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const steer = runner.turn({
@@ -150,8 +147,10 @@ describe("TurnRunner active turns", () => {
 
   test("answers behave like prompts after serialization during active turns", async () => {
     const { runner, events } = createStreamingRunner();
-    const first = runner.turn({ type: "start", mode: "agent", prompt: "ask me later" });
-    const state = await waitForStartedState(events);
+    const { state, turn: first } = await startTurn(runner, {
+      mode: "agent",
+      prompt: "ask me later",
+    });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const answer = runner.turn({
@@ -172,27 +171,9 @@ describe("TurnRunner active turns", () => {
     expect(messageTexts(firstTerminal.state).join("\n")).toContain("Here are my answers");
   });
 
-  test("start during an active turn rejects without creating another branch", async () => {
-    const { runner, events } = createStreamingRunner();
-    const first = runner.turn({ type: "start", mode: "agent", prompt: "first" });
-    await waitForStartedState(events);
-    await waitFor(() => runner.pendingStreams.length === 1);
-
-    const second = runner.turn({ type: "start", mode: "agent", prompt: "second" });
-    await expect(second).rejects.toThrow("Cannot start a new turn while another turn is active.");
-
-    runner.completeNext("first response");
-
-    const terminal = await first;
-    expect(terminal).toMatchObject({ type: "complete", status: "completed" });
-    expect(messageTexts(terminal.state)).not.toContain("second");
-    expect(terminalEvents(events)).toHaveLength(1);
-  });
-
   test("queued wake rebases onto latest state and no-ops when no longer sleeping on a poll", async () => {
     const { runner, events } = createStreamingRunner();
-    const first = runner.turn({ type: "start", mode: "agent", prompt: "finish work" });
-    await waitForStartedState(events);
+    const { turn: first } = await startTurn(runner, { mode: "agent", prompt: "finish work" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const wake = runner.turn({
@@ -214,12 +195,10 @@ describe("TurnRunner active turns", () => {
 
   test("prompts sent during script work run before state-machine continuation", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { state, turn } = await startTurn(runner, {
       mode: scriptThenTerminalDefinition(),
       prompt: "run script flow",
     });
-    const state = await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -257,12 +236,10 @@ describe("TurnRunner active turns", () => {
 
   test("answers sent during script work run before state-machine continuation", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { state, turn } = await startTurn(runner, {
       mode: scriptThenTerminalDefinition(),
       prompt: "run script flow",
     });
-    const state = await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -300,12 +277,10 @@ describe("TurnRunner active turns", () => {
 
   test("steer prompts sent during script work run before state-machine continuation", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { state, turn } = await startTurn(runner, {
       mode: scriptThenTerminalDefinition(),
       prompt: "run script flow",
     });
-    const state = await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -342,12 +317,10 @@ describe("TurnRunner active turns", () => {
 
   test("prompts sent during poll checks run immediately and return to sleep when unresolved", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { state, turn } = await startTurn(runner, {
       mode: unresolvedPollDefinition(),
       prompt: "run poll flow",
     });
-    const state = await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -376,12 +349,10 @@ describe("TurnRunner active turns", () => {
 
   test("steer prompts sent during poll checks run immediately and return to sleep", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { state, turn } = await startTurn(runner, {
       mode: unresolvedPollDefinition(),
       prompt: "run poll flow",
     });
-    const state = await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -410,12 +381,10 @@ describe("TurnRunner active turns", () => {
 
   test("queued wake behind state-machine work rebases onto sleeping poll state", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { turn } = await startTurn(runner, {
       mode: immediateUnresolvedPollDefinition(),
       prompt: "run poll flow",
     });
-    await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const wake = runner.turn({
@@ -436,12 +405,10 @@ describe("TurnRunner active turns", () => {
 
   test("additional prompts during a mid-poll answer join the active parent agent", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { state, turn } = await startTurn(runner, {
       mode: unresolvedPollDefinition(),
       prompt: "run poll flow",
     });
-    const state = await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -484,12 +451,10 @@ describe("TurnRunner active turns", () => {
 
   test("resolved polls enqueue state-machine continuation after the mid-poll agent answer", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { state, turn } = await startTurn(runner, {
       mode: resolvedPollDefinition(),
       prompt: "run resolved poll flow",
     });
-    const state = await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -555,8 +520,7 @@ describe("TurnRunner active turns", () => {
 
   test("failed active turns emit one failed terminal and drop queued commands", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({ type: "start", mode: "agent", prompt: "start" });
-    await waitForStartedState(events);
+    const { turn } = await startTurn(runner, { mode: "agent", prompt: "start" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const wake = runner.turn({
@@ -577,8 +541,7 @@ describe("TurnRunner active turns", () => {
 
   test("interrupt drops queued work and emits one interrupted terminal", async () => {
     const { runner, events } = createStreamingRunner();
-    const first = runner.turn({ type: "start", mode: "agent", prompt: "start" });
-    const state = await waitForStartedState(events);
+    const { state, turn: first } = await startTurn(runner, { mode: "agent", prompt: "start" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const followUp = runner.turn({
@@ -602,8 +565,7 @@ describe("TurnRunner active turns", () => {
 
   test("dispose drops queued work without starting another command", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({ type: "start", mode: "agent", prompt: "start" });
-    await waitForStartedState(events);
+    const { state, turn } = await startTurn(runner, { mode: "agent", prompt: "start" });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     const wake = runner.turn({
@@ -612,7 +574,7 @@ describe("TurnRunner active turns", () => {
     });
     void runner.turn({
       type: "prompt",
-      state: await waitForStartedState(events),
+      state,
       message: "queued before dispose",
       behavior: "follow_up",
     });
@@ -637,12 +599,10 @@ describe("TurnRunner active turns", () => {
 
   test("answers can follow up the active child agent directly", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { state, turn } = await startTurn(runner, {
       mode: childAgentDefinition(),
       prompt: "run child flow",
     });
-    const state = await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -679,12 +639,10 @@ describe("TurnRunner active turns", () => {
 
   test("prompts during active child agent work queue for the parent", async () => {
     const { runner, events } = createStreamingRunner();
-    const turn = runner.turn({
-      type: "start",
+    const { state, turn } = await startTurn(runner, {
       mode: childAgentDefinition(),
       prompt: "run child flow",
     });
-    const state = await waitForStartedState(events);
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("select_state_machine_state", {
@@ -727,13 +685,6 @@ function createStreamingRunner(): { runner: StreamingTurnRunner; events: TurnEve
   const events: TurnEvent[] = [];
   runner.subscribe((event) => events.push(event));
   return { runner, events };
-}
-
-async function waitForStartedState(events: TurnEvent[]): Promise<TurnState> {
-  await waitFor(() => events.some((event) => event.type === "session_started"));
-  const event = events.find((item) => item.type === "session_started");
-  if (!event || event.type !== "session_started") throw new Error("Missing session_started event");
-  return event.state;
 }
 
 function terminalEvents(events: TurnEvent[]): TurnTerminalEvent[] {

--- a/test/turn-runner-events.test.ts
+++ b/test/turn-runner-events.test.ts
@@ -5,7 +5,7 @@ import { TurnRunner, type AgentWorkerInput } from "../src/turn-runner/turn-runne
 import type { TurnEvent } from "../src/types/protocol.js";
 import { waitFor } from "./helpers/async.js";
 import { createAssistantMessage } from "./helpers/messages.js";
-import { createTurnRunner } from "./helpers/turn-runner-protocol.js";
+import { createTurnRunner, startTurn } from "./helpers/turn-runner-protocol.js";
 
 class EventTurnRunner extends TurnRunner {
   emitAgentEventForTest(event: AgentEvent): void {
@@ -73,16 +73,14 @@ function createToolEventTurnRunner(): { runner: ToolEventTurnRunner; events: Tur
 }
 
 describe("TurnRunner event emission", () => {
-  test("emits ready, session_started, and the terminal event for a turn", async () => {
+  test("emits session_started and the terminal event for a turn", async () => {
     const { runner, events } = createTurnRunner();
 
-    const terminal = await runner.turn({
-      type: "start",
-      mode: "agent",
-      prompt: "Summarize this file.",
-    });
+    const terminal = await (
+      await startTurn(runner, { mode: "agent", prompt: "Summarize this file." })
+    ).turn;
 
-    expect(events.map((event) => event.type)).toEqual(["ready", "session_started", "complete"]);
+    expect(events.map((event) => event.type)).toEqual(["session_started", "complete"]);
     expect(events.at(-1)).toBe(terminal);
   });
 
@@ -221,7 +219,7 @@ describe("TurnRunner event emission", () => {
 
   test("emits todos events when todo_write runs", async () => {
     const { runner, events } = createToolEventTurnRunner();
-    const turn = runner.turn({ type: "start", mode: "agent", prompt: "Track work with todos." });
+    const { turn } = await startTurn(runner, { mode: "agent", prompt: "Track work with todos." });
     await waitFor(() => runner.pendingStreams.length === 1);
 
     runner.completeNextToolCall("todo_write", {

--- a/test/turn-runner-events.test.ts
+++ b/test/turn-runner-events.test.ts
@@ -73,14 +73,14 @@ function createToolEventTurnRunner(): { runner: ToolEventTurnRunner; events: Tur
 }
 
 describe("TurnRunner event emission", () => {
-  test("emits session_started and the terminal event for a turn", async () => {
+  test("emits turn_started and the terminal event for a turn", async () => {
     const { runner, events } = createTurnRunner();
 
     const terminal = await (
       await startTurn(runner, { mode: "agent", prompt: "Summarize this file." })
     ).turn;
 
-    expect(events.map((event) => event.type)).toEqual(["session_started", "complete"]);
+    expect(events.map((event) => event.type)).toEqual(["turn_started", "complete"]);
     expect(events.at(-1)).toBe(terminal);
   });
 

--- a/test/turn-runner-interrupt.test.ts
+++ b/test/turn-runner-interrupt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { startTurn } from "./helpers/turn-runner-protocol.js";
 import assert from "node:assert";
 import { Agent, type StreamFn } from "@mariozechner/pi-agent-core";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
@@ -60,8 +61,7 @@ describe("TurnRunner interrupts", () => {
     const events: TurnEvent[] = [];
     runner.subscribe((event) => events.push(event));
 
-    const turn = runner.turn({
-      type: "start",
+    const { turn } = await startTurn(runner, {
       mode: "agent",
       prompt: "Keep working until interrupted.",
     });

--- a/test/turn-runner-interrupt.test.ts
+++ b/test/turn-runner-interrupt.test.ts
@@ -73,7 +73,7 @@ describe("TurnRunner interrupts", () => {
     expect(turnState).toBeDefined();
     assert(turnState);
 
-    runner.interrupt({ type: "interrupt", state: turnState });
+    runner.interrupt({ type: "interrupt" });
 
     const terminal = await turn;
     const interruptedEvent = events.find((event) => event.type === "interrupted");

--- a/test/turn-runner-interrupt.test.ts
+++ b/test/turn-runner-interrupt.test.ts
@@ -67,7 +67,7 @@ describe("TurnRunner interrupts", () => {
     });
     await runner.streamStarted;
 
-    const turnState = events.find((event) => event.type === "session_started")?.state as
+    const turnState = events.find((event) => event.type === "turn_started")?.state as
       | TurnState
       | undefined;
     expect(turnState).toBeDefined();

--- a/test/turn-runner-memory.test.ts
+++ b/test/turn-runner-memory.test.ts
@@ -157,6 +157,52 @@ describe("TurnRunner memory", () => {
     ]);
   });
 
+  test("observational transform waits for a full new suffix after first observation", async () => {
+    const runner = new MemoryTransformTurnRunner({
+      model: "anthropic:claude-opus-4-7",
+      skillDiscovery: { includeDefaults: false },
+      memory: {
+        observation: {
+          messageTokens: 20,
+          bufferActivation: 10,
+        },
+        reflection: {
+          observationTokens: 1_000,
+          bufferActivation: 500,
+        },
+      },
+    });
+    await runner.appendObservationForTest(
+      '<observation-group id="test" range="msg_assistant_observed:msg_assistant_observed">\n* 🔴 Already observed the long message.\n</observation-group>',
+    );
+    const events: unknown[] = [];
+    runner.subscribe((event) => events.push(event));
+    const transform = runner.createMemoryTransformForTest({
+      provider: "unknown",
+      id: "test",
+    } as Model<any>);
+    const messages: AgentMessage[] = [
+      {
+        ...createAssistantMessage({ text: "x".repeat(100), timestamp: 1 }),
+        responseId: "observed",
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "tiny follow-up" }],
+        timestamp: 2,
+      },
+    ];
+
+    const transformed = await transform(messages);
+
+    expect(events.filter((event) => (event as { type?: string }).type === "memory")).toEqual([]);
+    expect(transformed).toHaveLength(3);
+    expect(transformed.at(-1)).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "tiny follow-up" }],
+    });
+  });
+
   test("observational transform emits reflection activity events", async () => {
     const runner = new MemoryTransformTurnRunner({
       model: "anthropic:claude-opus-4-7",

--- a/test/turn-runner-memory.test.ts
+++ b/test/turn-runner-memory.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { startTurn } from "./helpers/turn-runner-protocol.js";
 import { Agent, type AgentMessage } from "@mariozechner/pi-agent-core";
 import { createAssistantMessageEventStream, type Model } from "@mariozechner/pi-ai";
 import {
@@ -241,11 +242,9 @@ describe("TurnRunner memory", () => {
     const events: unknown[] = [];
     runner.subscribe((event) => events.push(event));
 
-    const terminal = await runner.turn({
-      type: "start",
-      prompt: "Check usage.",
-      mode: "agent",
-    });
+    const terminal = await (
+      await startTurn(runner, { mode: "agent", prompt: "Check usage." })
+    ).turn;
 
     expect(terminal.usage).toEqual({
       inputTokens: 16,

--- a/test/turn-runner-protocol.test.ts
+++ b/test/turn-runner-protocol.test.ts
@@ -18,7 +18,7 @@ describe("TurnRunner protocol scenarios", () => {
     ).turn;
 
     expect(events[0]).toMatchObject({
-      type: "session_started",
+      type: "turn_started",
       state: { status: "running", mode: "auto", agent: { status: "running" } },
     });
     expect(events.some((event) => event.type === "state_machine")).toBe(false);
@@ -71,7 +71,7 @@ describe("TurnRunner protocol scenarios", () => {
     const terminal = await (await startTurn(runner, { mode: "auto", prompt })).turn;
 
     expect(events[0]).toMatchObject({
-      type: "session_started",
+      type: "turn_started",
       state: {
         status: "running",
         mode: "auto",
@@ -296,7 +296,7 @@ describe("TurnRunner protocol scenarios", () => {
     const terminal = await (await startTurn(runner, { mode: definition, prompt })).turn;
 
     expect(events[0]).toMatchObject({
-      type: "session_started",
+      type: "turn_started",
       state: {
         status: "running",
         mode: definition,
@@ -332,7 +332,7 @@ describe("TurnRunner protocol scenarios", () => {
     ).turn;
 
     expect(events[0]).toMatchObject({
-      type: "session_started",
+      type: "turn_started",
       state: { status: "running", mode: definition, agent: { status: "running" } },
     });
     expect(terminal).toMatchObject({

--- a/test/turn-runner-protocol.test.ts
+++ b/test/turn-runner-protocol.test.ts
@@ -5,6 +5,7 @@ import {
   createTurnRunner,
   createOutreachStateMachine,
   createStateMachineState,
+  startTurn,
 } from "./helpers/turn-runner-protocol.js";
 import { createAssistantMessage } from "./helpers/messages.js";
 
@@ -12,14 +13,11 @@ describe("TurnRunner protocol scenarios", () => {
   test("runs a simple auto-classified prompt in agent mode", async () => {
     const { runner, events } = createTurnRunner();
 
-    const terminal = await runner.turn({
-      type: "start",
-      prompt: "Summarize this file.",
-      mode: "auto",
-    });
+    const terminal = await (
+      await startTurn(runner, { mode: "auto", prompt: "Summarize this file." })
+    ).turn;
 
-    expect(events[0]).toMatchObject({ type: "ready" });
-    expect(events[1]).toMatchObject({
+    expect(events[0]).toMatchObject({
       type: "session_started",
       state: { status: "running", mode: "auto", agent: { status: "running" } },
     });
@@ -44,11 +42,9 @@ describe("TurnRunner protocol scenarios", () => {
       ],
     });
 
-    const terminal = await runner.turn({
-      type: "start",
-      prompt: "Deploy the app.",
-      mode: "agent",
-    });
+    const terminal = await (
+      await startTurn(runner, { mode: "agent", prompt: "Deploy the app." })
+    ).turn;
 
     expect(terminal).toMatchObject({
       type: "ask",
@@ -72,14 +68,9 @@ describe("TurnRunner protocol scenarios", () => {
       firstState: "research_prospect",
     });
 
-    const terminal = await runner.turn({
-      type: "start",
-      prompt,
-      mode: "auto",
-    });
+    const terminal = await (await startTurn(runner, { mode: "auto", prompt })).turn;
 
-    expect(events[0]).toMatchObject({ type: "ready" });
-    expect(events[1]).toMatchObject({
+    expect(events[0]).toMatchObject({
       type: "session_started",
       state: {
         status: "running",
@@ -136,11 +127,9 @@ describe("TurnRunner protocol scenarios", () => {
       return result;
     };
 
-    const terminal = await runner.turn({
-      type: "start",
-      prompt: "Prospect Ada until she books a meeting.",
-      mode: "auto",
-    });
+    const terminal = await (
+      await startTurn(runner, { mode: "auto", prompt: "Prospect Ada until she books a meeting." })
+    ).turn;
 
     expect(terminal).toMatchObject({
       type: "complete",
@@ -305,14 +294,9 @@ describe("TurnRunner protocol scenarios", () => {
       decision: { kind: "run_state", state: "research_prospect" },
     });
 
-    const terminal = await runner.turn({
-      type: "start",
-      prompt,
-      mode: definition,
-    });
+    const terminal = await (await startTurn(runner, { mode: definition, prompt })).turn;
 
-    expect(events[0]).toMatchObject({ type: "ready" });
-    expect(events[1]).toMatchObject({
+    expect(events[0]).toMatchObject({
       type: "session_started",
       state: {
         status: "running",
@@ -344,14 +328,11 @@ describe("TurnRunner protocol scenarios", () => {
     const { runner, events } = createTurnRunner();
     const definition = createOutreachStateMachine();
 
-    const terminal = await runner.turn({
-      type: "start",
-      prompt: "What is the capital of France?",
-      mode: definition,
-    });
+    const terminal = await (
+      await startTurn(runner, { mode: definition, prompt: "What is the capital of France?" })
+    ).turn;
 
-    expect(events[0]).toMatchObject({ type: "ready" });
-    expect(events[1]).toMatchObject({
+    expect(events[0]).toMatchObject({
       type: "session_started",
       state: { status: "running", mode: definition, agent: { status: "running" } },
     });
@@ -371,11 +352,12 @@ describe("TurnRunner protocol scenarios", () => {
       decision: { kind: "run_state", state: "invented_state" },
     });
 
-    const terminal = await runner.turn({
-      type: "start",
-      prompt: "Prospect Ada until she books a meeting.",
-      mode: definition,
-    });
+    const terminal = await (
+      await startTurn(runner, {
+        mode: definition,
+        prompt: "Prospect Ada until she books a meeting.",
+      })
+    ).turn;
 
     if (terminal.type !== "complete") {
       throw new Error("Expected complete event");

--- a/test/turn-runner-protocol.test.ts
+++ b/test/turn-runner-protocol.test.ts
@@ -146,6 +146,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("uses a steering prompt to update and continue an active state-machine session", async () => {
     const { runner, events } = createTurnRunner();
     const turnState = createStateMachineState("waiting_for_reply");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push({
       type: "select_state_machine_state",
       decision: { kind: "run_state", state: "classify_reply" },
@@ -153,7 +154,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "I've already received this email: yes, happy to meet next week.",
       behavior: "steer",
     });
@@ -172,10 +172,10 @@ describe("TurnRunner protocol scenarios", () => {
   test("answers unrelated prompts during an active state-machine session without changing state", async () => {
     const { runner, events } = createTurnRunner();
     const turnState = createStateMachineState("waiting_for_reply");
+    await runner.start({ type: "start", state: turnState });
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "What is the capital of France?",
       behavior: "follow_up",
     });
@@ -195,6 +195,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("sleeps between poll attempts while waiting for an external email response", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("poll_email_reply");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push({
       type: "select_state_machine_state",
       decision: { kind: "run_state", state: "poll_email_reply" },
@@ -202,7 +203,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Continue polling.",
       behavior: "follow_up",
     });
@@ -225,10 +225,10 @@ describe("TurnRunner protocol scenarios", () => {
       ...createStateMachineState("poll_email_reply"),
       status: "sleeping" as const,
     };
+    await runner.start({ type: "start", state: turnState });
 
     const terminal = await runner.turn({
       type: "wake",
-      state: turnState,
     });
 
     expect(terminal).toMatchObject({
@@ -243,23 +243,23 @@ describe("TurnRunner protocol scenarios", () => {
   test("wake is a no-op when the session is not sleeping on a poll", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("waiting_for_reply");
+    await runner.start({ type: "start", state: turnState });
 
     const terminal = await runner.turn({
       type: "wake",
-      state: turnState,
     });
 
     expect(terminal).toMatchObject({
       type: "complete",
       status: "completed",
       result: "Nothing to wake.",
-      state: turnState,
     });
   });
 
   test("interrupts a running turn and resolves it with the current session", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("send_email");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push({
       type: "select_state_machine_state",
       decision: { kind: "fail", reason: "Interrupted" },
@@ -267,7 +267,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const turn = runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Send the email now.",
       behavior: "steer",
     });
@@ -373,6 +372,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("uses transition overrides for one state attempt without mutating the definition", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("research_prospect");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push({
       type: "select_state_machine_state",
       decision: {
@@ -384,7 +384,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Focus on Grace.",
       behavior: "steer",
     });
@@ -398,6 +397,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("uses optional state agent system prompts without injecting state-machine context", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("research_prospect");
+    await runner.start({ type: "start", state: turnState });
     if (!turnState.stateMachine) throw new Error("Expected state machine session");
     turnState.stateMachine.definition = {
       ...turnState.stateMachine.definition,
@@ -414,7 +414,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Continue outreach.",
       behavior: "follow_up",
     });
@@ -447,6 +446,7 @@ describe("TurnRunner protocol scenarios", () => {
       ],
     });
     const turnState = createStateMachineState("research_prospect");
+    await runner.start({ type: "start", state: turnState });
     if (!turnState.stateMachine) throw new Error("Expected state machine session");
     turnState.stateMachine.definition = {
       ...turnState.stateMachine.definition,
@@ -463,7 +463,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Continue outreach.",
       behavior: "follow_up",
     });
@@ -475,6 +474,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("asks the parent runner for the next state immediately after a state completes", async () => {
     const { runner, events } = createTurnRunner();
     const turnState = createStateMachineState("waiting_for_reply");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push(
       {
         type: "select_state_machine_state",
@@ -489,7 +489,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Continue.",
       behavior: "follow_up",
     });
@@ -513,6 +512,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("renders parent-provided transition input into agent prompts", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("research_prospect");
+    await runner.start({ type: "start", state: turnState });
     assert(turnState.stateMachine);
     turnState.stateMachine.definition = {
       ...turnState.stateMachine.definition,
@@ -571,7 +571,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Continue.",
       behavior: "follow_up",
     });
@@ -592,7 +591,10 @@ describe("TurnRunner protocol scenarios", () => {
 
   test("timer poll continues without script and forwards elapsed output", async () => {
     const { runner } = createTurnRunner();
-    const turnState = createStateMachineState("wait_before_retry");
+    const turnState = {
+      ...createStateMachineState("wait_before_retry"),
+      status: "sleeping" as const,
+    };
     const startedAt = Date.now() - 12_000;
     turnState.stateMachine?.history.push({
       type: "state_started",
@@ -603,10 +605,10 @@ describe("TurnRunner protocol scenarios", () => {
       type: "select_state_machine_state",
       decision: { kind: "terminal", state: "meeting_scheduled" },
     });
+    await runner.start({ type: "start", state: turnState });
 
     const terminal = await runner.turn({
       type: "wake",
-      state: { ...turnState, status: "sleeping" },
     });
 
     expect(runner.workerInputs).toHaveLength(1);
@@ -628,6 +630,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("timer poll sleeps when first selected before producing output on wake", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("wait_before_retry");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push({
       type: "select_state_machine_state",
       decision: { kind: "run_state", state: "wait_before_retry" },
@@ -635,7 +638,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Wait before retrying.",
       behavior: "follow_up",
     });
@@ -653,7 +655,10 @@ describe("TurnRunner protocol scenarios", () => {
 
   test("poll timeout fails after the maximum time in the poll state", async () => {
     const { runner } = createTurnRunner();
-    const turnState = createStateMachineState("wait_before_retry");
+    const turnState = {
+      ...createStateMachineState("wait_before_retry"),
+      status: "sleeping" as const,
+    };
     const startedAt = Date.now() - 10_000;
     if (!turnState.stateMachine) throw new Error("Expected state machine session");
     turnState.stateMachine.definition = {
@@ -669,10 +674,10 @@ describe("TurnRunner protocol scenarios", () => {
       timestamp: startedAt,
       state: "wait_before_retry",
     });
+    await runner.start({ type: "start", state: turnState });
 
     const terminal = await runner.turn({
       type: "wake",
-      state: { ...turnState, status: "sleeping" },
     });
 
     expect(terminal).toMatchObject({
@@ -689,6 +694,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("script states honor successCodes and forward stdout plus parsed state", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("send_email");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push(
       {
         type: "select_state_machine_state",
@@ -713,7 +719,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Send the email.",
       behavior: "follow_up",
     });
@@ -735,6 +740,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("retries when the parent runner does not choose the next state after completion", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("waiting_for_reply");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push({
       type: "select_state_machine_state",
       decision: { kind: "run_state", state: "research_prospect" },
@@ -742,7 +748,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Continue.",
       behavior: "follow_up",
     });
@@ -761,6 +766,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("cannot create a new state-machine definition while one is active", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("waiting_for_reply");
+    await runner.start({ type: "start", state: turnState });
     const definition = {
       name: "follow_up_flow",
       prompt: "Use after outreach needs a new follow-up process.",
@@ -787,7 +793,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Continue.",
       behavior: "follow_up",
     });
@@ -803,6 +808,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("can create a new state-machine definition after the previous one is terminal", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("meeting_scheduled");
+    await runner.start({ type: "start", state: turnState });
     assert(turnState.stateMachine);
     const terminalState = {
       ...turnState,
@@ -811,6 +817,7 @@ describe("TurnRunner protocol scenarios", () => {
         terminal: { state: "meeting_scheduled", status: "completed" as const },
       },
     };
+    await runner.start({ type: "start", state: terminalState });
     const definition = {
       name: "follow_up_flow",
       prompt: "Use after a completed outreach process needs follow-up.",
@@ -830,7 +837,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: terminalState,
       message: "Start a follow-up process.",
       behavior: "follow_up",
     });
@@ -851,6 +857,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("bubbles an agent state's ask terminal status to the parent turn runner", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("research_prospect");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push({
       type: "select_state_machine_state",
       decision: { kind: "run_state", state: "research_prospect" },
@@ -873,7 +880,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Continue.",
       behavior: "steer",
     });
@@ -887,6 +893,7 @@ describe("TurnRunner protocol scenarios", () => {
       ...createStateMachineState("research_prospect"),
       status: "waiting_for_human" as const,
     };
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push(
       { type: "none" },
       {
@@ -897,7 +904,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "answer",
-      state: turnState,
       questions: [{ question: "Which prospect?", options: [{ label: "Ada" }] }],
       answers: { prospect: "Ada Lovelace" },
       behavior: "follow_up",
@@ -938,6 +944,7 @@ describe("TurnRunner protocol scenarios", () => {
   test("lets the parent runner prompt the current state-machine agent", async () => {
     const { runner } = createTurnRunner();
     const turnState = createStateMachineState("waiting_for_reply");
+    await runner.start({ type: "start", state: turnState });
     runner.controlResults.push(
       {
         type: "prompt_state_machine_agent",
@@ -952,7 +959,6 @@ describe("TurnRunner protocol scenarios", () => {
 
     const terminal = await runner.turn({
       type: "prompt",
-      state: turnState,
       message: "Ada replied yes.",
       behavior: "follow_up",
     });

--- a/test/turn-runner-state-machine-agent-events.test.ts
+++ b/test/turn-runner-state-machine-agent-events.test.ts
@@ -6,7 +6,7 @@ import {
   type AgentWorkerResult,
 } from "../src/turn-runner/turn-runner.js";
 import type { TurnEvent } from "../src/types/protocol.js";
-import { createStateMachineState } from "./helpers/turn-runner-protocol.js";
+import { createOutreachStateMachine } from "./helpers/turn-runner-protocol.js";
 
 class StateMachineAgentEventTurnRunner extends TurnRunner {
   private workerCalls = 0;
@@ -87,10 +87,10 @@ describe("State-machine agent state events", () => {
     const runner = new StateMachineAgentEventTurnRunner();
     const events: TurnEvent[] = [];
     runner.subscribe((event) => events.push(event));
+    await runner.start({ type: "start", mode: createOutreachStateMachine() });
 
     await runner.turn({
       type: "prompt",
-      state: createStateMachineState("waiting_for_reply"),
       message: "Continue.",
       behavior: "follow_up",
     });


### PR DESCRIPTION
## Summary

- `start` is now a setup-only command: it loads memory and skills, emits `session_started`, and returns. No agent work runs. The CLI/TUI dispatches `start` at launch so the user sees the skill summary before typing the first prompt.
- The `ready` event is removed. Skills, agent files, and skill collisions are exposed through new session/runner methods (`getSkills`, `getResolvedAgentFiles`, `getSkillCollisions`); the TUI queries them directly when it boots.
- `TurnStartCommand` no longer carries a `prompt`; it gains an optional `state` for resumed sessions. `TurnCommand` drops `start`; only `TurnRunnerCommand` still includes it.
- `SessionManager.create` dispatches setup automatically and chains `session.prompt` only when an initial prompt was supplied.
- Test isolation: `createTestTurnRunner` now allocates a tempdir as `projectRoot`, so the runner's cwd no longer inherits whatever skills ship in the repo or developer's home — putting a skill in the repo's `.agents` folder won't pollute tests anymore.
- Adds `test/cli-skills.test.ts` covering the `{ name, description, path, scope }` shape that the \`duet skills\` command returns.

## Verification

- 152/152 tests pass (`bun run test`).
- Lint clean (`bun run lint`).
- Typecheck clean (`bunx tsc --noEmit`).