### PR TITLE
feat: add `duet send-feedback` command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { runEnvCommand } from "./cli/env.js";
 import { runLoginCommand } from "./cli/login.js";
 import { runMemoryCommand } from "./cli/memory.js";
 import { runRunCommand } from "./cli/run.js";
+import { runSendFeedbackCommand } from "./cli/send-feedback.js";
 import { runSkillsCommand } from "./cli/skills.js";
 import { runUpgradeCommand } from "./cli/upgrade.js";
 import { shimDuetApiKeyToAiGateway } from "./model-resolution/duet-gateway.js";
@@ -36,6 +37,8 @@ export type { LoginCommandIO } from "./cli/login.js";
 export { runSkillsCommand } from "./cli/skills.js";
 export { runUpgradeCommand } from "./cli/upgrade.js";
 export { runMemoryCommand } from "./cli/memory.js";
+export { runSendFeedbackCommand } from "./cli/send-feedback.js";
+export type { SendFeedbackCommandIO } from "./cli/send-feedback.js";
 export {
   cliEnvFilePaths,
   defaultDuetEnvFilePath,
@@ -90,6 +93,10 @@ async function main(): Promise<void> {
     }
     if (subcommand === "memory" || subcommand === "memories") {
       await runMemoryCommand(args.slice(1));
+      return;
+    }
+    if (subcommand === "send-feedback") {
+      await runSendFeedbackCommand(args.slice(1));
       return;
     }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -12,6 +12,7 @@ USAGE
   duet env [--env-file <path>] [--import [path]|--keys]
   duet skills [--workdir <path>]
   duet memory [--db <path>]
+  duet send-feedback [--file <path>] [text...]
   duet upgrade [--manager npm|bun|pnpm|yarn]
   echo "prompt" | duet
 
@@ -20,6 +21,7 @@ COMMANDS
   env                      Manually create or update the shared duet env file with provider API keys
   skills                   List installed skills as JSON (name, description, path, scope)
   memory                   Open a TUI to view, edit, and delete observational memories (alias: memories)
+  send-feedback            Send free-form markdown feedback to the Duet team
   upgrade                  Upgrade the global ${packageName} installation
 
 OPTIONS
@@ -75,6 +77,7 @@ EXAMPLES
   duet login
   duet env
   duet memory
+  duet send-feedback "the TUI flickers when..."
   duet upgrade
 `);
 }
@@ -170,6 +173,25 @@ KEYS
   e                        Edit selected memory in $EDITOR
   d                        Delete selected memory
   q / Esc                  Quit
+`);
+}
+
+export function printSendFeedbackHelp(): void {
+  console.log(`
+duet send-feedback — Send free-form markdown feedback to the Duet team
+
+USAGE
+  duet send-feedback [text...]
+  duet send-feedback --file <path>
+  echo "feedback" | duet send-feedback
+
+Submits a piece of markdown feedback to the Duet team's triage queue. The
+endpoint is public — no API key required. With no input, drops you into an
+interactive prompt; submit an empty line to send.
+
+OPTIONS
+  -f, --file <path>        Read feedback content from a file
+  -h, --help               Show this help
 `);
 }
 

--- a/src/cli/send-feedback.ts
+++ b/src/cli/send-feedback.ts
@@ -1,0 +1,120 @@
+import { readFile } from "node:fs/promises";
+import { createInterface } from "node:readline/promises";
+import { resolveDuetAppBaseUrl } from "../lib/duet-app-url.js";
+import { printSendFeedbackHelp } from "./help.js";
+import { fail, isInteractive, resolveUserPath } from "./shared.js";
+
+export interface SendFeedbackCommandIO {
+  cwd?: string;
+  /** Inject a stand-in for the readline-backed prompt so tests can drive it. */
+  promptForFeedback?: () => Promise<string>;
+  /** Inject a stand-in for fetch so tests can intercept the upload. */
+  fetch?: typeof fetch;
+}
+
+const FEEDBACK_SOURCE = "duet-agent-cli";
+
+/**
+ * Run `duet send-feedback`.
+ *
+ * Submits a piece of free-form markdown feedback to the chat-app's public
+ * feedback endpoint. No API key required — the endpoint is intentionally
+ * unauthenticated so external clients can drop notes into the team's triage
+ * queue without a login.
+ *
+ * Content sources, in priority order:
+ *   1. Positional argument (e.g. `duet send-feedback "thing is broken"`)
+ *   2. `--file <path>` (read markdown from a file)
+ *   3. stdin if piped
+ *   4. Interactive prompt
+ */
+export async function runSendFeedbackCommand(
+  args: string[],
+  io: SendFeedbackCommandIO = {},
+): Promise<void> {
+  const cwd = io.cwd ?? process.cwd();
+  let filePath: string | undefined;
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--file":
+      case "-f":
+        if (!args[i + 1] || args[i + 1]?.startsWith("-")) fail(`Missing value for ${args[i]}`);
+        filePath = args[++i]!;
+        break;
+      case "--help":
+      case "-h":
+        printSendFeedbackHelp();
+        return;
+      default: {
+        const arg = args[i]!;
+        if (arg.startsWith("-")) fail(`Unknown send-feedback option: ${arg}`);
+        positional.push(arg);
+      }
+    }
+  }
+
+  let content = positional.join(" ").trim();
+
+  if (!content && filePath) {
+    content = (await readFile(resolveUserPath(filePath, cwd), "utf8")).trim();
+  }
+
+  if (!content && !process.stdin.isTTY) {
+    content = (await readStdin()).trim();
+  }
+
+  if (!content) {
+    if (!isInteractive()) {
+      fail("No feedback provided. Pass it as an argument, via --file, or pipe it on stdin.");
+    }
+    content = (await (io.promptForFeedback ?? promptForFeedback)()).trim();
+  }
+
+  if (!content) {
+    fail("Feedback content is required.");
+  }
+
+  const url = `${resolveDuetAppBaseUrl()}/api/v1/feedback`;
+  const fetchImpl = io.fetch ?? globalThis.fetch;
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content, source: FEEDBACK_SOURCE }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    fail(`Feedback submission failed (${response.status}): ${text || response.statusText}`);
+  }
+
+  console.error(`Thanks! Feedback sent to ${resolveDuetAppBaseUrl()}.`);
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function promptForFeedback(): Promise<string> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  try {
+    console.error("Type your feedback (markdown). Submit an empty line to send.");
+    const lines: string[] = [];
+    while (true) {
+      const line = await rl.question("> ");
+      if (line.length === 0) break;
+      lines.push(line);
+    }
+    return lines.join("\n");
+  } finally {
+    rl.close();
+  }
+}

