### PR TITLE
feat: store todos + followUpQueue on TurnState, expose getState() for shutdown flushes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -211,6 +211,20 @@ async function main() {
   }
 
   const manager = new SessionManager(config);
+  // Best-effort state flush on signal-driven shutdown so Ctrl+C / SIGTERM
+  // preserves mid-turn progress (in-flight agent messages, queued follow-ups,
+  // todos written but not yet committed via terminal).
+  let signalFlushed = false;
+  const flushAndExit = (signal: NodeJS.Signals) => {
+    if (signalFlushed) return;
+    signalFlushed = true;
+    void manager
+      .flush()
+      .catch((err) => console.error(`Flush during ${signal} failed:`, err))
+      .finally(() => process.exit(signal === "SIGTERM" ? 143 : 130));
+  };
+  process.once("SIGINT", () => flushAndExit("SIGINT"));
+  process.once("SIGTERM", () => flushAndExit("SIGTERM"));
   let streamedTextThisTurn = false;
   let activeTextDelta = false;
   let activeTextDeltaNeedsNewline = false;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -295,15 +295,12 @@ async function main() {
     let resumedHistory: import("@mariozechner/pi-agent-core").AgentMessage[] | undefined;
 
     if (resumeSessionId) {
-      // Force-load the persisted state.json so setup hands the resumed
-      // state to the runner and any TUI history replays before new turns.
-      await session.hydrate();
+      // Setup loads persisted state.json and hands it to the runner;
+      // manager.create() already dispatched setup for fresh sessions.
+      await session.start();
       if (!session.getState()) {
         throw new Error(`Unknown session: ${resumeSessionId}`);
       }
-      // Setup runs against the hydrated state; manager.create() already
-      // dispatched setup for fresh sessions.
-      await session.start();
       resumedHistory = session.getState()?.agent.messages;
     }
 

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -89,7 +89,26 @@ export class SessionManager {
     return session;
   }
 
+  /**
+   * Persist every active session's current state to disk. Call this before
+   * process exit (signal handlers, normal shutdown) so mid-turn work survives.
+   * Errors per session are caught and logged so one failure doesn't block the
+   * others — flushing is best-effort.
+   */
+  async flush(): Promise<void> {
+    await Promise.all(
+      Array.from(this.sessions.values()).map(async (session) => {
+        try {
+          await session.flush();
+        } catch (error) {
+          console.error(`Failed to flush session ${session.id}:`, error);
+        }
+      }),
+    );
+  }
+
   async dispose(): Promise<void> {
+    await this.flush();
     for (const session of this.sessions.values()) {
       await session.dispose();
     }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -55,6 +55,8 @@ export interface SessionTurnRunner {
   getSkills(): Promise<readonly Skill[]>;
   getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]>;
   getSkillCollisions(): Promise<readonly SkillCollision[]>;
+  /** Latest runner-owned state, kept fresh mid-turn for shutdown flushes. */
+  getState(): TurnState | undefined;
   dispose(): Promise<void>;
 }
 
@@ -207,9 +209,27 @@ export class Session {
     return Boolean(this.activeTurn);
   }
 
-  /** Latest known turn state snapshot, including agent message history. */
+  /**
+   * Latest turn state snapshot. Pulls from the runner so mid-turn callers
+   * (e.g., shutdown flushes) get current agent transcript, todos, and
+   * follow-up queue rather than the last terminal snapshot. Falls back to
+   * the cached terminal state when the runner has not started.
+   */
   getState(): TurnState | undefined {
-    return this.state;
+    return this.runner.getState() ?? this.state;
+  }
+
+  /**
+   * Persist the current state to disk. Call this before process exit so
+   * mid-turn progress (in-flight agent messages, queued follow-ups, todos
+   * touched but not yet committed via terminal) survives the shutdown.
+   * No-op when no state exists yet.
+   */
+  async flush(): Promise<void> {
+    const state = this.getState();
+    if (!state) return;
+    this.state = state;
+    await this.writeStoredState(state);
   }
 
   /**

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -78,8 +78,12 @@ export class Session {
   private readonly eventHandlers = new Set<SessionEventHandler>();
   /** Removes the session's subscription to its owned runner during disposal. */
   private readonly unsubscribeRunner: () => void;
-  /** Latest turn state snapshot used to continue prompts, answers, wakes, and interrupts. */
-  private state?: TurnState;
+  /**
+   * Initial state passed at construction time, consumed once on `start()` and
+   * cleared. After start, `runner.getState()` is the single source of truth;
+   * the session no longer caches state.
+   */
+  private initialState?: TurnState;
   /** In-flight runner turn, used to distinguish active work from a reusable terminal result. */
   private activeTurn?: Promise<void>;
   /** In-flight runner setup, awaited before any turn dispatches so turn_started lands first. */
@@ -102,7 +106,7 @@ export class Session {
     options: SessionOptions,
   ) {
     this.id = options.id;
-    this.state = options.initialState;
+    this.initialState = options.initialState;
     this.resumeFromStorage = options.resumeFromStorage ?? Boolean(options.id);
     this.runner = options.runner ?? new TurnRunner(config);
     this.sessionPath = options.sessionPath;
@@ -129,17 +133,17 @@ export class Session {
       return;
     }
     this.hasStarted = true;
-    if (!this.state && this.resumeFromStorage) {
-      this.state = await this.readStoredState();
+    let resumed = this.initialState;
+    if (!resumed && this.resumeFromStorage) {
+      resumed = await this.readStoredState();
     }
+    this.initialState = undefined;
     const command: TurnStartCommand = {
       type: "start",
       ...((input.mode ?? this.config.mode) ? { mode: input.mode ?? this.config.mode } : {}),
-      ...(this.state ? { state: this.state } : {}),
+      ...(resumed ? { state: resumed } : {}),
       ...(input.options ? { options: input.options } : {}),
     };
-    // The runner emits `turn_started` synchronously while `start` runs;
-    // `handleTurnEvent` captures that state, so we only need to await setup.
     this.startPromise = this.runner.start(command).then(() => undefined);
     await this.startPromise;
   }
@@ -210,13 +214,12 @@ export class Session {
   }
 
   /**
-   * Latest turn state snapshot. Pulls from the runner so mid-turn callers
-   * (e.g., shutdown flushes) get current agent transcript, todos, and
-   * follow-up queue rather than the last terminal snapshot. Falls back to
-   * the cached terminal state when the runner has not started.
+   * Latest turn state snapshot, sourced from the runner. Always returns the
+   * live snapshot when the runner has been started; otherwise returns the
+   * pre-start initial state if one was provided to the constructor.
    */
   getState(): TurnState | undefined {
-    return this.runner.getState() ?? this.state;
+    return this.runner.getState() ?? this.initialState;
   }
 
   /**
@@ -228,7 +231,6 @@ export class Session {
   async flush(): Promise<void> {
     const state = this.getState();
     if (!state) return;
-    this.state = state;
     await this.writeStoredState(state);
   }
 
@@ -248,13 +250,6 @@ export class Session {
   /** Skill name collisions where one definition shadowed another during discovery. */
   getSkillCollisions(): Promise<readonly SkillCollision[]> {
     return this.runner.getSkillCollisions();
-  }
-
-  /** Force-load persisted state for resumed sessions before any command runs. */
-  async hydrate(): Promise<void> {
-    if (!this.state && this.resumeFromStorage) {
-      this.state = await this.readStoredState();
-    }
   }
 
   async dispose(): Promise<void> {
@@ -287,7 +282,6 @@ export class Session {
     let emitted = event;
     if (isTerminalEvent(event)) {
       emitted = this.normalizeTerminalEvent(event);
-      this.state = emitted.state;
       this.lastTerminal = emitted;
       await this.writeStoredState(emitted.state);
       if (emitted.type === "sleep") {
@@ -296,8 +290,6 @@ export class Session {
       for (const resolve of this.terminalWaiters.splice(0)) {
         resolve(emitted);
       }
-    } else if (event.type === "turn_started") {
-      this.state = event.state;
     }
     this.emit(emitted);
   }
@@ -338,7 +330,8 @@ export class Session {
     this.wakeTimer = setTimeout(
       () => {
         this.wakeTimer = undefined;
-        if (!this.state || this.state.status !== "sleeping") return;
+        const state = this.runner.getState();
+        if (!state || state.status !== "sleeping") return;
         this.dispatchTurn({ type: "wake" });
       },
       Math.max(0, terminal.wakeAt - Date.now()),
@@ -353,13 +346,11 @@ export class Session {
   }
 
   private async requireState(): Promise<TurnState> {
-    if (!this.state && this.resumeFromStorage) {
-      this.state = await this.readStoredState();
-    }
-    if (!this.state) {
+    const state = this.runner.getState();
+    if (!state) {
       throw new Error(`Unknown session: ${this.id}`);
     }
-    return this.state;
+    return state;
   }
 
   private isWaitingOnPoll(state: TurnState | undefined): boolean {

--- a/src/turn-runner/state-machine-runtime.ts
+++ b/src/turn-runner/state-machine-runtime.ts
@@ -535,6 +535,8 @@ export class StateMachineRuntime {
         status: "running",
         messages: [],
       },
+      todos: [],
+      followUpQueue: [],
     };
   }
 

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -1,4 +1,9 @@
-import { Agent, type AgentEvent, type AgentTool } from "@mariozechner/pi-agent-core";
+import {
+  Agent,
+  type AgentEvent,
+  type AgentMessage,
+  type AgentTool,
+} from "@mariozechner/pi-agent-core";
 import { getEnvApiKey, getModel, type Model, type Usage } from "@mariozechner/pi-ai";
 import type { Skill } from "@mariozechner/pi-coding-agent";
 import type { SkillCollision } from "./skills.js";
@@ -84,18 +89,26 @@ export class TurnRunner {
   private activeTurnPromise?: Promise<TurnTerminalEvent>;
   /** Commands that could not be absorbed into the active pi agent and must run later. */
   private readonly queuedTurnCommands: TurnCommand[] = [];
-  /** Latest runner-owned state, hydrated by start() and advanced by terminal events. */
+  /**
+   * Latest runner-owned state. Hydrated by start(), advanced through terminal
+   * events, and continuously updated mid-turn so `getState()` returns a fresh
+   * snapshot at any instant: agent messages sync on each agent event, the
+   * TodoWrite tool mutates `state.todos`, and follow-up queue ops mutate
+   * `state.followUpQueue`.
+   */
   private state?: TurnState;
-  /** User-visible mirror of follow-up prompts accepted by this runner. */
-  private followUpQueuePrompts: string[] = [];
-  /** Current todo list emitted through todo protocol events. */
-  private todos: TurnTodo[] = [];
   /** Aggregates model usage across parent agents, child agents, and memory work for one turn chain. */
   private turnUsage?: TurnTokenUsage;
   /** Prevents queued user prompts from recursively preempting continuation prompts. */
   private drainingQueuedCommandsBeforeContinuation = false;
   /** Ensures persisted memory hydrates once before the first turn that needs it. */
   private memoryLoaded = false;
+  /**
+   * Set by `start()` when resumed state carries a non-empty follow-up queue.
+   * The first parent pi agent created after start consumes the flag and
+   * replays the queue into pi's follow-up channel.
+   */
+  private pendingFollowUpReplay = false;
   private readonly skillContext: SkillContext;
   private readonly stateMachineRuntime: StateMachineRuntime;
 
@@ -163,10 +176,29 @@ export class TurnRunner {
     await this.ensureMemoryLoaded();
     await this.ensureSkillsLoaded();
     const mode = command.mode ?? this.config.mode ?? "auto";
-    const state = command.state ?? this.stateMachineRuntime.createInitialState(mode);
+    const state = this.normalizeResumedState(
+      command.state ?? this.stateMachineRuntime.createInitialState(mode),
+    );
     this.state = state;
+    this.pendingFollowUpReplay = state.followUpQueue.length > 0;
+    if (this.pendingFollowUpReplay) {
+      this.emit({ type: "follow_up_queue", prompts: [...state.followUpQueue] });
+    }
     this.emit({ type: "turn_started", state });
     return state;
+  }
+
+  /**
+   * Backfill `todos` and `followUpQueue` for resumed states written before
+   * those fields were on `TurnState`. Without this, hydrated state from disk
+   * would be missing required fields.
+   */
+  private normalizeResumedState(state: TurnState): TurnState {
+    return {
+      ...state,
+      todos: state.todos ?? [],
+      followUpQueue: state.followUpQueue ?? [],
+    };
   }
 
   async turn(command: TurnCommand): Promise<TurnTerminalEvent> {
@@ -311,9 +343,9 @@ export class TurnRunner {
   }
 
   private replaceFollowUpQueue(prompts: string[]): void {
-    this.followUpQueuePrompts = [...prompts];
+    this.setFollowUpQueue([...prompts]);
     this.activeAgent?.clearFollowUpQueue();
-    for (const prompt of this.followUpQueuePrompts) {
+    for (const prompt of prompts) {
       this.activeAgent?.followUp({
         role: "user",
         content: prompt,
@@ -352,8 +384,17 @@ export class TurnRunner {
     );
   }
 
+  private getFollowUpQueue(): string[] {
+    return this.state?.followUpQueue ?? [];
+  }
+
+  private setFollowUpQueue(prompts: string[]): void {
+    if (!this.state) return;
+    this.state = { ...this.state, followUpQueue: prompts };
+  }
+
   private appendFollowUpPrompt(prompt: string): void {
-    this.followUpQueuePrompts.push(prompt);
+    this.setFollowUpQueue([...this.getFollowUpQueue(), prompt]);
     this.emitFollowUpQueue();
   }
 
@@ -363,20 +404,23 @@ export class TurnRunner {
   }
 
   private removeFollowUpPrompt(prompt: string): void {
-    const index = this.followUpQueuePrompts.indexOf(prompt);
+    const queue = this.getFollowUpQueue();
+    const index = queue.indexOf(prompt);
     if (index === -1) return;
-    this.followUpQueuePrompts.splice(index, 1);
+    const next = queue.slice();
+    next.splice(index, 1);
+    this.setFollowUpQueue(next);
     this.emitFollowUpQueue();
   }
 
   private clearFollowUpQueue(): void {
-    if (this.followUpQueuePrompts.length === 0) return;
-    this.followUpQueuePrompts = [];
+    if (this.getFollowUpQueue().length === 0) return;
+    this.setFollowUpQueue([]);
     this.emitFollowUpQueue();
   }
 
   private emitFollowUpQueue(): void {
-    this.emit({ type: "follow_up_queue", prompts: [...this.followUpQueuePrompts] });
+    this.emit({ type: "follow_up_queue", prompts: [...this.getFollowUpQueue()] });
   }
 
   interrupt(_command: TurnInterruptCommand): void {
@@ -416,6 +460,41 @@ export class TurnRunner {
     for (const handler of this.eventHandlers) {
       handler(event);
     }
+  }
+
+  /**
+   * Latest turn-runner state. Returns a fresh snapshot at any moment,
+   * including mid-turn: agent messages and status are synced as the live
+   * agent emits events; todos and follow-up queue mutations write through
+   * `this.state` directly. Use this for shutdown flushes when you need to
+   * persist whatever state is current right now.
+   */
+  getState(): TurnState | undefined {
+    if (!this.state) return undefined;
+    return {
+      ...this.state,
+      agent: { ...this.state.agent, messages: [...this.state.agent.messages] },
+      todos: [...this.state.todos],
+      followUpQueue: [...this.state.followUpQueue],
+    };
+  }
+
+  /**
+   * Sync the runner's `state.agent` with the live agent's messages and status.
+   * Called on each agent event so `getState()` returns a fresh transcript at
+   * any moment (e.g., mid-turn shutdown flushes).
+   */
+  protected syncAgentState(messages: AgentMessage[], errorMessage: string | undefined): void {
+    if (!this.state) return;
+    const status = errorMessage ? "failed" : "running";
+    this.state = {
+      ...this.state,
+      agent: {
+        ...this.state.agent,
+        status,
+        messages,
+      },
+    };
   }
 
   private consumeInterruptedTerminal(): TurnTerminalEvent | undefined {
@@ -584,9 +663,11 @@ export class TurnRunner {
   } {
     const cwd = this.config.cwd ?? process.cwd();
     const todoStorage = {
-      getTodos: () => this.todos,
+      getTodos: (): TurnTodo[] => this.state?.todos ?? [],
       setTodos: (todos: TurnTodo[]) => {
-        this.todos = todos;
+        if (this.state) {
+          this.state = { ...this.state, todos };
+        }
       },
     };
     const skills = this.skillContext.getSkills();
@@ -632,6 +713,7 @@ export class TurnRunner {
         setActiveAgent: (slot, agent) => {
           if (slot === "parent") {
             this.activeAgent = agent;
+            if (agent) this.replayPendingFollowUpsInto(agent);
           } else {
             this.activeChildAgent = agent;
           }
@@ -661,7 +743,7 @@ export class TurnRunner {
   ): Agent {
     const model = this.resolveTurnModel(input.options);
     const memoryModel = this.resolveMemoryModel(input.options);
-    return new Agent({
+    const agent = new Agent({
       initialState: {
         model,
         thinkingLevel: input.options?.thinkingLevel ?? this.config.thinkingLevel ?? "medium",
@@ -685,6 +767,27 @@ export class TurnRunner {
       },
       getApiKey: getEnvApiKey,
     });
+    return agent;
+  }
+
+  /**
+   * On resume, push each persisted follow-up prompt into the freshly created
+   * parent pi agent so it drains them after the current user prompt. Only
+   * runs once per session (consumes a flag set by `start()`), and only for
+   * the parent slot — child state-machine agents share the parent's transcript
+   * but should not absorb user-level follow-ups.
+   */
+  private replayPendingFollowUpsInto(agent: Agent): void {
+    if (!this.pendingFollowUpReplay) return;
+    this.pendingFollowUpReplay = false;
+    const queue = this.getFollowUpQueue();
+    for (const prompt of queue) {
+      agent.followUp({
+        role: "user",
+        content: prompt,
+        timestamp: Date.now(),
+      });
+    }
   }
 
   protected createMemoryTransform(model: Model<any>) {
@@ -784,6 +887,15 @@ export class TurnRunner {
   }
 
   protected emitAgentEvent(event: AgentEvent): void {
+    // Sync the live agent's transcript into runner state so `getState()`
+    // returns a fresh snapshot mid-turn (e.g., for shutdown flushes). The
+    // child slot is preferred when active because its events are what's
+    // currently driving the conversation; child transcripts share the parent
+    // message list (child starts with parent.messages and appends).
+    const liveAgent = this.activeChildAgent ?? this.activeAgent;
+    if (liveAgent) {
+      this.syncAgentState(liveAgent.state.messages, liveAgent.state.errorMessage);
+    }
     emitAgentWorkerEvent(
       event,
       (turnEvent) => this.emit(turnEvent),

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -177,6 +177,14 @@ export interface TurnState {
   agent: AgentSession;
   /** Present when this session is executing in state-machine mode. */
   stateMachine?: StateMachineSession;
+  /** Current todo list for this session. Mutated by the TodoWrite tool. */
+  todos: TurnTodo[];
+  /**
+   * User prompts queued behind active work that have not yet been consumed by
+   * the pi agent. Persisted on `TurnState` so a resumed session can replay them
+   * into the next pi agent on the next turn instead of dropping them.
+   */
+  followUpQueue: string[];
 }
 
 /**

--- a/test/helpers/turn-runner-protocol.ts
+++ b/test/helpers/turn-runner-protocol.ts
@@ -115,6 +115,8 @@ export function createStateMachineState(currentState: string): TurnState {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     },
+    todos: [],
+    followUpQueue: [],
   };
 }
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -124,6 +124,10 @@ class FakeTurnRunner implements SessionTurnRunner {
     return this.skillInstructions.get(skillId) ?? "";
   }
 
+  getState(): TurnState | undefined {
+    return this.state;
+  }
+
   async dispose(): Promise<void> {
     this.disposed = true;
   }
@@ -444,6 +448,30 @@ describe("Session", () => {
       ]);
     },
   );
+
+  testIfDocker("flush writes the runner's current state to disk mid-turn", async () => {
+    const runner = new FakeTurnRunner([complete()]);
+    const tempDir = await mkdtemp(join(tmpdir(), "duet-session-flush-"));
+    tempDirs.push(tempDir);
+    const session = new Session(
+      { model: "anthropic:claude-opus-4-7" },
+      { id: "session_flush_test", runner, sessionPath: tempDir },
+    );
+    await session.start();
+
+    // Simulate mid-turn state without going through a terminal event.
+    runner.state = {
+      ...turnState,
+      todos: [{ id: "t1", content: "ship it", status: "in_progress" }],
+      followUpQueue: ["queued"],
+    };
+
+    await session.flush();
+
+    const written = JSON.parse(await readFile(join(tempDir, "state.json"), "utf-8"));
+    expect(written.state.todos).toEqual([{ id: "t1", content: "ship it", status: "in_progress" }]);
+    expect(written.state.followUpQueue).toEqual(["queued"]);
+  });
 });
 
 describe("SessionManager", () => {

--- a/test/turn-runner-protocol.test.ts
+++ b/test/turn-runner-protocol.test.ts
@@ -978,4 +978,30 @@ describe("TurnRunner protocol scenarios", () => {
       },
     });
   });
+
+  test("resumed state replays followUpQueue on start and exposes it via getState", async () => {
+    const { runner, events } = createTurnRunner();
+    const resumed = createStateMachineState("draft");
+    resumed.followUpQueue = ["queued one", "queued two"];
+
+    await runner.start({ type: "start", state: resumed });
+
+    const followUpEvents = events.filter((event) => event.type === "follow_up_queue");
+    expect(followUpEvents).toEqual([
+      { type: "follow_up_queue", prompts: ["queued one", "queued two"] },
+    ]);
+    expect(runner.getState()?.followUpQueue).toEqual(["queued one", "queued two"]);
+  });
+
+  test("getState returns a defensive snapshot, not the runner's mutable cell", async () => {
+    const { runner } = createTurnRunner();
+    await runner.start({ type: "start", mode: "agent" });
+
+    const snapshot = runner.getState();
+    expect(snapshot).toBeDefined();
+    snapshot!.todos.push({ id: "x", content: "noise", status: "pending" });
+
+    // Mutating the returned snapshot must not leak into the runner.
+    expect(runner.getState()?.todos).toEqual([]);
+  });
 });

--- a/test/turn-runner-serialization.test.ts
+++ b/test/turn-runner-serialization.test.ts
@@ -204,5 +204,7 @@ function createSerializableTurnState(): TurnState {
         createAssistantMessage({ text: "The deployment config is serializable.", timestamp: 2 }),
       ],
     },
+    todos: [],
+    followUpQueue: [],
   };
 }


### PR DESCRIPTION
## Summary

- `TurnState` gains `todos: TurnTodo[]` and `followUpQueue: string[]`. The runner no longer holds them as private fields; both are mutated through `this.state` directly.
- New public `TurnRunner.getState()` returns a defensive snapshot of the runner's current state at any moment. Mid-turn it's kept fresh by syncing the live agent's transcript on each agent event into `state.agent.messages`.
- `Session.getState()` now pulls from the runner. New `Session.flush()` writes that snapshot to disk. `SessionManager.flush()` flushes every active session in parallel.
- CLI installs `SIGINT`/`SIGTERM` handlers that call `manager.flush()` before exiting, so Ctrl+C preserves mid-turn progress. `manager.dispose()` also flushes for clean shutdowns.
- On resume (`start` with `command.state.followUpQueue` non-empty), the runner replays the persisted queue into the first parent pi agent's follow-up channel and emits `follow_up_queue` so UIs see the restored queue immediately. Child state-machine agents skip the replay.
- Resumed state is normalized to backfill `todos`/`followUpQueue` for state files written before this change.

## Why

Sessions could only persist on terminal events. Mid-turn state — in-flight agent messages, TodoWrite mutations, queued follow-up prompts — was lost on Ctrl+C or process crash. Step events stay bite-sized; persistence is now an explicit `getState`/`flush` flow rather than per-event payload bloat.

## Test plan

- [x] `bun run check-types`
- [x] `bun test ./test/*.test.ts` — 120 pass, 0 fail (38 docker-only skips); new tests cover follow-up replay on resume, defensive snapshot semantics, and mid-turn flush-to-disk.
- [x] `bun run format`
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)