### PR TITLE
[david] feat(cli): rename --no-memory to --incognito (-i)

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ const turnRunner = new TurnRunner({
 });
 ```
 
-By default, the CLI stores durable observations in `~/.duet/memory.db`; run it with `--no-memory` to keep observational memory in process only. Programmatic callers can pass `memoryDbPath: false` or provide a custom `memoryDbPath`. The CLI's `SessionManager` is a convenience layer that stores session snapshots under `~/.duet/sessions`, but the runner owns memory hydration, pi-turn observation/reflection, compaction, and observation persistence.
+By default, the CLI stores durable observations in `~/.duet/memory.db`; run it with `--incognito` (or `-i`) to keep observational memory in process only. Programmatic callers can pass `memoryDbPath: false` or provide a custom `memoryDbPath`. The CLI's `SessionManager` is a convenience layer that stores session snapshots under `~/.duet/sessions`, but the runner owns memory hydration, pi-turn observation/reflection, compaction, and observation persistence.
 
 You can also resume directly from saved state. The runner owns state
 internally after `start`, so resumed state is handed in through the start

--- a/evals/cli-paths.eval.ts
+++ b/evals/cli-paths.eval.ts
@@ -62,7 +62,7 @@ describe("CLI production paths", () => {
           workDir,
           "--model",
           model,
-          "--no-memory",
+          "--incognito",
           "--system-prompt",
           dedent`
             This is a live eval. Use the state-machine tools, not a plain answer.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -28,7 +28,7 @@ OPTIONS
   --provider <name>        Pin the provider and use its catalog default model.
                             Accepts: duet, vercel, openrouter, anthropic, openai.
                             Mutually exclusive with --model / --memory-model.
-  --no-memory              Keep memory in-process; do not read or write durable memory
+  -i, --incognito          Keep memory in-process; do not read or write durable memory
   -w, --workdir <path>     Working directory (default: cwd)
   -r, --resume <id>        Resume a saved session
   --resume-history-lines <n>

--- a/src/cli/resume-hint.ts
+++ b/src/cli/resume-hint.ts
@@ -9,7 +9,7 @@ export interface ResumeCommandInput {
   modelName?: string;
   memoryModelName?: string;
   workDir: string;
-  disableDurableMemory?: boolean;
+  incognito?: boolean;
   systemInstructions?: string;
   systemPromptFiles?: string[];
   envFilePath?: string;
@@ -36,8 +36,8 @@ export function resumeCommand(sessionId: string, input: ResumeCommandInput): str
   if (input.memoryModelName) {
     command.push("--memory-model", shellQuote(input.memoryModelName));
   }
-  if (input.disableDurableMemory) {
-    command.push("--no-memory");
+  if (input.incognito) {
+    command.push("--incognito");
   }
   if (input.systemInstructions) {
     command.push("--system-prompt", shellQuote(input.systemInstructions));

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -25,7 +25,7 @@ import { getNewVersionNotice } from "./version-check.js";
 export interface CliTurnConfigInput {
   modelName?: string;
   memoryModelName?: string;
-  disableDurableMemory?: boolean;
+  incognito?: boolean;
   workDir: string;
   systemInstructions?: string;
   systemPromptFiles?: string[];
@@ -71,7 +71,7 @@ export function buildCliTurnConfig(
     config: {
       model: modelResolution.modelName,
       memoryModel: memoryModelResolution.modelName,
-      ...(input.disableDurableMemory ? { memoryDbPath: false } : {}),
+      ...(input.incognito ? { memoryDbPath: false } : {}),
       cwd: input.workDir,
       ...(input.systemInstructions ? { systemInstructions: input.systemInstructions } : {}),
       ...(input.systemPromptFiles ? { systemPromptFiles: input.systemPromptFiles } : {}),
@@ -101,7 +101,7 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
   let resumeHistoryLinesExplicit = false;
   let jsonOutput = false;
   let envFilePath: string | undefined;
-  let disableDurableMemory = false;
+  let incognito = false;
   const promptParts: string[] = [];
   const interactive = isInteractive();
 
@@ -120,8 +120,9 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
         if (!args[i + 1] || args[i + 1]?.startsWith("-")) fail(`Missing value for ${args[i]}`);
         providerFlag = args[++i];
         break;
-      case "--no-memory":
-        disableDurableMemory = true;
+      case "--incognito":
+      case "-i":
+        incognito = true;
         break;
       case "--workdir":
       case "-w":
@@ -230,7 +231,7 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
     {
       ...(modelName ? { modelName } : {}),
       ...(memoryModelName ? { memoryModelName } : {}),
-      disableDurableMemory,
+      incognito,
       workDir,
       ...(systemInstructions ? { systemInstructions } : {}),
       ...(systemPromptFiles ? { systemPromptFiles } : {}),
@@ -314,7 +315,7 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
         ...(modelName ? { modelName } : {}),
         ...(memoryModelName ? { memoryModelName } : {}),
         workDir,
-        disableDurableMemory,
+        incognito,
         ...(systemInstructions ? { systemInstructions } : {}),
         ...(systemPromptFiles ? { systemPromptFiles } : {}),
         ...(envFilePath ? { envFilePath } : {}),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -338,7 +338,7 @@ describe("CLI model inference", () => {
 
     const { config, modelResolution, memoryModelResolution } = buildCliTurnConfig(
       {
-        disableDurableMemory: true,
+        incognito: true,
         workDir: "/repo",
         systemInstructions: "Prefer concise answers.",
         systemPromptFiles: [],
@@ -536,15 +536,15 @@ describe("CLI version checks", () => {
 });
 
 describe("CLI resume command", () => {
-  test("preserves in-process-only memory mode", () => {
+  test("preserves incognito mode", () => {
     expect(
       resumeCommand("session_123", {
         modelName: "opus-4.7",
         memoryModelName: "haiku-4.5",
         workDir: "/repo",
-        disableDurableMemory: true,
+        incognito: true,
       }),
-    ).toContain("--no-memory");
+    ).toContain("--incognito");
   });
 });
 


### PR DESCRIPTION
## Summary
- Rename the in-process-only memory flag from `--no-memory` to `--incognito`, with `-i` as a shorthand.
- Rename the internal `disableDurableMemory` variable/option to `incognito` for consistency.
- Update help text, README, eval script, resume-hint, and tests.

## Test plan
- [x] `bun run check-types` passes
- [x] `bun test test/cli.test.ts` — 44 pass / 7 skip
- [ ] `duet --incognito "prompt"` runs without writing to `~/.duet/memory.db`
- [ ] `duet -i "prompt"` works as the shorthand
- [ ] Resume hint after a session with `--incognito` includes `--incognito`