--- a/test/cli-send-feedback.test.ts
+++ b/test/cli-send-feedback.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { runSendFeedbackCommand } from "../src/cli/send-feedback.js";
+
+let originalBaseUrl: string | undefined;
+
+beforeEach(() => {
+  originalBaseUrl = process.env.DUET_APP_BASE_URL;
+  process.env.DUET_APP_BASE_URL = "https://test";
+});
+
+afterEach(() => {
+  if (originalBaseUrl === undefined) delete process.env.DUET_APP_BASE_URL;
+  else process.env.DUET_APP_BASE_URL = originalBaseUrl;
+});
+
+describe("duet send-feedback", () => {
+  test("posts the positional argument as markdown content", async () => {
+    const calls: { url: string; method: string; body: string }[] = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({
+        url: typeof input === "string" ? input : (input as URL).toString(),
+        method: init?.method ?? "GET",
+        body: typeof init?.body === "string" ? init.body : "",
+      });
+      return new Response(JSON.stringify({ data: { ok: true } }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await runSendFeedbackCommand(["the TUI flickers when resuming"], { fetch: fetchImpl });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("https://test/api/v1/feedback");
+    expect(calls[0]!.method).toBe("POST");
+    expect(JSON.parse(calls[0]!.body)).toEqual({
+      content: "the TUI flickers when resuming",
+      source: "duet-agent-cli",
+    });
+  });
+
+  test("reads content from a file when --file is passed", async () => {
+    const { writeFile, mkdtemp, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const root = await mkdtemp(join(tmpdir(), "duet-feedback-"));
+    const filePath = join(root, "feedback.md");
+    await writeFile(filePath, "# Bug report\n\nSomething is broken.\n");
+
+    const calls: { body: string }[] = [];
+    const fetchImpl = (async (_input: string | URL | Request, init?: RequestInit) => {
+      calls.push({ body: typeof init?.body === "string" ? init.body : "" });
+      return new Response(JSON.stringify({ data: { ok: true } }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    try {
+      await runSendFeedbackCommand(["--file", filePath], { fetch: fetchImpl });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(calls[0]!.body)).toEqual({
+      content: "# Bug report\n\nSomething is broken.",
+      source: "duet-agent-cli",
+    });
+  });
+
+  test("surfaces non-2xx responses as fatal errors", async () => {
+    const fetchImpl = (async () =>
+      new Response("server boom", { status: 500 })) as unknown as typeof fetch;
+
+    const exit = process.exit;
+    let exitCode: number | undefined;
+    process.exit = ((code?: number) => {
+      exitCode = code ?? 0;
+      throw new Error("__exit__");
+    }) as never;
+    try {
+      await expect(runSendFeedbackCommand(["broken"], { fetch: fetchImpl })).rejects.toThrow(
+        "__exit__",
+      );
+      expect(exitCode).toBe(1);
+    } finally {
+      process.exit = exit;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- New built-in CLI subcommand `duet send-feedback` that POSTs free-form markdown to the chat-app public feedback endpoint (`/api/v1/feedback`).
- Endpoint is intentionally unauthenticated — no API key required.
- Content sources (priority order): positional args, `--file <path>`, piped stdin, interactive prompt.

Paired with the chat-app PR (aomni-com/chat-app) that ships the `/api/v1/feedback` route, the `feedback` domain, and the internal admin panel triage UI (filter open/done/dismissed, mark done, dismiss, reopen).

## Test plan
- [x] `bun test test/cli-send-feedback.test.ts` — covers positional, `--file`, and non-2xx error cases (mocks `fetch` at the command boundary).
- [ ] After chat-app PR ships to staging: `DUET_APP_BASE_URL=https://staging.duet.so duet send-feedback "test from CLI"` and verify it appears in the internal admin panel.