### PR TITLE
feat: carry latest TurnState on every state-mutation event

### DIFF
--- a/evals/todo-tool.eval.ts
+++ b/evals/todo-tool.eval.ts
@@ -24,7 +24,7 @@ describe("todo tool", () => {
       const todoEvents: TurnTodo[][] = [];
       runner.subscribe((event) => {
         if (event.type === "todos") {
-          todoEvents.push(event.todos);
+          todoEvents.push(event.state.todos);
         }
       });
 

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -277,7 +277,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     if (event.type === "step") {
       renderStep(event.step);
     } else if (event.type === "todos") {
-      renderTodos(event.todos);
+      renderTodos(event.state.todos);
     } else if (event.type === "follow_up_queue") {
       renderFollowUpQueue(event.prompts);
     } else if (event.type === "memory") {

--- a/src/turn-runner/agent-worker.ts
+++ b/src/turn-runner/agent-worker.ts
@@ -6,7 +6,7 @@ import {
 } from "@mariozechner/pi-agent-core";
 import type { Skill } from "@mariozechner/pi-coding-agent";
 import { assistantText } from "../core/serializer.js";
-import type { TurnEvent, TurnOptions, TurnState, TurnTerminalEvent } from "../types/protocol.js";
+import type { TurnOptions, TurnState, TurnStep, TurnTerminalEvent } from "../types/protocol.js";
 import type { TodoWriteToolDetails, TurnRunnerControlResult } from "./tools.js";
 import { usageFromMessages } from "./usage-accounting.js";
 
@@ -33,8 +33,10 @@ export interface AgentWorkerRuntime {
     input: AgentWorkerInput,
     onControlResult?: (result: TurnRunnerControlResult) => void,
   ): Agent;
-  emitAgentEvent(event: AgentEvent): void;
+  emitAgentEvent(event: AgentEvent, agent: Agent): void;
   consumeInterruptedTerminal(): TurnTerminalEvent | undefined;
+  /** Returns the runner's latest TurnState snapshot, used to compose worker terminals. */
+  getCurrentState(): TurnState | undefined;
 }
 
 export async function runAgentWorker(
@@ -57,7 +59,7 @@ export async function runAgentWorker(
   });
   runtime.setActiveAgent(activeSlot, agent);
 
-  const unsubscribe = agent.subscribe((event) => runtime.emitAgentEvent(event));
+  const unsubscribe = agent.subscribe((event) => runtime.emitAgentEvent(event, agent));
   let interruptedDuringPrompt: TurnTerminalEvent | undefined;
   try {
     await agent.prompt(input.prompt);
@@ -79,8 +81,12 @@ export async function runAgentWorker(
   const messages = agent.state.messages;
   const usage = usageFromMessages(messages.slice(input.state.agent.messages.length));
   const status = agent.state.errorMessage ? "failed" : "completed";
+  // Pull the runner-owned state to capture mid-turn mutations (todos, etc.)
+  // that happened during this worker run; fall back to `input.state` for
+  // standalone callers that have no runner-owned snapshot.
+  const liveState = runtime.getCurrentState() ?? input.state;
   const state = {
-    ...input.state,
+    ...liveState,
     status,
     agent: {
       status,
@@ -103,7 +109,7 @@ export async function runAgentWorker(
 
 export function emitAgentEvent(
   event: AgentEvent,
-  emit: (event: TurnEvent) => void,
+  emitStep: (step: TurnStep) => void,
   removeFollowUpPrompt: (prompt: string) => void,
 ): void {
   if (event.type === "message_start" && event.message.role === "user") {
@@ -112,40 +118,34 @@ export function emitAgentEvent(
   if (event.type === "message_update") {
     const update = event.assistantMessageEvent;
     if (update.type === "text_delta") {
-      emit({ type: "step", step: { type: "text_delta", delta: update.delta } });
+      emitStep({ type: "text_delta", delta: update.delta });
     }
     if (update.type === "thinking_delta") {
-      emit({ type: "step", step: { type: "reasoning_delta", delta: update.delta } });
+      emitStep({ type: "reasoning_delta", delta: update.delta });
     }
     if (update.type === "text_end") {
-      emit({ type: "step", step: { type: "text", text: update.content } });
+      emitStep({ type: "text", text: update.content });
     }
     if (update.type === "thinking_end") {
-      emit({ type: "step", step: { type: "reasoning", text: update.content } });
+      emitStep({ type: "reasoning", text: update.content });
     }
   }
   if (event.type === "tool_execution_start") {
-    emit({
-      type: "step",
-      step: {
-        type: "tool_call",
-        toolName: event.toolName,
-        toolCallId: event.toolCallId,
-        status: "running",
-        input: event.args,
-      },
+    emitStep({
+      type: "tool_call",
+      toolName: event.toolName,
+      toolCallId: event.toolCallId,
+      status: "running",
+      input: event.args,
     });
   }
   if (event.type === "tool_execution_end") {
-    emit({
-      type: "step",
-      step: {
-        type: "tool_call",
-        toolName: event.toolName,
-        toolCallId: event.toolCallId,
-        status: event.isError ? "error" : "completed",
-        output: event.result?.content,
-      },
+    emitStep({
+      type: "tool_call",
+      toolName: event.toolName,
+      toolCallId: event.toolCallId,
+      status: event.isError ? "error" : "completed",
+      output: event.result?.content,
     });
   }
 }

--- a/src/turn-runner/state-machine-runtime.ts
+++ b/src/turn-runner/state-machine-runtime.ts
@@ -70,6 +70,7 @@ interface StateMachineRuntimeDeps {
   hasQueuedTurnCommands(): boolean;
   isDrainingQueuedCommandsBeforeContinuation(): boolean;
   setDrainingQueuedCommandsBeforeContinuation(value: boolean): void;
+  getCurrentState(): TurnState | undefined;
   setCurrentState(state: TurnState): void;
   consumeInterruptedTerminal(): TurnTerminalEvent | undefined;
   setActiveAbortController(controller: AbortController | undefined): void;
@@ -111,7 +112,12 @@ export class StateMachineRuntime {
       decision.kind === "run_state" ? decision.input : undefined,
     );
 
-    this.deps.emit({ type: "state_machine", currentState: effectiveState.name });
+    this.deps.setCurrentState(nextSession);
+    this.deps.emit({
+      type: "state_machine",
+      currentState: effectiveState.name,
+      state: nextSession,
+    });
 
     switch (effectiveState.kind) {
       case "agent":
@@ -172,7 +178,14 @@ export class StateMachineRuntime {
       "state_machine_child",
     );
     const childResult = childWorkerResult.terminal;
-    const parentSession = { ...session, agent: childResult.state.agent };
+    // Parent session = parent's everything (mode, stateMachine, latest todos)
+    // + the child's new agent transcript. Read from runner state so todo
+    // mutations made during the child worker run are preserved.
+    const parentBase = this.deps.getCurrentState() ?? session;
+    const parentSession: TurnState = {
+      ...parentBase,
+      agent: childResult.state.agent,
+    };
     const rawOutput = {
       result: childResult.type === "complete" ? childResult.result : undefined,
       childStatus: childResult.state.status,
@@ -535,6 +548,7 @@ export class StateMachineRuntime {
         status: "running",
         messages: [],
       },
+      todos: [],
     };
   }
 

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -27,6 +27,7 @@ import type {
   TurnOptions,
   TurnTodo,
 } from "../types/protocol.js";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { createStateMachineSystemPromptLayer } from "./prompts.js";
 import {
   createDefaultTurnRunnerTools,
@@ -88,8 +89,6 @@ export class TurnRunner {
   private state?: TurnState;
   /** User-visible mirror of follow-up prompts accepted by this runner. */
   private followUpQueuePrompts: string[] = [];
-  /** Current todo list emitted through todo protocol events. */
-  private todos: TurnTodo[] = [];
   /** Aggregates model usage across parent agents, child agents, and memory work for one turn chain. */
   private turnUsage?: TurnTokenUsage;
   /** Prevents queued user prompts from recursively preempting continuation prompts. */
@@ -118,6 +117,7 @@ export class TurnRunner {
       setDrainingQueuedCommandsBeforeContinuation: (value) => {
         this.drainingQueuedCommandsBeforeContinuation = value;
       },
+      getCurrentState: () => this.state,
       setCurrentState: (state) => {
         this.state = state;
       },
@@ -418,6 +418,36 @@ export class TurnRunner {
     }
   }
 
+  /** Shallow clone so emitted events do not share the runner's mutable wrapper. */
+  private snapshotState(): TurnState {
+    if (!this.state) {
+      throw new Error("Cannot snapshot turn state before start() has run.");
+    }
+    return {
+      ...this.state,
+      agent: { ...this.state.agent },
+      todos: [...this.state.todos],
+    };
+  }
+
+  /**
+   * Sync the runner's `state.agent` with the live agent's messages and status
+   * before emitting a `step` event. Callers snapshot the updated state into
+   * the emitted event payload.
+   */
+  protected syncAgentState(messages: AgentMessage[], errorMessage: string | undefined): void {
+    if (!this.state) return;
+    const status = errorMessage ? "failed" : "running";
+    this.state = {
+      ...this.state,
+      agent: {
+        ...this.state.agent,
+        status,
+        messages,
+      },
+    };
+  }
+
   private consumeInterruptedTerminal(): TurnTerminalEvent | undefined {
     const terminal = this.interruptedTerminal;
     this.interruptedTerminal = undefined;
@@ -584,9 +614,11 @@ export class TurnRunner {
   } {
     const cwd = this.config.cwd ?? process.cwd();
     const todoStorage = {
-      getTodos: () => this.todos,
+      getTodos: (): TurnTodo[] => this.state?.todos ?? [],
       setTodos: (todos: TurnTodo[]) => {
-        this.todos = todos;
+        if (this.state) {
+          this.state = { ...this.state, todos };
+        }
       },
     };
     const skills = this.skillContext.getSkills();
@@ -638,8 +670,9 @@ export class TurnRunner {
         },
         createAgent: (workerInput, onControlResult) =>
           this.createAgent(workerInput, onControlResult),
-        emitAgentEvent: (event) => this.emitAgentEvent(event),
+        emitAgentEvent: (event, agent) => this.emitAgentEvent(event, agent),
         consumeInterruptedTerminal: () => this.consumeInterruptedTerminal(),
+        getCurrentState: () => this.state,
       },
       input,
       activeSlot,
@@ -679,7 +712,7 @@ export class TurnRunner {
           onControlResult?.(context.result.details);
         }
         if (isTodoWriteToolDetails(context.result.details)) {
-          this.emit({ type: "todos", todos: context.result.details.todos });
+          this.emit({ type: "todos", state: this.snapshotState() });
         }
         return undefined;
       },
@@ -783,10 +816,13 @@ export class TurnRunner {
     return getModel(provider, model);
   }
 
-  protected emitAgentEvent(event: AgentEvent): void {
+  protected emitAgentEvent(event: AgentEvent, agent: Agent): void {
+    // Sync the live agent's messages/status into runner state so the snapshot
+    // attached to each `step` event reflects the agent's current transcript.
+    this.syncAgentState(agent.state.messages, agent.state.errorMessage);
     emitAgentWorkerEvent(
       event,
-      (turnEvent) => this.emit(turnEvent),
+      (step) => this.emit({ type: "step", step, state: this.snapshotState() }),
       (prompt) => this.removeFollowUpPrompt(prompt),
     );
   }

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -177,6 +177,8 @@ export interface TurnState {
   agent: AgentSession;
   /** Present when this session is executing in state-machine mode. */
   stateMachine?: StateMachineSession;
+  /** Current todo list for this session. Mutated by the TodoWrite tool. */
+  todos: TurnTodo[];
 }
 
 /**
@@ -369,14 +371,24 @@ export interface TurnStartedEvent {
   state: TurnState;
 }
 
-export interface TurnStepEvent {
+/**
+ * Events that mutate `TurnState` carry the latest snapshot so the session layer
+ * can persist mid-turn and resume from any event. Today this covers `step`,
+ * `todos`, and `state_machine`; `follow_up_queue`, `memory`, and `system` are
+ * UI/diagnostic signals and stay stateless.
+ */
+export interface TurnStateEvent {
+  /** Latest turn state at the moment this event was emitted. */
+  state: TurnState;
+}
+
+export interface TurnStepEvent extends TurnStateEvent {
   type: "step";
   step: TurnStep;
 }
 
-export interface TurnTodosEvent {
+export interface TurnTodosEvent extends TurnStateEvent {
   type: "todos";
-  todos: TurnTodo[];
 }
 
 export interface TurnFollowUpQueueEvent {
@@ -385,7 +397,7 @@ export interface TurnFollowUpQueueEvent {
   prompts: string[];
 }
 
-export interface TurnStateMachineEvent {
+export interface TurnStateMachineEvent extends TurnStateEvent {
   type: "state_machine";
   /** Display name/title of the current state. */
   currentState: string;

--- a/test/helpers/turn-runner-protocol.ts
+++ b/test/helpers/turn-runner-protocol.ts
@@ -115,6 +115,7 @@ export function createStateMachineState(currentState: string): TurnState {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     },
+    todos: [],
   };
 }
 

--- a/test/turn-runner-events.test.ts
+++ b/test/turn-runner-events.test.ts
@@ -1,16 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import { Agent, type AgentEvent } from "@mariozechner/pi-agent-core";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { emitAgentEvent } from "../src/turn-runner/agent-worker.js";
 import { TurnRunner, type AgentWorkerInput } from "../src/turn-runner/turn-runner.js";
-import type { TurnEvent } from "../src/types/protocol.js";
+import type { TurnEvent, TurnStep } from "../src/types/protocol.js";
 import { waitFor } from "./helpers/async.js";
 import { createAssistantMessage } from "./helpers/messages.js";
 import { createTurnRunner, startTurn } from "./helpers/turn-runner-protocol.js";
 
-class EventTurnRunner extends TurnRunner {
-  emitAgentEventForTest(event: AgentEvent): void {
-    this.emitAgentEvent(event);
+function captureSteps(events: AgentEvent[]): TurnStep[] {
+  const steps: TurnStep[] = [];
+  for (const event of events) {
+    emitAgentEvent(
+      event,
+      (step) => steps.push(step),
+      () => {},
+    );
   }
+  return steps;
 }
 
 class ToolEventTurnRunner extends TurnRunner {
@@ -52,16 +59,6 @@ class ToolEventTurnRunner extends TurnRunner {
   }
 }
 
-function createEventTurnRunner(): { runner: EventTurnRunner; events: TurnEvent[] } {
-  const runner = new EventTurnRunner({
-    model: "anthropic:claude-opus-4-7",
-    skillDiscovery: { includeDefaults: false },
-  });
-  const events: TurnEvent[] = [];
-  runner.subscribe((event) => events.push(event));
-  return { runner, events };
-}
-
 function createToolEventTurnRunner(): { runner: ToolEventTurnRunner; events: TurnEvent[] } {
   const runner = new ToolEventTurnRunner({
     model: "anthropic:claude-opus-4-7",
@@ -85,134 +82,128 @@ describe("TurnRunner event emission", () => {
   });
 
   test("translates complete assistant text and reasoning blocks into step events", () => {
-    const { runner, events } = createEventTurnRunner();
-
-    runner.emitAgentEventForTest({
-      type: "message_update",
-      message: { role: "assistant" } as never,
-      assistantMessageEvent: {
-        type: "text_end",
-        contentIndex: 0,
-        content: "Final answer",
-        partial: { role: "assistant" } as never,
+    const steps = captureSteps([
+      {
+        type: "message_update",
+        message: { role: "assistant" } as never,
+        assistantMessageEvent: {
+          type: "text_end",
+          contentIndex: 0,
+          content: "Final answer",
+          partial: { role: "assistant" } as never,
+        },
       },
-    });
-    runner.emitAgentEventForTest({
-      type: "message_update",
-      message: { role: "assistant" } as never,
-      assistantMessageEvent: {
-        type: "thinking_end",
-        contentIndex: 0,
-        content: "Reasoning summary",
-        partial: { role: "assistant" } as never,
+      {
+        type: "message_update",
+        message: { role: "assistant" } as never,
+        assistantMessageEvent: {
+          type: "thinking_end",
+          contentIndex: 0,
+          content: "Reasoning summary",
+          partial: { role: "assistant" } as never,
+        },
       },
-    });
+    ]);
 
-    expect(events).toEqual([
-      { type: "step", step: { type: "text", text: "Final answer" } },
-      { type: "step", step: { type: "reasoning", text: "Reasoning summary" } },
+    expect(steps).toEqual([
+      { type: "text", text: "Final answer" },
+      { type: "reasoning", text: "Reasoning summary" },
     ]);
   });
 
   test("translates streaming assistant text and reasoning deltas into step events", () => {
-    const { runner, events } = createEventTurnRunner();
+    const steps = captureSteps([
+      {
+        type: "message_update",
+        message: { role: "assistant" } as never,
+        assistantMessageEvent: {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: "Partial ",
+          partial: { role: "assistant" } as never,
+        },
+      },
+      {
+        type: "message_update",
+        message: { role: "assistant" } as never,
+        assistantMessageEvent: {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: "answer",
+          partial: { role: "assistant" } as never,
+        },
+      },
+      {
+        type: "message_update",
+        message: { role: "assistant" } as never,
+        assistantMessageEvent: {
+          type: "text_end",
+          contentIndex: 0,
+          content: "Partial answer",
+          partial: { role: "assistant" } as never,
+        },
+      },
+      {
+        type: "message_update",
+        message: { role: "assistant" } as never,
+        assistantMessageEvent: {
+          type: "thinking_delta",
+          contentIndex: 1,
+          delta: "Reason",
+          partial: { role: "assistant" } as never,
+        },
+      },
+      {
+        type: "message_update",
+        message: { role: "assistant" } as never,
+        assistantMessageEvent: {
+          type: "thinking_end",
+          contentIndex: 1,
+          content: "Reasoning summary",
+          partial: { role: "assistant" } as never,
+        },
+      },
+    ]);
 
-    runner.emitAgentEventForTest({
-      type: "message_update",
-      message: { role: "assistant" } as never,
-      assistantMessageEvent: {
-        type: "text_delta",
-        contentIndex: 0,
-        delta: "Partial ",
-        partial: { role: "assistant" } as never,
-      },
-    });
-    runner.emitAgentEventForTest({
-      type: "message_update",
-      message: { role: "assistant" } as never,
-      assistantMessageEvent: {
-        type: "text_delta",
-        contentIndex: 0,
-        delta: "answer",
-        partial: { role: "assistant" } as never,
-      },
-    });
-    runner.emitAgentEventForTest({
-      type: "message_update",
-      message: { role: "assistant" } as never,
-      assistantMessageEvent: {
-        type: "text_end",
-        contentIndex: 0,
-        content: "Partial answer",
-        partial: { role: "assistant" } as never,
-      },
-    });
-    runner.emitAgentEventForTest({
-      type: "message_update",
-      message: { role: "assistant" } as never,
-      assistantMessageEvent: {
-        type: "thinking_delta",
-        contentIndex: 1,
-        delta: "Reason",
-        partial: { role: "assistant" } as never,
-      },
-    });
-    runner.emitAgentEventForTest({
-      type: "message_update",
-      message: { role: "assistant" } as never,
-      assistantMessageEvent: {
-        type: "thinking_end",
-        contentIndex: 1,
-        content: "Reasoning summary",
-        partial: { role: "assistant" } as never,
-      },
-    });
-
-    expect(events).toEqual([
-      { type: "step", step: { type: "text_delta", delta: "Partial " } },
-      { type: "step", step: { type: "text_delta", delta: "answer" } },
-      { type: "step", step: { type: "text", text: "Partial answer" } },
-      { type: "step", step: { type: "reasoning_delta", delta: "Reason" } },
-      { type: "step", step: { type: "reasoning", text: "Reasoning summary" } },
+    expect(steps).toEqual([
+      { type: "text_delta", delta: "Partial " },
+      { type: "text_delta", delta: "answer" },
+      { type: "text", text: "Partial answer" },
+      { type: "reasoning_delta", delta: "Reason" },
+      { type: "reasoning", text: "Reasoning summary" },
     ]);
   });
 
   test("translates tool execution lifecycle into tool_call step events", () => {
-    const { runner, events } = createEventTurnRunner();
-
-    runner.emitAgentEventForTest({
-      type: "tool_execution_start",
-      toolCallId: "tool-1",
-      toolName: "read",
-      args: { path: "README.md" },
-    });
-    runner.emitAgentEventForTest({
-      type: "tool_execution_end",
-      toolCallId: "tool-1",
-      toolName: "read",
-      result: undefined,
-      isError: false,
-    });
-
-    expect(events).toEqual([
+    const steps = captureSteps([
       {
-        type: "step",
-        step: {
-          type: "tool_call",
-          toolName: "read",
-          toolCallId: "tool-1",
-          status: "running",
-          input: { path: "README.md" },
-        },
+        type: "tool_execution_start",
+        toolCallId: "tool-1",
+        toolName: "read",
+        args: { path: "README.md" },
       },
       {
-        type: "step",
-        step: {
-          type: "tool_call",
-          toolName: "read",
-          toolCallId: "tool-1",
-          status: "completed",
-        },
+        type: "tool_execution_end",
+        toolCallId: "tool-1",
+        toolName: "read",
+        result: undefined,
+        isError: false,
+      },
+    ]);
+
+    expect(steps).toEqual([
+      {
+        type: "tool_call",
+        toolName: "read",
+        toolCallId: "tool-1",
+        status: "running",
+        input: { path: "README.md" },
+      },
+      {
+        type: "tool_call",
+        toolName: "read",
+        toolCallId: "tool-1",
+        status: "completed",
       },
     ]);
   });
@@ -230,9 +221,11 @@ describe("TurnRunner event emission", () => {
     runner.completeNext("Done");
     await turn;
 
-    expect(events).toContainEqual({
-      type: "todos",
-      todos: [{ id: "test", content: "Run tests", status: "in_progress" }],
-    });
+    const todosEvent = events.find(
+      (event): event is Extract<TurnEvent, { type: "todos" }> => event.type === "todos",
+    );
+    expect(todosEvent?.state.todos).toEqual([
+      { id: "test", content: "Run tests", status: "in_progress" },
+    ]);
   });
 });

--- a/test/turn-runner-serialization.test.ts
+++ b/test/turn-runner-serialization.test.ts
@@ -204,5 +204,6 @@ function createSerializableTurnState(): TurnState {
         createAssistantMessage({ text: "The deployment config is serializable.", timestamp: 2 }),
       ],
     },
+    todos: [],
   };
 }

--- a/test/turn-runner-state-machine-agent-events.test.ts
+++ b/test/turn-runner-state-machine-agent-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import type { Agent, AgentEvent } from "@mariozechner/pi-agent-core";
 import {
   TurnRunner,
   type AgentWorkerInput,
@@ -36,32 +36,44 @@ class StateMachineAgentEventTurnRunner extends TurnRunner {
       };
     }
 
-    this.emitAgentEvent({
-      type: "message_update",
-      message: { role: "assistant" } as never,
-      assistantMessageEvent: {
-        type: "text_delta",
-        contentIndex: 0,
-        delta: "Child agent",
-        partial: { role: "assistant" } as never,
+    const fakeAgent = {
+      state: { messages: input.state.agent.messages, errorMessage: undefined },
+    } as unknown as Agent;
+    this.emitAgentEvent(
+      {
+        type: "message_update",
+        message: { role: "assistant" } as never,
+        assistantMessageEvent: {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: "Child agent",
+          partial: { role: "assistant" } as never,
+        },
+      } satisfies AgentEvent,
+      fakeAgent,
+    );
+    this.emitAgentEvent(
+      {
+        type: "message_update",
+        message: { role: "assistant" } as never,
+        assistantMessageEvent: {
+          type: "text_end",
+          contentIndex: 0,
+          content: "Child agent researched the prospect.",
+          partial: { role: "assistant" } as never,
+        },
+      } satisfies AgentEvent,
+      fakeAgent,
+    );
+    this.emitAgentEvent(
+      {
+        type: "tool_execution_start",
+        toolCallId: "tool-1",
+        toolName: "read",
+        args: { path: "profile.md" },
       },
-    } satisfies AgentEvent);
-    this.emitAgentEvent({
-      type: "message_update",
-      message: { role: "assistant" } as never,
-      assistantMessageEvent: {
-        type: "text_end",
-        contentIndex: 0,
-        content: "Child agent researched the prospect.",
-        partial: { role: "assistant" } as never,
-      },
-    } satisfies AgentEvent);
-    this.emitAgentEvent({
-      type: "tool_execution_start",
-      toolCallId: "tool-1",
-      toolName: "read",
-      args: { path: "profile.md" },
-    });
+      fakeAgent,
+    );
 
     return {
       control: { type: "none" },
@@ -95,23 +107,18 @@ describe("State-machine agent state events", () => {
       behavior: "follow_up",
     });
 
-    expect(events).toContainEqual({
-      type: "step",
-      step: { type: "text_delta", delta: "Child agent" },
+    const stepEvents = events.flatMap((event) => (event.type === "step" ? [event.step] : []));
+    expect(stepEvents).toContainEqual({ type: "text_delta", delta: "Child agent" });
+    expect(stepEvents).toContainEqual({
+      type: "text",
+      text: "Child agent researched the prospect.",
     });
-    expect(events).toContainEqual({
-      type: "step",
-      step: { type: "text", text: "Child agent researched the prospect." },
-    });
-    expect(events).toContainEqual({
-      type: "step",
-      step: {
-        type: "tool_call",
-        toolName: "read",
-        toolCallId: "tool-1",
-        status: "running",
-        input: { path: "profile.md" },
-      },
+    expect(stepEvents).toContainEqual({
+      type: "tool_call",
+      toolName: "read",
+      toolCallId: "tool-1",
+      status: "running",
+      input: { path: "profile.md" },
     });
   });
 });


### PR DESCRIPTION
## Summary

- Every state-mutation event (`step`, `todos`, `state_machine`) now carries a fresh `TurnState` snapshot, so the session layer can persist mid-turn and resume from any event.
- `todos` moves onto `TurnState.todos` and is dropped from `TurnTodosEvent` (canonical is now `event.state.todos`); runner no longer holds todos as a private field.
- `follow_up_queue`, `system`, and `memory` stay stateless — the queue isn't part of `TurnState`, system events are diagnostic, and memory work isn't a `TurnState` mutation (memory still persists out-of-band via its own store).

## Why

Sessions previously only got `state` on terminal events and `turn_started`. If a turn died mid-stream (process crash, network drop), everything streamed since the last terminal was unrecoverable. With per-event snapshots, the session layer can checkpoint on each step/todos/state_machine event and resume from anywhere.

## Notes

- `agent-worker` syncs the live agent's `messages` into runner state before each `step` emit, and the worker terminal pulls todos via `runtime.getCurrentState()` so child-worker todo mutations are preserved.
- State-machine runtime gets a matching `getCurrentState()` dep, used to recompose parent sessions after child agent runs (so latest todos survive the child→parent merge).
- `emitAgentEvent` helper now takes an `emitStep(step)` callback instead of a full `emit(event)` — the runner is the only thing that can attach state.

## Future: memory on TurnState

Out of scope here. Two possible designs when needed:
- **Snapshot-mode**: add `memory?: ObservationalMemorySnapshot` to `TurnState`, attach to terminal events only (during-event payload would otherwise bloat). Self-contained state, no external DB dependency.
- **Digest-mode**: keep `memoryDbPath` as canonical, add `memoryDigest` for resume verification.

## Test plan

- [x] `bun run check-types`
- [x] `bun test ./test/*.test.ts` — 118 pass, 0 fail (37 docker-only skips)
- [x] `bun run format`
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)