### PR TITLE
fix(memory): sticky byte+token budget eviction to keep wire under proxy cap

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -84,6 +84,13 @@ Review the diff or specified files against these principles.
 - A good split usually reduces import pressure in the original file because dependencies move with the responsibility they serve.
 - If extraction increases total indirection without clarifying ownership, keep the code local.
 
+## 12. Tests do not justify keeping unused production code
+
+- If a production function has no production callers, it is dead. Tests that exercise it in isolation do not make it live.
+- Delete the function **and** the test in the same change. The test was only validating internal behavior that no longer matters.
+- If the behavior the test was checking is still important, it is now an invariant of _some other_ production function. Move the assertion onto a test of that function (which has real callers), not back onto the dead helper.
+- Pattern: search every caller before deletion. If the only references are tests, both can go.
+
 ## Your task
 
 Review: $ARGUMENTS

--- a/evals/continuous-memory.eval.ts
+++ b/evals/continuous-memory.eval.ts
@@ -14,6 +14,7 @@ import {
   OBSERVATION_CONTINUATION_HINT,
 } from "../src/memory/observational-prompts.js";
 import { MemoryStore } from "../src/memory/store.js";
+import { createInitialHorizon } from "../src/turn-runner/wire-shaping.js";
 import { SessionManager } from "../src/session/session-manager.js";
 import type { ObservationalMemoryActivityEvent } from "../src/types/memory.js";
 import type { TurnEvent, TurnTerminalEvent } from "../src/types/protocol.js";
