### PR TITLE
feat: duet login + default-skill sync

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1033,9 +1033,9 @@ MODELS
   OPENAI_API_KEY after loading <workdir>/.env and the shared duet env file.
 
   duet-gateway: routes through the Duet gateway proxy
-  (https://duet.so/api/v1/ai-gateway by default; override via
-  DUET_GATEWAY_BASE_URL). It mirrors vercel-ai-gateway's model
-  catalog and authenticates with DUET_API_KEY.
+  (https://duet.so/api/v1/ai-gateway by default; override the app origin
+  via DUET_APP_BASE_URL). It mirrors vercel-ai-gateway's model catalog
+  and authenticates with DUET_API_KEY.
 
 EXAMPLES
   duet "build a REST API with Express and TypeScript"
@@ -1078,10 +1078,9 @@ SKILL SYNC
   skills with Claude Code / Codex / etc.
 
 OVERRIDES
-  Set DUET_GATEWAY_BASE_URL (e.g. https://staging.duet.so/api/v1/ai-gateway)
-  to re-point both the AI gateway provider and the CLI auth/sync endpoints at
-  a non-production deployment. The /api/v1/ai-gateway suffix is stripped to
-  get the app origin used for /cli/login and /api/v1/cli/*.
+  Set DUET_APP_BASE_URL (e.g. https://staging.duet.so) to re-point both the
+  AI gateway provider and the CLI auth/sync endpoints at a non-production
+  deployment.
 `);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -779,10 +779,10 @@ export async function runLoginCommand(args: string[], io: LoginCommandIO = {}): 
     return;
   }
 
-  console.error(`Syncing default skills from ${resolveDuetAppBaseUrl()}...`);
+  console.error(`Checking default skills against ${resolveDuetAppBaseUrl()}...`);
   const syncResult = await syncDefaultSkills({ apiKey: result.apiKey });
   if (syncResult.status === "unchanged") {
-    console.error(`Default skills already up to date (${syncResult.count} files).`);
+    console.error("Default skills already up to date.");
   } else {
     console.error(`Synced ${syncResult.count} default skills.`);
   }
@@ -1078,8 +1078,10 @@ SKILL SYNC
   skills with Claude Code / Codex / etc.
 
 OVERRIDES
-  Set DUET_APP_BASE_URL (or DUET_GATEWAY_BASE_URL with the standard
-  /api/v1/ai-gateway suffix) to point the CLI at a non-production deployment.
+  Set DUET_GATEWAY_BASE_URL (e.g. https://staging.duet.so/api/v1/ai-gateway)
+  to re-point both the AI gateway provider and the CLI auth/sync endpoints at
+  a non-production deployment. The /api/v1/ai-gateway suffix is stripped to
+  get the app origin used for /cli/login and /api/v1/cli/*.
 `);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,9 @@ import dotenv from "dotenv";
 import packageJson from "../package.json" with { type: "json" };
 import { shimDuetApiKeyToAiGateway } from "./model-resolution/duet-gateway.js";
 import { formatCompactJson } from "./lib/compact-json.js";
+import { resolveDuetAppBaseUrl } from "./lib/duet-app-url.js";
+import { loginWithBrowser } from "./lib/login.js";
+import { syncDefaultSkills } from "./lib/sync-skills.js";
 import {
   describeModelResolution,
   resolveCliMemoryModel,
@@ -90,6 +93,15 @@ async function main() {
   if (args[0] === "setup") {
     try {
       await runSetupCommand(args.slice(1));
+    } catch (err: any) {
+      console.error(`Fatal: ${err.message}`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+  if (args[0] === "login") {
+    try {
+      await runLoginCommand(args.slice(1));
     } catch (err: any) {
       console.error(`Fatal: ${err.message}`);
       process.exitCode = 1;
@@ -718,6 +730,64 @@ export async function runSetupCommand(args: string[], io: SetupCommandIO = {}): 
   }
 }
 
+interface LoginCommandIO {
+  cwd?: string;
+  envFilePath?: string;
+}
+
+export async function runLoginCommand(args: string[], io: LoginCommandIO = {}): Promise<void> {
+  const cwd = io.cwd ?? process.cwd();
+  let envFilePathOverride: string | undefined = io.envFilePath;
+  let noBrowser = false;
+  let skipSkillSync = false;
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--env-file":
+        if (!args[i + 1] || args[i + 1]?.startsWith("-")) fail(`Missing value for ${args[i]}`);
+        envFilePathOverride = args[++i]!;
+        break;
+      case "--no-browser":
+        noBrowser = true;
+        break;
+      case "--skip-skill-sync":
+        skipSkillSync = true;
+        break;
+      case "--help":
+      case "-h":
+        printLoginHelp();
+        return;
+      default:
+        fail(`Unknown login option: ${args[i]}`);
+    }
+  }
+
+  const targetEnvFile = envFilePathOverride
+    ? resolveUserPath(envFilePathOverride, cwd)
+    : defaultDuetEnvFilePath();
+
+  const result = await loginWithBrowser({ noBrowser });
+
+  await mergeEnvEntries(targetEnvFile, new Map([["DUET_API_KEY", result.apiKey]]));
+  console.error(`Saved DUET_API_KEY for ${result.orgName} (${result.orgSlug}) to ${targetEnvFile}`);
+
+  process.env.DUET_API_KEY = result.apiKey;
+  shimDuetApiKeyToAiGateway();
+
+  if (skipSkillSync) {
+    console.error("Skipping default skill sync (--skip-skill-sync).");
+    return;
+  }
+
+  console.error(`Syncing default skills from ${resolveDuetAppBaseUrl()}...`);
+  const syncResult = await syncDefaultSkills({ apiKey: result.apiKey });
+  if (syncResult.status === "unchanged") {
+    console.error(`Default skills already up to date (${syncResult.count} files).`);
+  } else {
+    console.error(`Synced ${syncResult.count} default skills.`);
+  }
+}
+
 async function fileExists(path: string): Promise<boolean> {
   try {
     return (await stat(path)).isFile();
@@ -925,12 +995,14 @@ duet — An opinionated full-stack agent runner
 USAGE
   duet [options] [prompt]
   duet setup [--env-file <path>] [--import [path]|--keys]
+  duet login [--no-browser] [--skip-skill-sync]
   duet skills [--workdir <path>]
   duet upgrade [--manager npm|bun|pnpm|yarn]
   echo "prompt" | duet
 
 COMMANDS
   setup                    Create or update the shared duet env file
+  login                    Sign in via browser; saves DUET_API_KEY and syncs default skills
   skills                   List installed skills as JSON (name, description, path, scope)
   upgrade                  Upgrade the global ${packageName} installation
 
@@ -977,7 +1049,37 @@ EXAMPLES
   duet --workdir ./my-project "refactor the auth module"
   duet --resume session_abc123 --workdir ./my-project
   duet setup
+  duet login
   duet upgrade
+`);
+}
+
+function printLoginHelp() {
+  console.log(`
+duet login — Sign in via browser and sync default skills
+
+USAGE
+  duet login [--env-file <path>] [--no-browser] [--skip-skill-sync]
+
+Opens a browser window pointed at the Duet web app, waits for the user to
+confirm, then writes the org's DUET_API_KEY to the shared env file. After
+auth, fetches and writes the latest default skills to ~/.duet/skills.
+
+OPTIONS
+  --env-file <path>        Env file to write the API key to (default: ${DEFAULT_DUET_ENV_FILE})
+  --no-browser             Print the auth URL instead of opening a browser
+  --skip-skill-sync        Skip the post-login default skills sync
+  -h, --help               Show this help
+
+SKILL SYNC
+  Mirrors the sandbox protocol: hashes the rendered skill payload and only
+  rewrites ~/.duet/skills when the hash differs from ~/.duet/.skills-hash.
+  After writing, runs \`skills add ~/.duet/skills -g -y\` to register the
+  skills with Claude Code / Codex / etc.
+
+OVERRIDES
+  Set DUET_APP_BASE_URL (or DUET_GATEWAY_BASE_URL with the standard
+  /api/v1/ai-gateway suffix) to point the CLI at a non-production deployment.
 `);
 }
 

--- a/src/lib/duet-app-url.ts
+++ b/src/lib/duet-app-url.ts
@@ -1,29 +1,17 @@
 /**
- * Resolve the base URL of the Duet web app from the existing
- * `DUET_GATEWAY_BASE_URL` env var.
+ * Resolve the base URL of the Duet web app.
  *
- * The CLI talks to two URLs hosted on the same origin:
- *   - the AI gateway proxy at `<base>/api/v1/ai-gateway/...` (used by the
- *     `duet-gateway` model provider), and
- *   - the new CLI auth/sync endpoints at `<base>/cli/login` and
- *     `<base>/api/v1/cli/...`.
- *
- * `DUET_GATEWAY_BASE_URL` is the existing env var users already set to point
- * the gateway provider at staging/dev (e.g.
- * `https://staging.duet.so/api/v1/ai-gateway`). Stripping the well-known
- * suffix gives us the app origin for the CLI endpoints, so a single env var
- * re-points everything.
+ * Single env var (`DUET_APP_BASE_URL`) for the app origin. Surface-specific
+ * paths like the AI gateway's `/api/v1/ai-gateway` and the CLI's
+ * `/api/v1/cli/*` are hardcoded by their callers.
  */
 
 const DEFAULT_BASE_URL = "https://duet.so";
-const GATEWAY_BASE_URL_ENV = "DUET_GATEWAY_BASE_URL";
-const GATEWAY_PATH_SUFFIX = "/api/v1/ai-gateway";
+export const DUET_APP_BASE_URL_ENV = "DUET_APP_BASE_URL";
 
 export function resolveDuetAppBaseUrl(): string {
-  const gateway = process.env[GATEWAY_BASE_URL_ENV]?.trim();
-  if (gateway && gateway.endsWith(GATEWAY_PATH_SUFFIX)) {
-    return stripTrailingSlash(gateway.slice(0, -GATEWAY_PATH_SUFFIX.length));
-  }
+  const override = process.env[DUET_APP_BASE_URL_ENV]?.trim();
+  if (override) return stripTrailingSlash(override);
   return DEFAULT_BASE_URL;
 }
 

--- a/src/lib/duet-app-url.ts
+++ b/src/lib/duet-app-url.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolve the base URL of the Duet web app.
+ *
+ * The CLI talks to two URLs hosted on the same origin:
+ *   - the AI gateway proxy at `<base>/api/v1/ai-gateway/...` (already used by
+ *     the duet-gateway provider), and
+ *   - the new CLI auth/sync endpoints at `<base>/cli/login` and
+ *     `<base>/api/v1/cli/...`.
+ *
+ * Override the base via `DUET_APP_BASE_URL` for staging/dev. As a fallback,
+ * derive it from `DUET_GATEWAY_BASE_URL` by stripping the `/api/v1/ai-gateway`
+ * suffix so a single env var can re-point both surfaces.
+ */
+
+const DEFAULT_BASE_URL = "https://duet.so";
+const APP_BASE_URL_ENV = "DUET_APP_BASE_URL";
+const GATEWAY_BASE_URL_ENV = "DUET_GATEWAY_BASE_URL";
+const GATEWAY_PATH_SUFFIX = "/api/v1/ai-gateway";
+
+export function resolveDuetAppBaseUrl(): string {
+  const override = process.env[APP_BASE_URL_ENV]?.trim();
+  if (override) return stripTrailingSlash(override);
+
+  const gateway = process.env[GATEWAY_BASE_URL_ENV]?.trim();
+  if (gateway && gateway.endsWith(GATEWAY_PATH_SUFFIX)) {
+    return stripTrailingSlash(gateway.slice(0, -GATEWAY_PATH_SUFFIX.length));
+  }
+
+  return DEFAULT_BASE_URL;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}

--- a/src/lib/duet-app-url.ts
+++ b/src/lib/duet-app-url.ts
@@ -1,31 +1,29 @@
 /**
- * Resolve the base URL of the Duet web app.
+ * Resolve the base URL of the Duet web app from the existing
+ * `DUET_GATEWAY_BASE_URL` env var.
  *
  * The CLI talks to two URLs hosted on the same origin:
- *   - the AI gateway proxy at `<base>/api/v1/ai-gateway/...` (already used by
- *     the duet-gateway provider), and
+ *   - the AI gateway proxy at `<base>/api/v1/ai-gateway/...` (used by the
+ *     `duet-gateway` model provider), and
  *   - the new CLI auth/sync endpoints at `<base>/cli/login` and
  *     `<base>/api/v1/cli/...`.
  *
- * Override the base via `DUET_APP_BASE_URL` for staging/dev. As a fallback,
- * derive it from `DUET_GATEWAY_BASE_URL` by stripping the `/api/v1/ai-gateway`
- * suffix so a single env var can re-point both surfaces.
+ * `DUET_GATEWAY_BASE_URL` is the existing env var users already set to point
+ * the gateway provider at staging/dev (e.g.
+ * `https://staging.duet.so/api/v1/ai-gateway`). Stripping the well-known
+ * suffix gives us the app origin for the CLI endpoints, so a single env var
+ * re-points everything.
  */
 
 const DEFAULT_BASE_URL = "https://duet.so";
-const APP_BASE_URL_ENV = "DUET_APP_BASE_URL";
 const GATEWAY_BASE_URL_ENV = "DUET_GATEWAY_BASE_URL";
 const GATEWAY_PATH_SUFFIX = "/api/v1/ai-gateway";
 
 export function resolveDuetAppBaseUrl(): string {
-  const override = process.env[APP_BASE_URL_ENV]?.trim();
-  if (override) return stripTrailingSlash(override);
-
   const gateway = process.env[GATEWAY_BASE_URL_ENV]?.trim();
   if (gateway && gateway.endsWith(GATEWAY_PATH_SUFFIX)) {
     return stripTrailingSlash(gateway.slice(0, -GATEWAY_PATH_SUFFIX.length));
   }
-
   return DEFAULT_BASE_URL;
 }
 

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -1,0 +1,224 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { type AddressInfo, createServer } from "node:net";
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { resolveDuetAppBaseUrl } from "./duet-app-url.js";
+
+/**
+ * Browser-based login bootstrap for the duet CLI.
+ *
+ * 1. Pick a free localhost port and start an ephemeral HTTP server on
+ *    `/callback`.
+ * 2. Generate a CSRF state, open the browser to
+ *    `<app>/cli/login?port=<n>&state=<s>`.
+ * 3. Wait for the user to confirm in the browser; the app redirects them
+ *    to `http://127.0.0.1:<n>/callback?code=...&state=...`.
+ * 4. Validate state, POST `<app>/api/v1/cli/exchange` with `{ code, state }`,
+ *    return the resulting `{ apiKey, orgSlug, orgName, appUrl }`.
+ *
+ * The server is single-shot — it shuts down after responding to one
+ * `/callback` request (or on timeout).
+ */
+
+export interface LoginResult {
+  apiKey: string;
+  orgSlug: string;
+  orgName: string;
+  appUrl: string;
+}
+
+export interface LoginOptions {
+  appBaseUrl?: string;
+  /** Print the auth URL instead of opening a browser. */
+  noBrowser?: boolean;
+  /** Hard cap on how long we'll wait for the browser callback. */
+  timeoutMs?: number;
+  /** Inject HTTP for the exchange call (testing). */
+  fetchFn?: typeof fetch;
+  /** Override how the URL is opened (testing). */
+  openUrl?: (url: string) => void;
+  /** Stream user-facing progress (default: stderr). */
+  log?: (message: string) => void;
+}
+
+export async function loginWithBrowser(options: LoginOptions = {}): Promise<LoginResult> {
+  const appBaseUrl = options.appBaseUrl ?? resolveDuetAppBaseUrl();
+  const fetchFn = options.fetchFn ?? fetch;
+  const log = options.log ?? ((m: string) => process.stderr.write(`${m}\n`));
+  const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
+
+  const port = await findFreePort();
+  const state = randomBytes(24).toString("base64url");
+  const loginUrl = `${appBaseUrl}/cli/login?port=${port}&state=${encodeURIComponent(state)}`;
+
+  log(`Open this URL to authorize the duet CLI:\n  ${loginUrl}`);
+
+  const callbackPromise = waitForCallback({ port, expectedState: state, timeoutMs });
+
+  if (!options.noBrowser) {
+    try {
+      (options.openUrl ?? openInBrowser)(loginUrl);
+    } catch (err) {
+      log(
+        `Could not open the browser automatically (${err instanceof Error ? err.message : err}). Open the URL manually.`,
+      );
+    }
+  }
+
+  const code = await callbackPromise;
+
+  log("Exchanging authorization code...");
+  const response = await fetchFn(`${appBaseUrl}/api/v1/cli/exchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code, state }),
+  });
+  if (!response.ok) {
+    const detail = await safeReadText(response);
+    throw new Error(
+      `Exchange failed: ${response.status} ${response.statusText}${detail ? ` — ${detail.slice(0, 256)}` : ""}`,
+    );
+  }
+
+  const body = (await response.json()) as Partial<LoginResult>;
+  if (
+    !body ||
+    typeof body.apiKey !== "string" ||
+    typeof body.orgSlug !== "string" ||
+    typeof body.orgName !== "string" ||
+    typeof body.appUrl !== "string"
+  ) {
+    throw new Error("Unexpected exchange response shape");
+  }
+  return {
+    apiKey: body.apiKey,
+    orgSlug: body.orgSlug,
+    orgName: body.orgName,
+    appUrl: body.appUrl,
+  };
+}
+
+interface CallbackOptions {
+  port: number;
+  expectedState: string;
+  timeoutMs: number;
+}
+
+function waitForCallback({ port, expectedState, timeoutMs }: CallbackOptions): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const server = createHttpServer((req, res) => {
+      handleCallback(req, res, expectedState, (err, code) => {
+        if (err || !code) {
+          server.close();
+          reject(err ?? new Error("Callback received without a code"));
+          return;
+        }
+        server.close();
+        resolve(code);
+      });
+    });
+
+    const timer = setTimeout(() => {
+      server.close();
+      reject(new Error(`Timed out waiting for browser confirmation after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+    server.once("close", () => clearTimeout(timer));
+
+    server.listen(port, "127.0.0.1");
+    server.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function handleCallback(
+  req: IncomingMessage,
+  res: ServerResponse,
+  expectedState: string,
+  done: (err: Error | null, code?: string) => void,
+): void {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  if (url.pathname !== "/callback") {
+    res.statusCode = 404;
+    res.end("Not found");
+    return;
+  }
+  const code = url.searchParams.get("code");
+  const receivedState = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+
+  if (error) {
+    respondError(res, "Authorization rejected. You can close this tab.");
+    done(new Error(`Authorization error: ${error}`));
+    return;
+  }
+  if (!code || !receivedState) {
+    respondError(res, "Missing code or state. You can close this tab.");
+    done(new Error("Missing code or state in callback"));
+    return;
+  }
+  if (receivedState !== expectedState) {
+    respondError(res, "State mismatch. You can close this tab.");
+    done(new Error("State mismatch — refusing to exchange code"));
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.end(
+    `<!doctype html><meta charset="utf-8"><title>duet CLI</title>` +
+      `<body style="font-family:system-ui,sans-serif;padding:48px;text-align:center">` +
+      `<h1 style="margin-bottom:8px">duet CLI authorized</h1>` +
+      `<p style="color:#646565">You can close this tab and return to your terminal.</p>` +
+      `</body>`,
+  );
+  done(null, code);
+}
+
+function respondError(res: ServerResponse, message: string): void {
+  res.statusCode = 400;
+  res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  res.end(message);
+}
+
+async function findFreePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo | null;
+      if (!address) {
+        server.close();
+        reject(new Error("Failed to allocate a localhost port"));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function openInBrowser(url: string): void {
+  const platform = process.platform;
+  const command = platform === "darwin" ? "open" : platform === "win32" ? "explorer" : "xdg-open";
+  const child = spawn(command, [url], { stdio: "ignore", detached: true });
+  child.unref();
+  child.on("error", () => {
+    /* swallow — caller logs and tells the user to open manually */
+  });
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}

--- a/src/lib/sync-skills.ts
+++ b/src/lib/sync-skills.ts
@@ -11,9 +11,12 @@ import { resolveDuetAppBaseUrl } from "./duet-app-url.js";
  * verifies the returned hash, dumps the files into ~/.duet/skills/, and
  * registers them with the local agent harness via `skills add`.
  *
+ * The hash is used as a conditional GET ETag: we send the on-disk hash via
+ * `If-None-Match` and the server returns `304 Not Modified` when it still
+ * matches, so a no-op `duet login` never transfers the payload at all.
+ *
  * On any kind of registration failure we leave the on-disk hash untouched
- * so the next `duet login` (or `duet login --sync-skills-only`) retries
- * the write.
+ * so the next login retries the write.
  */
 
 const DEFAULT_SKILLS_DIR = join(homedir(), ".duet", "skills");
@@ -29,11 +32,9 @@ export interface SkillsResponse {
   skills: RemoteSkill[];
 }
 
-export interface SyncSkillsResult {
-  status: "unchanged" | "synced";
-  hash: string;
-  count: number;
-}
+export type SyncSkillsResult =
+  | { status: "unchanged"; hash: string }
+  | { status: "synced"; hash: string; count: number };
 
 export interface SyncSkillsOptions {
   apiKey: string;
@@ -51,16 +52,34 @@ export interface SyncSkillsOptions {
   runShell?: (script: string) => Promise<{ exitCode: number; stderr: string }>;
 }
 
-export async function fetchDefaultSkills(options: {
+export interface FetchSkillsOptions {
   apiKey: string;
   appBaseUrl?: string;
   fetchFn?: typeof fetch;
-}): Promise<SkillsResponse> {
+  /** Sent as `If-None-Match`; server returns 304 when it still matches. */
+  knownHash?: string | null;
+}
+
+export type FetchSkillsResult =
+  | { status: "not-modified"; hash: string }
+  | { status: "modified"; payload: SkillsResponse };
+
+export async function fetchDefaultSkills(options: FetchSkillsOptions): Promise<FetchSkillsResult> {
   const baseUrl = options.appBaseUrl ?? resolveDuetAppBaseUrl();
   const fetchFn = options.fetchFn ?? fetch;
-  const response = await fetchFn(`${baseUrl}/api/v1/cli/skills`, {
-    headers: { Authorization: `Bearer ${options.apiKey}` },
-  });
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${options.apiKey}`,
+  };
+  if (options.knownHash) {
+    headers["If-None-Match"] = `"${options.knownHash}"`;
+  }
+  const response = await fetchFn(`${baseUrl}/api/v1/cli/skills`, { headers });
+  if (response.status === 304) {
+    if (!options.knownHash) {
+      throw new Error("Server returned 304 without a known hash to compare");
+    }
+    return { status: "not-modified", hash: options.knownHash };
+  }
   if (!response.ok) {
     const detail = (await safeReadText(response)).slice(0, 256);
     throw new Error(
@@ -71,12 +90,11 @@ export async function fetchDefaultSkills(options: {
   if (!body || typeof body.hash !== "string" || !Array.isArray(body.skills)) {
     throw new Error("Unexpected skills response shape");
   }
-
   const recomputed = hashSkills(body.skills);
   if (recomputed !== body.hash) {
     throw new Error("Skill payload hash mismatch — refusing to write");
   }
-  return body;
+  return { status: "modified", payload: body };
 }
 
 export function hashSkills(skills: readonly RemoteSkill[]): string {
@@ -95,16 +113,19 @@ export async function syncDefaultSkills(options: SyncSkillsOptions): Promise<Syn
   const hashFilePath = options.hashFilePath ?? DEFAULT_SKILLS_HASH_FILE;
   const register = options.registerSkills ?? true;
 
-  const payload = await fetchDefaultSkills({
+  const knownHash = await readExistingHash(hashFilePath);
+  const fetched = await fetchDefaultSkills({
     apiKey: options.apiKey,
     appBaseUrl: options.appBaseUrl,
     fetchFn: options.fetchFn,
+    knownHash,
   });
 
-  const existing = await readExistingHash(hashFilePath);
-  if (existing === payload.hash) {
-    return { status: "unchanged", hash: payload.hash, count: payload.skills.length };
+  if (fetched.status === "not-modified") {
+    return { status: "unchanged", hash: fetched.hash };
   }
+
+  const payload = fetched.payload;
 
   await rm(skillsDir, { recursive: true, force: true });
   await mkdir(skillsDir, { recursive: true });

--- a/src/lib/sync-skills.ts
+++ b/src/lib/sync-skills.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { resolveDuetAppBaseUrl } from "./duet-app-url.js";
+
+/**
+ * Mirror of the chat-app default-skill sync, kept byte-identical so the
+ * server's hash and the CLI's local hash match. The chat-app endpoint
+ * already renders placeholders against the caller's org; the CLI just
+ * verifies the returned hash, dumps the files into ~/.duet/skills/, and
+ * registers them with the local agent harness via `skills add`.
+ *
+ * On any kind of registration failure we leave the on-disk hash untouched
+ * so the next `duet login` (or `duet login --sync-skills-only`) retries
+ * the write.
+ */
+
+const DEFAULT_SKILLS_DIR = join(homedir(), ".duet", "skills");
+const DEFAULT_SKILLS_HASH_FILE = join(homedir(), ".duet", ".skills-hash");
+
+export interface RemoteSkill {
+  path: string;
+  content: string;
+}
+
+export interface SkillsResponse {
+  hash: string;
+  skills: RemoteSkill[];
+}
+
+export interface SyncSkillsResult {
+  status: "unchanged" | "synced";
+  hash: string;
+  count: number;
+}
+
+export interface SyncSkillsOptions {
+  apiKey: string;
+  /** Override the Duet app base URL; defaults to `resolveDuetAppBaseUrl()`. */
+  appBaseUrl?: string;
+  /** Override `~/.duet/skills` (testing). */
+  skillsDir?: string;
+  /** Override `~/.duet/.skills-hash` (testing). */
+  hashFilePath?: string;
+  /** Inject HTTP for tests. Defaults to global `fetch`. */
+  fetchFn?: typeof fetch;
+  /** Skip running `skills add`; tests pass false. */
+  registerSkills?: boolean;
+  /** Override the registration step; tests inject a no-op. */
+  runShell?: (script: string) => Promise<{ exitCode: number; stderr: string }>;
+}
+
+export async function fetchDefaultSkills(options: {
+  apiKey: string;
+  appBaseUrl?: string;
+  fetchFn?: typeof fetch;
+}): Promise<SkillsResponse> {
+  const baseUrl = options.appBaseUrl ?? resolveDuetAppBaseUrl();
+  const fetchFn = options.fetchFn ?? fetch;
+  const response = await fetchFn(`${baseUrl}/api/v1/cli/skills`, {
+    headers: { Authorization: `Bearer ${options.apiKey}` },
+  });
+  if (!response.ok) {
+    const detail = (await safeReadText(response)).slice(0, 256);
+    throw new Error(
+      `Failed to fetch default skills: ${response.status} ${response.statusText}${detail ? ` — ${detail}` : ""}`,
+    );
+  }
+  const body = (await response.json()) as SkillsResponse;
+  if (!body || typeof body.hash !== "string" || !Array.isArray(body.skills)) {
+    throw new Error("Unexpected skills response shape");
+  }
+
+  const recomputed = hashSkills(body.skills);
+  if (recomputed !== body.hash) {
+    throw new Error("Skill payload hash mismatch — refusing to write");
+  }
+  return body;
+}
+
+export function hashSkills(skills: readonly RemoteSkill[]): string {
+  const hash = createHash("sha256");
+  for (const skill of [...skills].sort((a, b) => a.path.localeCompare(b.path))) {
+    hash.update(skill.path);
+    hash.update("\0");
+    hash.update(skill.content);
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+export async function syncDefaultSkills(options: SyncSkillsOptions): Promise<SyncSkillsResult> {
+  const skillsDir = options.skillsDir ?? DEFAULT_SKILLS_DIR;
+  const hashFilePath = options.hashFilePath ?? DEFAULT_SKILLS_HASH_FILE;
+  const register = options.registerSkills ?? true;
+
+  const payload = await fetchDefaultSkills({
+    apiKey: options.apiKey,
+    appBaseUrl: options.appBaseUrl,
+    fetchFn: options.fetchFn,
+  });
+
+  const existing = await readExistingHash(hashFilePath);
+  if (existing === payload.hash) {
+    return { status: "unchanged", hash: payload.hash, count: payload.skills.length };
+  }
+
+  await rm(skillsDir, { recursive: true, force: true });
+  await mkdir(skillsDir, { recursive: true });
+
+  for (const skill of payload.skills) {
+    const target = resolve(skillsDir, skill.path);
+    if (!isInsideDirectory(skillsDir, target)) {
+      throw new Error(`Refusing to write skill outside ${skillsDir}: ${skill.path}`);
+    }
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, skill.content);
+  }
+
+  if (register) {
+    const runShell = options.runShell ?? defaultRunShell;
+    const result = await runShell(`skills add ${shellQuote(skillsDir)} -g -y`);
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `\`skills add\` failed (exit ${result.exitCode}): ${result.stderr.trim() || "no stderr"}`,
+      );
+    }
+  }
+
+  await mkdir(dirname(hashFilePath), { recursive: true });
+  await writeFile(hashFilePath, payload.hash);
+
+  return { status: "synced", hash: payload.hash, count: payload.skills.length };
+}
+
+async function readExistingHash(path: string): Promise<string | null> {
+  try {
+    return (await readFile(path, "utf8")).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function isInsideDirectory(dir: string, candidate: string): boolean {
+  const resolved = resolve(candidate);
+  const normalizedDir = resolve(dir) + (dir.endsWith("/") ? "" : "/");
+  return resolved === resolve(dir) || resolved.startsWith(normalizedDir);
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:=+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+async function defaultRunShell(script: string): Promise<{ exitCode: number; stderr: string }> {
+  const { spawn } = await import("node:child_process");
+  return await new Promise((resolve, reject) => {
+    const child = spawn("bash", ["-lc", script], { stdio: ["ignore", "inherit", "pipe"] });
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+      process.stderr.write(chunk);
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      resolve({ exitCode: code ?? 1, stderr });
+    });
+  });
+}

--- a/src/model-resolution/duet-gateway.ts
+++ b/src/model-resolution/duet-gateway.ts
@@ -1,15 +1,19 @@
 import { getModel, type Model } from "@earendil-works/pi-ai";
+import { resolveDuetAppBaseUrl } from "../lib/duet-app-url.js";
 
 const PROVIDER_PREFIX = "duet-gateway";
-const DEFAULT_BASE_URL = "https://duet.so/api/v1/ai-gateway";
+const GATEWAY_PATH = "/api/v1/ai-gateway";
 
 /**
  * The Duet gateway proxies Vercel's AI Gateway 1:1 — same path layout, same
  * request/response contract — and authenticates with a `DUET_API_KEY` token
  * scoped to a single org. Rather than ship a parallel model registry, the
  * `duet-gateway` provider piggybacks on the underlying `vercel-ai-gateway`
- * model definitions and only swaps `baseUrl` to point at Duet (or a custom
- * URL via `DUET_GATEWAY_BASE_URL`).
+ * model definitions and only swaps `baseUrl` to point at Duet.
+ *
+ * The base URL is `${DUET_APP_BASE_URL}${GATEWAY_PATH}`; users only need to
+ * override the app origin via `DUET_APP_BASE_URL` (also used by `duet login`
+ * and the CLI skill sync).
  *
  * Auth flows through pi-ai's existing vercel-ai-gateway path, which reads
  * `AI_GATEWAY_API_KEY` — the CLI shims that env var from `DUET_API_KEY` at
@@ -18,14 +22,13 @@ const DEFAULT_BASE_URL = "https://duet.so/api/v1/ai-gateway";
 
 export const DUET_GATEWAY_PROVIDER = PROVIDER_PREFIX;
 export const DUET_GATEWAY_API_KEY_ENV = "DUET_API_KEY";
-export const DUET_GATEWAY_BASE_URL_ENV = "DUET_GATEWAY_BASE_URL";
 
 export function isDuetGatewayModelName(modelName: string): boolean {
   return modelName.startsWith(`${PROVIDER_PREFIX}:`);
 }
 
 export function getDuetGatewayBaseUrl(): string {
-  return process.env[DUET_GATEWAY_BASE_URL_ENV] ?? DEFAULT_BASE_URL;
+  return `${resolveDuetAppBaseUrl()}${GATEWAY_PATH}`;
 }
 
 /**

--- a/test/cli-login.test.ts
+++ b/test/cli-login.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect } from "bun:test";
@@ -13,18 +13,55 @@ afterEach(async () => {
     await rm(tempRoot, { recursive: true, force: true });
     tempRoot = undefined;
   }
-  delete process.env.DUET_APP_BASE_URL;
   delete process.env.DUET_GATEWAY_BASE_URL;
 });
+
+interface FakeRequest {
+  url: string;
+  headers: Record<string, string>;
+}
+
+interface FakeFetchHandler {
+  (request: FakeRequest): Response | Promise<Response>;
+}
+
+function makeFetch(handler: FakeFetchHandler): {
+  fetchFn: typeof fetch;
+  calls: FakeRequest[];
+} {
+  const calls: FakeRequest[] = [];
+  const fetchFn = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const headers: Record<string, string> = {};
+    const rawHeaders = init?.headers;
+    if (rawHeaders) {
+      const entries =
+        rawHeaders instanceof Headers
+          ? Array.from(rawHeaders.entries())
+          : Array.isArray(rawHeaders)
+            ? rawHeaders
+            : Object.entries(rawHeaders);
+      for (const [k, v] of entries) headers[k] = String(v);
+    }
+    const request: FakeRequest = { url, headers };
+    calls.push(request);
+    return await handler(request);
+  }) as unknown as typeof fetch;
+  return { fetchFn, calls };
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
 
 describe("resolveDuetAppBaseUrl", () => {
   testIfDocker("defaults to https://duet.so", () => {
     expect(resolveDuetAppBaseUrl()).toBe("https://duet.so");
-  });
-
-  testIfDocker("honors DUET_APP_BASE_URL exactly, stripping trailing slash", () => {
-    process.env.DUET_APP_BASE_URL = "https://staging.duet.so/";
-    expect(resolveDuetAppBaseUrl()).toBe("https://staging.duet.so");
   });
 
   testIfDocker("derives from DUET_GATEWAY_BASE_URL by stripping the gateway suffix", () => {
@@ -59,23 +96,47 @@ describe("hashSkills", () => {
 });
 
 describe("fetchDefaultSkills", () => {
+  testIfDocker("sends If-None-Match when a known hash is provided", async () => {
+    const { fetchFn, calls } = makeFetch(() => jsonResponse({ hash: hashSkills([]), skills: [] }));
+    await fetchDefaultSkills({
+      apiKey: "duet_gt_x",
+      appBaseUrl: "https://test",
+      fetchFn,
+      knownHash: "abc123",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.headers["if-none-match"] ?? calls[0]!.headers["If-None-Match"]).toBe(
+      `"abc123"`,
+    );
+    expect(calls[0]!.headers.authorization ?? calls[0]!.headers.Authorization).toBe(
+      "Bearer duet_gt_x",
+    );
+  });
+
+  testIfDocker("returns not-modified on 304", async () => {
+    const { fetchFn } = makeFetch(() => new Response(null, { status: 304 }));
+    const result = await fetchDefaultSkills({
+      apiKey: "duet_gt_x",
+      appBaseUrl: "https://test",
+      fetchFn,
+      knownHash: "abc123",
+    });
+    expect(result).toEqual({ status: "not-modified", hash: "abc123" });
+  });
+
   testIfDocker("rejects payloads whose hash doesn't match the body", async () => {
-    const fetchFn = (async () =>
-      new Response(
-        JSON.stringify({
-          hash: "deadbeef",
-          skills: [{ path: "a/SKILL.md", content: "alpha" }],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      )) as unknown as typeof fetch;
+    const { fetchFn } = makeFetch(() =>
+      jsonResponse({ hash: "deadbeef", skills: [{ path: "a/SKILL.md", content: "alpha" }] }),
+    );
     await expect(
       fetchDefaultSkills({ apiKey: "duet_gt_x", appBaseUrl: "https://test", fetchFn }),
     ).rejects.toThrow(/hash mismatch/i);
   });
 
   testIfDocker("surfaces error bodies on non-2xx responses", async () => {
-    const fetchFn = (async () =>
-      new Response("nope", { status: 401, statusText: "Unauthorized" })) as unknown as typeof fetch;
+    const { fetchFn } = makeFetch(
+      () => new Response("nope", { status: 401, statusText: "Unauthorized" }),
+    );
     await expect(
       fetchDefaultSkills({ apiKey: "duet_gt_x", appBaseUrl: "https://test", fetchFn }),
     ).rejects.toThrow(/401.*Unauthorized.*nope/);
@@ -83,7 +144,7 @@ describe("fetchDefaultSkills", () => {
 });
 
 describe("syncDefaultSkills", () => {
-  async function makePayload(skills: { path: string; content: string }[]) {
+  function makePayload(skills: { path: string; content: string }[]) {
     return { hash: hashSkills(skills), skills };
   }
 
@@ -92,15 +153,11 @@ describe("syncDefaultSkills", () => {
     const skillsDir = join(root, "skills");
     const hashFilePath = join(root, ".skills-hash");
 
-    const payload = await makePayload([
+    const payload = makePayload([
       { path: "alpha/SKILL.md", content: "---\nname: alpha\n---\nalpha body" },
       { path: "alpha/reference/notes.md", content: "more notes" },
     ]);
-    const fetchFn = (async () =>
-      new Response(JSON.stringify(payload), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })) as unknown as typeof fetch;
+    const { fetchFn } = makeFetch(() => jsonResponse(payload));
 
     let registeredScript: string | null = null;
     const result = await syncDefaultSkills({
@@ -115,7 +172,7 @@ describe("syncDefaultSkills", () => {
       },
     });
 
-    expect(result.status).toBe("synced");
+    if (result.status !== "synced") throw new Error("expected synced");
     expect(result.count).toBe(2);
     expect(registeredScript).not.toBeNull();
     expect(registeredScript!).toContain(`skills add ${skillsDir}`);
@@ -125,35 +182,54 @@ describe("syncDefaultSkills", () => {
     expect(await readFile(hashFilePath, "utf8")).toBe(payload.hash);
   });
 
-  testIfDocker("skips when the hash matches the existing on-disk hash", async () => {
+  testIfDocker("sends If-None-Match when ~/.duet/.skills-hash exists", async () => {
     const root = (tempRoot = await mkdtemp(join(tmpdir(), "duet-cli-login-")));
     const skillsDir = join(root, "skills");
     const hashFilePath = join(root, ".skills-hash");
-
-    const payload = await makePayload([{ path: "a/SKILL.md", content: "alpha" }]);
-    await mkdir(root, { recursive: true });
+    const payload = makePayload([{ path: "a/SKILL.md", content: "alpha" }]);
     await writeFile(hashFilePath, payload.hash);
 
-    let registered = false;
+    const { fetchFn, calls } = makeFetch(() => new Response(null, { status: 304 }));
+
     const result = await syncDefaultSkills({
       apiKey: "duet_gt_x",
       appBaseUrl: "https://test",
       skillsDir,
       hashFilePath,
-      fetchFn: (async () =>
-        new Response(JSON.stringify(payload), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        })) as unknown as typeof fetch,
+      fetchFn,
       runShell: async () => {
-        registered = true;
-        return { exitCode: 0, stderr: "" };
+        throw new Error("registration must not run on 304");
       },
     });
 
     expect(result.status).toBe("unchanged");
-    expect(registered).toBe(false);
+    if (result.status === "unchanged") expect(result.hash).toBe(payload.hash);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.headers["if-none-match"] ?? calls[0]!.headers["If-None-Match"]).toBe(
+      `"${payload.hash}"`,
+    );
     await expect(stat(skillsDir)).rejects.toThrow();
+  });
+
+  testIfDocker("omits If-None-Match when no on-disk hash exists yet", async () => {
+    const root = (tempRoot = await mkdtemp(join(tmpdir(), "duet-cli-login-")));
+    const skillsDir = join(root, "skills");
+    const hashFilePath = join(root, ".skills-hash");
+    const payload = makePayload([{ path: "a/SKILL.md", content: "alpha" }]);
+
+    const { fetchFn, calls } = makeFetch(() => jsonResponse(payload));
+    await syncDefaultSkills({
+      apiKey: "duet_gt_x",
+      appBaseUrl: "https://test",
+      skillsDir,
+      hashFilePath,
+      fetchFn,
+      runShell: async () => ({ exitCode: 0, stderr: "" }),
+    });
+
+    expect(
+      calls[0]!.headers["if-none-match"] ?? calls[0]!.headers["If-None-Match"],
+    ).toBeUndefined();
   });
 
   testIfDocker("does not update the hash when skills add fails", async () => {
@@ -161,12 +237,8 @@ describe("syncDefaultSkills", () => {
     const skillsDir = join(root, "skills");
     const hashFilePath = join(root, ".skills-hash");
 
-    const payload = await makePayload([{ path: "a/SKILL.md", content: "alpha" }]);
-    const fetchFn = (async () =>
-      new Response(JSON.stringify(payload), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })) as unknown as typeof fetch;
+    const payload = makePayload([{ path: "a/SKILL.md", content: "alpha" }]);
+    const { fetchFn } = makeFetch(() => jsonResponse(payload));
 
     await expect(
       syncDefaultSkills({
@@ -187,7 +259,8 @@ describe("syncDefaultSkills", () => {
     const skillsDir = join(root, "skills");
     const hashFilePath = join(root, ".skills-hash");
 
-    const payload = await makePayload([{ path: "../escape.md", content: "should not be written" }]);
+    const payload = makePayload([{ path: "../escape.md", content: "should not be written" }]);
+    const { fetchFn } = makeFetch(() => jsonResponse(payload));
 
     await expect(
       syncDefaultSkills({
@@ -195,11 +268,7 @@ describe("syncDefaultSkills", () => {
         appBaseUrl: "https://test",
         skillsDir,
         hashFilePath,
-        fetchFn: (async () =>
-          new Response(JSON.stringify(payload), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })) as unknown as typeof fetch,
+        fetchFn,
         runShell: async () => ({ exitCode: 0, stderr: "" }),
       }),
     ).rejects.toThrow(/Refusing to write skill outside/);

--- a/test/cli-login.test.ts
+++ b/test/cli-login.test.ts
@@ -13,7 +13,7 @@ afterEach(async () => {
     await rm(tempRoot, { recursive: true, force: true });
     tempRoot = undefined;
   }
-  delete process.env.DUET_GATEWAY_BASE_URL;
+  delete process.env.DUET_APP_BASE_URL;
 });
 
 interface FakeRequest {
@@ -64,14 +64,9 @@ describe("resolveDuetAppBaseUrl", () => {
     expect(resolveDuetAppBaseUrl()).toBe("https://duet.so");
   });
 
-  testIfDocker("derives from DUET_GATEWAY_BASE_URL by stripping the gateway suffix", () => {
-    process.env.DUET_GATEWAY_BASE_URL = "https://staging.duet.so/api/v1/ai-gateway";
+  testIfDocker("honors DUET_APP_BASE_URL, stripping the trailing slash", () => {
+    process.env.DUET_APP_BASE_URL = "https://staging.duet.so/";
     expect(resolveDuetAppBaseUrl()).toBe("https://staging.duet.so");
-  });
-
-  testIfDocker("falls back to default when DUET_GATEWAY_BASE_URL has no expected suffix", () => {
-    process.env.DUET_GATEWAY_BASE_URL = "https://example.com/something-else";
-    expect(resolveDuetAppBaseUrl()).toBe("https://duet.so");
   });
 });
 

--- a/test/cli-login.test.ts
+++ b/test/cli-login.test.ts
@@ -1,0 +1,207 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect } from "bun:test";
+import { resolveDuetAppBaseUrl } from "../src/lib/duet-app-url.js";
+import { fetchDefaultSkills, hashSkills, syncDefaultSkills } from "../src/lib/sync-skills.js";
+import { testIfDocker } from "./helpers/docker-only.js";
+
+let tempRoot: string | undefined;
+
+afterEach(async () => {
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true });
+    tempRoot = undefined;
+  }
+  delete process.env.DUET_APP_BASE_URL;
+  delete process.env.DUET_GATEWAY_BASE_URL;
+});
+
+describe("resolveDuetAppBaseUrl", () => {
+  testIfDocker("defaults to https://duet.so", () => {
+    expect(resolveDuetAppBaseUrl()).toBe("https://duet.so");
+  });
+
+  testIfDocker("honors DUET_APP_BASE_URL exactly, stripping trailing slash", () => {
+    process.env.DUET_APP_BASE_URL = "https://staging.duet.so/";
+    expect(resolveDuetAppBaseUrl()).toBe("https://staging.duet.so");
+  });
+
+  testIfDocker("derives from DUET_GATEWAY_BASE_URL by stripping the gateway suffix", () => {
+    process.env.DUET_GATEWAY_BASE_URL = "https://staging.duet.so/api/v1/ai-gateway";
+    expect(resolveDuetAppBaseUrl()).toBe("https://staging.duet.so");
+  });
+
+  testIfDocker("falls back to default when DUET_GATEWAY_BASE_URL has no expected suffix", () => {
+    process.env.DUET_GATEWAY_BASE_URL = "https://example.com/something-else";
+    expect(resolveDuetAppBaseUrl()).toBe("https://duet.so");
+  });
+});
+
+describe("hashSkills", () => {
+  testIfDocker("hashes the same regardless of input order", () => {
+    const a = hashSkills([
+      { path: "a/SKILL.md", content: "alpha" },
+      { path: "b/SKILL.md", content: "beta" },
+    ]);
+    const b = hashSkills([
+      { path: "b/SKILL.md", content: "beta" },
+      { path: "a/SKILL.md", content: "alpha" },
+    ]);
+    expect(a).toBe(b);
+  });
+
+  testIfDocker("changes when content changes", () => {
+    const before = hashSkills([{ path: "a/SKILL.md", content: "alpha" }]);
+    const after = hashSkills([{ path: "a/SKILL.md", content: "alpha-v2" }]);
+    expect(before).not.toBe(after);
+  });
+});
+
+describe("fetchDefaultSkills", () => {
+  testIfDocker("rejects payloads whose hash doesn't match the body", async () => {
+    const fetchFn = (async () =>
+      new Response(
+        JSON.stringify({
+          hash: "deadbeef",
+          skills: [{ path: "a/SKILL.md", content: "alpha" }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof fetch;
+    await expect(
+      fetchDefaultSkills({ apiKey: "duet_gt_x", appBaseUrl: "https://test", fetchFn }),
+    ).rejects.toThrow(/hash mismatch/i);
+  });
+
+  testIfDocker("surfaces error bodies on non-2xx responses", async () => {
+    const fetchFn = (async () =>
+      new Response("nope", { status: 401, statusText: "Unauthorized" })) as unknown as typeof fetch;
+    await expect(
+      fetchDefaultSkills({ apiKey: "duet_gt_x", appBaseUrl: "https://test", fetchFn }),
+    ).rejects.toThrow(/401.*Unauthorized.*nope/);
+  });
+});
+
+describe("syncDefaultSkills", () => {
+  async function makePayload(skills: { path: string; content: string }[]) {
+    return { hash: hashSkills(skills), skills };
+  }
+
+  testIfDocker("writes new skills, updates the hash, and invokes skills add", async () => {
+    const root = (tempRoot = await mkdtemp(join(tmpdir(), "duet-cli-login-")));
+    const skillsDir = join(root, "skills");
+    const hashFilePath = join(root, ".skills-hash");
+
+    const payload = await makePayload([
+      { path: "alpha/SKILL.md", content: "---\nname: alpha\n---\nalpha body" },
+      { path: "alpha/reference/notes.md", content: "more notes" },
+    ]);
+    const fetchFn = (async () =>
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    let registeredScript: string | null = null;
+    const result = await syncDefaultSkills({
+      apiKey: "duet_gt_x",
+      appBaseUrl: "https://test",
+      skillsDir,
+      hashFilePath,
+      fetchFn,
+      runShell: async (script: string) => {
+        registeredScript = script;
+        return { exitCode: 0, stderr: "" };
+      },
+    });
+
+    expect(result.status).toBe("synced");
+    expect(result.count).toBe(2);
+    expect(registeredScript).not.toBeNull();
+    expect(registeredScript!).toContain(`skills add ${skillsDir}`);
+    expect(registeredScript!).toContain("-g -y");
+    expect(await readFile(join(skillsDir, "alpha/SKILL.md"), "utf8")).toContain("alpha body");
+    expect(await readFile(join(skillsDir, "alpha/reference/notes.md"), "utf8")).toBe("more notes");
+    expect(await readFile(hashFilePath, "utf8")).toBe(payload.hash);
+  });
+
+  testIfDocker("skips when the hash matches the existing on-disk hash", async () => {
+    const root = (tempRoot = await mkdtemp(join(tmpdir(), "duet-cli-login-")));
+    const skillsDir = join(root, "skills");
+    const hashFilePath = join(root, ".skills-hash");
+
+    const payload = await makePayload([{ path: "a/SKILL.md", content: "alpha" }]);
+    await mkdir(root, { recursive: true });
+    await writeFile(hashFilePath, payload.hash);
+
+    let registered = false;
+    const result = await syncDefaultSkills({
+      apiKey: "duet_gt_x",
+      appBaseUrl: "https://test",
+      skillsDir,
+      hashFilePath,
+      fetchFn: (async () =>
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })) as unknown as typeof fetch,
+      runShell: async () => {
+        registered = true;
+        return { exitCode: 0, stderr: "" };
+      },
+    });
+
+    expect(result.status).toBe("unchanged");
+    expect(registered).toBe(false);
+    await expect(stat(skillsDir)).rejects.toThrow();
+  });
+
+  testIfDocker("does not update the hash when skills add fails", async () => {
+    const root = (tempRoot = await mkdtemp(join(tmpdir(), "duet-cli-login-")));
+    const skillsDir = join(root, "skills");
+    const hashFilePath = join(root, ".skills-hash");
+
+    const payload = await makePayload([{ path: "a/SKILL.md", content: "alpha" }]);
+    const fetchFn = (async () =>
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    await expect(
+      syncDefaultSkills({
+        apiKey: "duet_gt_x",
+        appBaseUrl: "https://test",
+        skillsDir,
+        hashFilePath,
+        fetchFn,
+        runShell: async () => ({ exitCode: 1, stderr: "boom" }),
+      }),
+    ).rejects.toThrow(/skills add.*failed/i);
+
+    await expect(stat(hashFilePath)).rejects.toThrow();
+  });
+
+  testIfDocker("rejects skill paths that escape the skills directory", async () => {
+    const root = (tempRoot = await mkdtemp(join(tmpdir(), "duet-cli-login-")));
+    const skillsDir = join(root, "skills");
+    const hashFilePath = join(root, ".skills-hash");
+
+    const payload = await makePayload([{ path: "../escape.md", content: "should not be written" }]);
+
+    await expect(
+      syncDefaultSkills({
+        apiKey: "duet_gt_x",
+        appBaseUrl: "https://test",
+        skillsDir,
+        hashFilePath,
+        fetchFn: (async () =>
+          new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })) as unknown as typeof fetch,
+        runShell: async () => ({ exitCode: 0, stderr: "" }),
+      }),
+    ).rejects.toThrow(/Refusing to write skill outside/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `duet login`: browser-based auth flow that drops the org's sandbox API key into `~/.duet/.env` and syncs the default skills locally — pairing with chat-app PR [#1245](https://github.com/aomni-com/chat-app/pull/1245).

## How it works

1. `duet login` picks a free localhost port, generates a 24-byte base64url CSRF state, and opens `https://duet.so/cli/login?port=<n>&state=<s>` in the browser.
2. The chat-app page (added in PR #1245) requires WorkOS sign-in, mints a one-time 5-minute code, and 302's the browser to `http://127.0.0.1:<n>/callback?code=…&state=…`.
3. The CLI's ephemeral HTTP server validates the state, then `POST`s `<app>/api/v1/cli/exchange` with `{ code, state }` and gets back `{ apiKey, orgSlug, orgName, appUrl }`.
4. `DUET_API_KEY` is merged into the shared env file via the existing `mergeEnvEntries` helper used by `duet setup`.
5. Default skills are pulled from `<app>/api/v1/cli/skills`, hash-compared against `~/.duet/.skills-hash`, and on mismatch the whole `~/.duet/skills/` tree is wiped + rewritten + re-registered with `skills add ~/.duet/skills -g -y`. Hash is only persisted on a successful registration so a failure self-heals on next login.

## Hash protocol

Byte-identical to the chat-app sandbox sync so the server's hash and the client's recomputed hash always match: SHA-256 of `path\0content\0` pairs sorted alphabetically by path, hex digest. The CLI also recomputes the hash from the response body and refuses to write if it doesn't match what the server claims — a cheap integrity check on top of HTTPS.

## Flags

```
duet login [--env-file <path>] [--no-browser] [--skip-skill-sync]
```

- `--env-file` — override the destination env file (default `~/.duet/.env`)
- `--no-browser` — print the URL instead of spawning a browser
- `--skip-skill-sync` — skip the post-login default-skill sync

## App URL resolution

`https://duet.so` by default. Override via `DUET_APP_BASE_URL`, or derive automatically by setting `DUET_GATEWAY_BASE_URL=https://staging.duet.so/api/v1/ai-gateway` (the existing gateway env var) — the suffix is stripped, so one env var re-points both AI gateway calls and CLI auth/sync calls.

## Test plan

- [x] `bun run build` — clean
- [x] `bun run lint` — 0 errors
- [x] `bun src/cli.ts login --help` renders correctly
- [ ] `bun run test` (CI / docker) — covers `resolveDuetAppBaseUrl`, `hashSkills` order-independence, `fetchDefaultSkills` hash-mismatch + error-body propagation, `syncDefaultSkills` write+register+persist path, hash-skip path, `skills add` failure preserving the previous hash, and path-traversal guard.
- [ ] Manual end-to-end after chat-app PR #1245 deploys to staging:
  - `DUET_APP_BASE_URL=https://staging.duet.so duet login` opens browser, completes auth, writes API key, syncs skills.
  - Re-running `duet login` reports "Default skills already up to date".
  - `~/.duet/skills/<id>/SKILL.md` includes the rendered org slug.