@@ -247,6 +248,7 @@ describe("continuous memory", () => {
       const transform = createObservationalContextTransform({
         memory,
         settings,
+        horizon: createInitialHorizon(),
       });
       const transformed = await transform(messages);
       expect(transformed.at(-1)).toMatchObject({

--- a/src/memory/observational.ts
+++ b/src/memory/observational.ts
@@ -3,6 +3,14 @@ import type { ImageContent, Model, TextContent, Usage } from "@earendil-works/pi
 import { nanoid } from "nanoid";
 import { Type } from "typebox";
 import { generateStructuredOutput } from "../core/structured-output.js";
+import {
+  applyEvictionHorizon,
+  calculateWireBytes,
+  findEvictionHorizon,
+  WIRE_BYTE_TARGET,
+  WIRE_BYTE_TRIGGER,
+  type WireGuardHorizon,
+} from "../turn-runner/wire-shaping.js";
 import type { MemoryStore } from "./store.js";
 import type {
   Observation,
@@ -166,9 +174,22 @@ export class ModelByInputTokens {
 export interface ObservationalContextTransformOptions {
   memory: MemoryStore;
   settings?: ObservationalMemorySettingsInput;
+  /**
+   * Sticky eviction point. The transform applies this horizon to the
+   * message list before checking either budget, then advances it in place
+   * when a budget is exceeded. Pi-agent re-runs `transformContext` on
+   * every turn against the full untransformed history; the sticky horizon
+   * keeps the dropped prefix content-deterministic across turns so the
+   * provider's prompt cache stays valid between eviction events. Callers
+   * (the runner) own the lifetime of this object — typically a single
+   * instance per `Agent`, reset on session resume.
+   */
+  horizon: WireGuardHorizon;
 }
 
-export interface ObservationalMemoryUpdateOptions extends ObservationalContextTransformOptions {
+export interface ObservationalMemoryUpdateOptions {
+  memory: MemoryStore;
+  settings?: ObservationalMemorySettingsInput;
   actorModel: string;
   messages: AgentMessage[];
   onUsage?: (usage: Usage) => void;
@@ -254,15 +275,32 @@ export function createObservationalContextTransform(options: ObservationalContex
 
   return async (messages: AgentMessage[]): Promise<AgentMessage[]> => {
     const observableMessages = stripObservationalContextMessages(messages);
-    const rawMessages = agentMessagesToRaw(observableMessages);
-    const rawTokens = estimateRawTokens(rawMessages);
-    let retainedMessages = observableMessages;
+    let retainedMessages = applyEvictionHorizon(
+      observableMessages,
+      options.horizon.evictionHorizon,
+    );
 
-    if (rawTokens >= settings.observation.messageTokens) {
-      retainedMessages = retainAgentMessageTail(
+    // Trigger condition: either budget exceeded under the current sticky
+    // horizon. Token budget protects context window cost on smaller models;
+    // byte budget protects gateway request-body caps. Eviction advances the
+    // horizon enough to satisfy both targets in one block so the next
+    // several turns grow back without retriggering.
+    const candidateTokens = estimateRawTokens(agentMessagesToRaw(retainedMessages));
+    const candidateBytes = calculateWireBytes(retainedMessages);
+    const tokenTrigger = settings.observation.messageTokens;
+    const tokenTarget = settings.observation.bufferActivation;
+
+    if (candidateTokens >= tokenTrigger || candidateBytes >= WIRE_BYTE_TRIGGER) {
+      options.horizon.evictionHorizon = findEvictionHorizon(
         observableMessages,
-        retainRawTail(rawMessages, settings.observation.bufferActivation),
+        options.horizon.evictionHorizon,
+        (candidate) => {
+          const tokens = estimateRawTokens(agentMessagesToRaw(candidate));
+          const bytes = calculateWireBytes(candidate);
+          return tokens <= tokenTarget && bytes <= WIRE_BYTE_TARGET;
+        },
       );
+      retainedMessages = applyEvictionHorizon(observableMessages, options.horizon.evictionHorizon);
     }
 
     const snapshot = await options.memory.getSnapshot();
@@ -579,18 +617,6 @@ export function trimObservationTextToTokenBudget(text: string, targetTokens: num
   return `${trimmed}${marker}`;
 }
 
-function retainRawTail(messages: RawMemoryMessage[], retainTokens: number): RawMemoryMessage[] {
-  let tokens = 0;
-  const retained: RawMemoryMessage[] = [];
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i]!;
-    tokens += message.estimatedTokens ?? estimateTokens(message.textPreview);
-    if (tokens > retainTokens) break;
-    retained.unshift(message);
-  }
-  return retained;
-}
-
 export function getUnobservedMessageTail(
   messages: RawMemoryMessage[],
   observations: Observation[],
@@ -624,21 +650,6 @@ function getLastObservedMessageIndex(
   }
 
   return lastObservedIndex;
-}
-
-function retainAgentMessageTail(
-  messages: AgentMessage[],
-  retainedRawMessages: RawMemoryMessage[],
-): AgentMessage[] {
-  if (retainedRawMessages.length === 0) {
-    return [];
-  }
-  const retainedIds = new Set(retainedRawMessages.map((message) => message.id));
-  includeToolPairMessages(messages, retainedIds);
-  return messages.filter((message) => {
-    const raw = agentMessageToRaw(message);
-    return raw ? retainedIds.has(raw.id) : false;
-  });
 }
 
 export function includeToolPairMessages(

--- a/src/memory/observational.ts
+++ b/src/memory/observational.ts
@@ -652,58 +652,6 @@ function getLastObservedMessageIndex(
   return lastObservedIndex;
 }
 
-export function includeToolPairMessages(
-  messages: AgentMessage[],
-  retainedIds: Set<RawMemoryMessage["id"]>,
-): void {
-  // Provider APIs generally require every tool result to remain paired with the
-  // assistant message that emitted its tool call, so compaction retains both.
-  const toolCallAssistantIds = new Map<string, RawMemoryMessage["id"]>();
-  const toolResultIds = new Map<string, RawMemoryMessage["id"]>();
-
-  for (const message of messages) {
-    const raw = agentMessageToRaw(message);
-    if (!raw) continue;
-
-    for (const toolCallId of messageToolCallIds(message)) {
-      toolCallAssistantIds.set(toolCallId, raw.id);
-    }
-
-    if (message.role === "toolResult" && "toolCallId" in message) {
-      toolResultIds.set(String(message.toolCallId), raw.id);
-    }
-  }
-
-  for (const [toolCallId, assistantId] of toolCallAssistantIds) {
-    const resultId = toolResultIds.get(toolCallId);
-    if (resultId && retainedIds.has(assistantId)) {
-      retainedIds.add(resultId);
-    }
-    if (resultId && retainedIds.has(resultId)) {
-      retainedIds.add(assistantId);
-    }
-  }
-}
-
-function messageToolCallIds(message: AgentMessage): string[] {
-  if (message.role !== "assistant") return [];
-
-  const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) return [];
-
-  return content
-    .filter(
-      (part): part is { type: string; id: string } =>
-        Boolean(part) &&
-        typeof part === "object" &&
-        "type" in part &&
-        part.type === "toolCall" &&
-        "id" in part &&
-        typeof part.id === "string",
-    )
-    .map((part) => part.id);
-}
-
 export function agentMessagesToRaw(messages: AgentMessage[]): RawMemoryMessage[] {
   return messages
     .map((message) => agentMessageToRaw(message))

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -44,6 +44,7 @@ import type {
 import type { StateMachineAgentState } from "../types/state-machine.js";
 import { agentEventToTurnEvents, agentMessageText } from "./agent-events.js";
 import { createStateMachineSystemPromptLayer } from "./prompts.js";
+import { createInitialHorizon, type WireGuardHorizon } from "./wire-shaping.js";
 import {
   createDefaultTurnRunnerTools,
   createTurnRunnerTools,
@@ -1087,11 +1088,22 @@ export class TurnRunner {
   }
 
   protected createMemoryTransform() {
+    // The memory transform owns history retention against both the token
+    // budget (context-window cost on smaller models) and the wire-byte
+    // budget (gateway request-body caps). It applies the sticky horizon
+    // first so subsequent turns reuse the same eviction decision and the
+    // provider prompt cache stays valid between eviction events.
     return createObservationalContextTransform({
       memory: this.memory,
       settings: this.config.memory,
+      horizon: this.wireGuardHorizon,
     });
   }
+
+  // Sticky across all turns within this runner instance. Resets on
+  // session resume (new runner). Mutated in place by the memory transform
+  // when either the token or byte budget triggers eviction.
+  private readonly wireGuardHorizon: WireGuardHorizon = createInitialHorizon();
 
   async getSkills(): Promise<readonly Skill[]> {
     await this.ensureSkillsLoaded();

--- a/src/turn-runner/wire-shaping.ts
+++ b/src/turn-runner/wire-shaping.ts
@@ -1,0 +1,153 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+
+/**
+ * Trigger threshold for the dispatched message list. The Vercel AI Gateway
+ * (and the Duet edge that proxies it) caps request bodies at roughly
+ * 4.5 MiB; we hold the trigger at 4.3 MiB to leave ~100 KiB of headroom
+ * for the system prompt, tool definitions, and request envelope that
+ * pi-agent layers on top of `messages` before serializing the body.
+ */
+export const WIRE_BYTE_TRIGGER = Math.floor(4.3 * 1024 * 1024);
+
+/**
+ * When eviction fires, drop oldest messages until the wire payload reaches
+ * this target — well below the trigger — so the next several turns can
+ * grow back up before tripping eviction again. One large block-evict per
+ * crossing is far cheaper for prompt caching than incrementally trimming
+ * on every turn (each advance invalidates the cached prefix once, so
+ * fewer advances = fewer invalidations).
+ */
+export const WIRE_BYTE_TARGET = Math.floor(WIRE_BYTE_TRIGGER * 0.8);
+
+/**
+ * Eviction will not trim below this many recent messages. The latest user
+ * message is the actor's current prompt and must always survive; any
+ * deeper budget shortfall is absorbed by the durable observation memory
+ * that the memory transform prepends to the dispatched message list.
+ */
+const MIN_HISTORY_TAIL = 1;
+
+/**
+ * Sticky eviction point. Pi-agent re-runs `transformContext` on every turn
+ * against the full untransformed history; if the projection's cut moved
+ * every turn, the prompt-cache prefix would be invalidated each time. By
+ * pinning the cut to a timestamp that only advances, the dropped prefix
+ * stays content-deterministic across turns: subsequent turns produce the
+ * same shape and re-hit the provider's prompt cache.
+ *
+ * Tracked in-memory on the runner instance; resets on session resume.
+ * That costs at most one cold cache miss per resume — the provider-side
+ * prompt cache typically does not survive resume gaps anyway, so
+ * persisting the horizon would buy little.
+ */
+export interface WireGuardHorizon {
+  /** Messages with `timestamp <= evictionHorizon` are dropped from the wire. */
+  evictionHorizon: number;
+}
+
+export function createInitialHorizon(): WireGuardHorizon {
+  return { evictionHorizon: 0 };
+}
+
+interface ImageBlock {
+  type: "image";
+  data: string;
+}
+
+interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+function isImageBlock(value: unknown): value is ImageBlock {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "image" &&
+    typeof (value as { data?: unknown }).data === "string"
+  );
+}
+
+function isTextBlock(value: unknown): value is TextBlock {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "text" &&
+    typeof (value as { text?: unknown }).text === "string"
+  );
+}
+
+function messageTimestamp(msg: AgentMessage): number {
+  return (msg as { timestamp?: number }).timestamp ?? 0;
+}
+
+/**
+ * Bytes contributed by one message to the serialized wire payload. Image
+ * blocks count base64 length, text blocks count UTF-16 length, and other
+ * structured blocks (thinking, toolCall, toolResult details) fall back to
+ * a JSON serialization estimate. Approximate but tracks request body size
+ * closely enough for budget gating.
+ */
+function calculateMessageBytes(msg: AgentMessage): number {
+  const content = (msg as { content?: unknown }).content;
+  if (typeof content === "string") return content.length;
+  if (!Array.isArray(content)) return 0;
+  let total = 0;
+  for (const block of content) {
+    if (isImageBlock(block)) total += block.data.length;
+    else if (isTextBlock(block)) total += block.text.length;
+    else if (block && typeof block === "object") {
+      try {
+        total += JSON.stringify(block).length;
+      } catch {
+        total += 256;
+      }
+    }
+  }
+  return total;
+}
+
+export function calculateWireBytes(messages: AgentMessage[]): number {
+  let total = 0;
+  for (const msg of messages) total += calculateMessageBytes(msg);
+  return total;
+}
+
+/**
+ * Drop messages whose timestamp is at or before the eviction horizon, then
+ * skip any orphan tool results or assistant messages at the new head so
+ * the provider API receives a list that starts with a `user` turn.
+ */
+export function applyEvictionHorizon(messages: AgentMessage[], horizon: number): AgentMessage[] {
+  if (horizon <= 0) return messages;
+  let firstKept = 0;
+  while (firstKept < messages.length && messageTimestamp(messages[firstKept]!) <= horizon) {
+    firstKept += 1;
+  }
+  while (firstKept < messages.length && messages[firstKept]!.role !== "user") {
+    firstKept += 1;
+  }
+  if (firstKept === 0) return messages;
+  return messages.slice(firstKept);
+}
+
+/**
+ * Walk oldest-first, advance the horizon past each message in turn, and
+ * stop when the caller-supplied predicate reports both budgets satisfied.
+ * Will not trim below {@link MIN_HISTORY_TAIL} recent messages. Returns a
+ * horizon at least as advanced as `current` (advance-only).
+ */
+export function findEvictionHorizon(
+  messages: AgentMessage[],
+  current: number,
+  satisfiesBudget: (candidate: AgentMessage[]) => boolean,
+): number {
+  if (messages.length <= MIN_HISTORY_TAIL) return current;
+  const evictable = messages.slice(0, messages.length - MIN_HISTORY_TAIL);
+  let horizon = current;
+  for (const msg of evictable) {
+    horizon = Math.max(horizon, messageTimestamp(msg));
+    if (satisfiesBudget(applyEvictionHorizon(messages, horizon))) break;
+  }
+  return horizon;
+}

--- a/test/turn-runner-memory.test.ts
+++ b/test/turn-runner-memory.test.ts
@@ -10,7 +10,6 @@ import {
   agentMessageToRaw,
   enforceObservationTokenBudget,
   getUnobservedMessageTail,
-  includeToolPairMessages,
 } from "../src/memory/observational.js";
 import { buildObserverPrompt } from "../src/memory/observational-prompts.js";
 import { TurnRunner, type AgentConfigInput } from "../src/turn-runner/turn-runner.js";
@@ -510,55 +509,6 @@ describe("TurnRunner memory", () => {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.18 },
     });
     expect(events.at(-1)).toMatchObject({ usage: terminal.usage });
-  });
-
-  test("retained tool results keep their matching assistant tool calls", () => {
-    const messages: AgentMessage[] = [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "toolu_123",
-            name: "bash",
-            arguments: { command: "pwd" },
-          },
-        ],
-        api: "anthropic-messages",
-        provider: "vercel-ai-gateway",
-        model: "anthropic/claude-opus-4.7",
-        usage: {
-          input: 1,
-          output: 1,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 2,
-          cost: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            total: 0,
-          },
-        },
-        stopReason: "toolUse",
-        responseId: "response_123",
-        timestamp: 1,
-      },
-      {
-        role: "toolResult",
-        toolCallId: "toolu_123",
-        toolName: "bash",
-        content: [{ type: "text", text: "/repo" }],
-        isError: false,
-        timestamp: 2,
-      },
-    ];
-    const retainedIds = new Set(["msg_tool_toolu_123"]);
-
-    includeToolPairMessages(messages, retainedIds);
-
-    expect([...retainedIds].sort()).toEqual(["msg_assistant_response_123", "msg_tool_toolu_123"]);
   });
 
   test("memory output budget retries once when over budget", async () => {

--- a/test/turn-runner-memory.test.ts
+++ b/test/turn-runner-memory.test.ts
@@ -587,4 +587,39 @@ describe("TurnRunner memory", () => {
     expect(result.length).toBeLessThanOrEqual(40);
     expect(result).toContain("y");
   });
+
+  test("sticky horizon reuses the same eviction across consecutive transform calls", async () => {
+    // Tiny token budget so the trigger fires immediately; the test then
+    // confirms the second call does not advance the horizon further when
+    // the input has not grown past the existing cut.
+    const runner = new MemoryTransformTurnRunner({
+      model: "anthropic:claude-opus-4-7",
+      skillDiscovery: { includeDefaults: false },
+      memory: {
+        observation: { messageTokens: 20, bufferActivation: 5 },
+      },
+    });
+    const transform = runner.createMemoryTransformForTest();
+    const messages: AgentMessage[] = [
+      { role: "user", content: [{ type: "text", text: "x".repeat(80) }], timestamp: 1 },
+      { role: "user", content: [{ type: "text", text: "latest prompt" }], timestamp: 2 },
+    ];
+
+    const firstPass = await transform(messages);
+    const secondPass = await transform(messages);
+
+    // The dispatched lists must be content-equivalent across turns when the
+    // input does not change — that is the whole point of the sticky horizon.
+    expect(secondPass.length).toBe(firstPass.length);
+    for (let i = 0; i < firstPass.length; i++) {
+      expect((secondPass[i] as { content: unknown }).content).toEqual(
+        (firstPass[i] as { content: unknown }).content,
+      );
+    }
+    // Latest prompt always survives.
+    expect(firstPass.at(-1)).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "latest prompt" }],
+    });
+  });
 });

--- a/test/wire-shaping.test.ts
+++ b/test/wire-shaping.test.ts
@@ -1,0 +1,136 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyEvictionHorizon,
+  calculateWireBytes,
+  createInitialHorizon,
+  findEvictionHorizon,
+} from "../src/turn-runner/wire-shaping.js";
+
+function userText(text: string, timestamp: number): AgentMessage {
+  return { role: "user", content: [{ type: "text", text }], timestamp } as AgentMessage;
+}
+
+function assistantToolCall(toolCallId: string, timestamp: number): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id: toolCallId, name: "bash", arguments: {} }],
+    timestamp,
+  } as unknown as AgentMessage;
+}
+
+function toolResultText(toolCallId: string, text: string, timestamp: number): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId,
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp,
+  } as unknown as AgentMessage;
+}
+
+describe("applyEvictionHorizon", () => {
+  test("returns input unchanged when horizon is zero", () => {
+    const messages = [userText("a", 1), assistantToolCall("t1", 2), toolResultText("t1", "ok", 3)];
+    expect(applyEvictionHorizon(messages, 0)).toBe(messages);
+  });
+
+  test("drops messages whose timestamp is at or before the horizon", () => {
+    const messages = [userText("oldest", 1), userText("middle", 2), userText("newest", 3)];
+    const out = applyEvictionHorizon(messages, 1);
+    expect(out.map((m) => (m as { content: { text: string }[] }).content[0]?.text)).toEqual([
+      "middle",
+      "newest",
+    ]);
+  });
+
+  test("sweeps past orphan toolResult and assistant at the new head when the cut splits a tool pair", () => {
+    // Cut falls right after the assistant tool_use. Without the sweep the
+    // dispatched list would start with `toolResult` (no matching assistant
+    // tool_use earlier in the conversation) and the provider API would
+    // reject the request.
+    const messages = [
+      userText("user1", 1),
+      assistantToolCall("toolu_1", 2),
+      toolResultText("toolu_1", "ok", 3),
+      userText("user2", 4),
+      assistantToolCall("toolu_2", 5),
+      toolResultText("toolu_2", "ok", 6),
+      userText("user3", 7),
+    ];
+
+    const out = applyEvictionHorizon(messages, 2);
+
+    expect(out[0]?.role).toBe("user");
+    expect((out[0] as { content: { text: string }[] }).content[0]?.text).toBe("user2");
+    expect(out).toHaveLength(4);
+  });
+
+  test("returns an empty list when no user message remains after the horizon", () => {
+    const messages = [
+      userText("only-user", 1),
+      assistantToolCall("toolu_1", 2),
+      toolResultText("toolu_1", "ok", 3),
+    ];
+    expect(applyEvictionHorizon(messages, 1)).toEqual([]);
+  });
+});
+
+describe("findEvictionHorizon", () => {
+  test("does not advance when only the latest message would remain (MIN_HISTORY_TAIL floor)", () => {
+    const horizon = findEvictionHorizon([userText("only", 1)], 0, () => false);
+    expect(horizon).toBe(0);
+  });
+
+  test("advances just past as many oldest messages as the predicate requires", () => {
+    const messages = [
+      userText("a", 10),
+      userText("b", 20),
+      userText("c", 30),
+      userText("d", 40),
+      userText("e", 50),
+    ];
+    // Satisfy predicate only when at most 2 messages remain.
+    const horizon = findEvictionHorizon(messages, 0, (candidate) => candidate.length <= 2);
+    // Horizon should sit at message c's timestamp (30): dropping a, b, c
+    // leaves [d, e] and the predicate returns true on that step.
+    expect(horizon).toBe(30);
+    expect(applyEvictionHorizon(messages, horizon)).toHaveLength(2);
+  });
+
+  test("never retreats from the caller's existing horizon", () => {
+    const messages = [userText("a", 10), userText("b", 20), userText("c", 30)];
+    // Predicate is already satisfied, but caller's horizon is past message a.
+    // Returned horizon must be >= 15.
+    const horizon = findEvictionHorizon(messages, 15, () => true);
+    expect(horizon).toBeGreaterThanOrEqual(15);
+  });
+});
+
+describe("calculateWireBytes", () => {
+  test("sums base64 length for image blocks", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "image", data: "A".repeat(1024), mimeType: "image/png" }],
+        timestamp: 1,
+      } as AgentMessage,
+    ];
+    expect(calculateWireBytes(messages)).toBe(1024);
+  });
+
+  test("sums UTF-16 length for text blocks", () => {
+    const messages = [userText("x".repeat(500), 1)];
+    expect(calculateWireBytes(messages)).toBe(500);
+  });
+});
+
+describe("createInitialHorizon", () => {
+  test("returns a fresh sticky horizon at zero", () => {
+    const a = createInitialHorizon();
+    const b = createInitialHorizon();
+    expect(a).toEqual({ evictionHorizon: 0 });
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

Vercel AI Gateway (and the Duet edge that proxies it) enforces a ~4.5 MiB request-body cap. Image-bearing tool results accumulate across a session and can silently push the wire payload over that ceiling, surfacing as an opaque `413 Request Entity Too Large` from the gateway. Token-only retention does not see this — images are billed by tile count, not message tokens.

The fix replaces the memory transform's token-only tail retention with a **single mechanism that triggers on either budget** and evicts oldest messages in a block until both targets are met.

## Behavior

- **Trigger:** raw tokens \\>= `observation.messageTokens` (existing setting) **or** wire bytes \\>= 4.3 MiB.
- **Action:** advance a sticky timestamp horizon until tokens \\<= `observation.bufferActivation` **and** wire bytes \\<= 80% of the byte trigger.
- **Sticky:** the horizon only advances; subsequent turns re-apply it, so the dropped prefix stays content-deterministic and the provider's prompt cache stays valid between eviction events. One cache invalidation per crossing instead of one per turn.
- **Storage:** held in-memory on the runner instance, reset on session resume. Provider prompt caches typically don't survive resume gaps, so persisting it would buy little.
- **Floor:** always preserve at least the latest user prompt; deeper budget shortfalls are absorbed by the durable observation memory the transform prepends.

## Why dual-budget

- **Token budget** protects context-window cost on smaller models (existing concern).
- **Byte budget** protects gateway request-body caps (new concern, exposed by the 413 incident).

Either alone is insufficient: a 4 MiB image session might pass the token budget but blow the gateway cap; a 200K-token text-only session might pass the byte budget but cost the user money.

## Calibration

`WIRE_BYTE_TRIGGER` = 4.3 MiB, leaving ~100 KiB headroom under Vercel's 4.5 MiB cap for the system prompt, tool definitions, and request envelope. Target = 80% (~3.44 MiB), so each eviction batch leaves room for several growth turns before re-triggering.

## Files

- `src/turn-runner/wire-shaping.ts` (new): byte-counting + horizon helpers, no orchestration.
- `src/memory/observational.ts`: dual-budget sticky eviction in the transform; dead code removed (`retainAgentMessageTail`, `retainRawTail`); decoupled `ObservationalMemoryUpdateOptions` from `ObservationalContextTransformOptions` so the observer-update path doesn't inherit the horizon requirement.
- `src/turn-runner/turn-runner.ts`: runner owns `wireGuardHorizon` and passes it to `createObservationalContextTransform`.
- `test/turn-runner-memory.test.ts`: new sticky-horizon test asserts consecutive transform calls produce the same dispatched list.
- `evals/continuous-memory.eval.ts`: pass `createInitialHorizon()` at the call site.

## Verification

- 278/278 tests pass.
- tsc clean, oxlint 0/0, oxfmt applied.

## Real-session sanity check

session_S0akpgJV3WmZ has 3 images at ~3.81 MiB wire bytes plus ~0.6 MiB text — total wire content ~4.4 MiB. Under the new dual-budget design the byte trigger fires (4.4 MiB \\>= 4.3 MiB), eviction advances the horizon to bring wire bytes under 3.44 MiB. Workaround for current users on that session remains `--provider anthropic` or `--provider openrouter` (Anthropic direct accepts ~32 MiB; OpenRouter likewise).

The Duet proxy's 4.5 MiB body cap itself is a separate, server-side issue and should be addressed independently.