### PR TITLE
[ani] feat(tui): Shift+Enter inserts newline; Enter always submits

### DIFF
--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -828,7 +828,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     // one keystroke instead of typing it again. Documented tradeoff: a
     // future iteration can swap this for true cross-session resume once
     // the session manager exposes a hot-swap API.
-    submit(entry.submit, false);
+    submit(entry.submit);
     return true;
   }
 
@@ -1055,10 +1055,6 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   // ---- input handling --------------------------------------------------------
 
-  // Track shift state for the most recent Enter keypress. The focused
-  // InputRenderable handles its own `enter` event after onKeyDown fires, so we
-  // capture the modifier here and read it during the ENTER event below.
-  let lastEnterShift = false;
   let skillAutocompleteSkills: readonly SkillAutocompleteItem[] = [];
   let skillAutocompleteToken: AutocompleteToken | undefined;
   let skillAutocompleteItems: SkillAutocompleteItem[] = [];
@@ -1561,18 +1557,24 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     }
 
     if (key.name === "return" || key.name === "enter") {
-      lastEnterShift = Boolean(key.shift);
+      // Shift+Enter inserts a literal newline at the cursor, matching every
+      // modern chat composer (Slack, Claude Code, ChatGPT, Discord). Plain
+      // Enter always submits — when the agent is running the submit path
+      // queues the message as a follow-up; otherwise it kicks off a new turn.
+      key.preventDefault();
+      if (key.shift) {
+        inputField.insertText("\n");
+        return;
+      }
       const value = inputField.plainText.trim();
       inputField.clear();
-      key.preventDefault();
       if (value) {
-        submit(value, lastEnterShift);
+        submit(value);
       } else if (questionPickerIsOpen()) {
         submitSelectedQuestionOption();
       } else if (startersAreVisible()) {
         submitHighlightedStarter();
       }
-      lastEnterShift = false;
       return;
     }
     if (key.name === "escape") {
@@ -1758,7 +1760,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     }
   }
 
-  function submit(message: string, shiftEnter: boolean): void {
+  function submit(message: string): void {
     // First user submit collapses the boot starter section permanently for
     // this session, even when the prompt came from autocomplete or paste.
     if (startersAreVisible()) dismissStarters();
@@ -1803,14 +1805,13 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     // double-charged with the same attachments on retry.
     clearPendingImages();
 
-    if (running) {
-      const behavior = shiftEnter ? "follow_up" : "steer";
-      void input.session.prompt({ message, behavior, images }).catch(reportError);
-      return;
-    }
-
+    // Every submit — running or idle — is a follow_up. While the agent is
+    // running this queues; while idle it kicks off a fresh turn. Single
+    // mental model: type, press Enter, your message lands.
     void input.session.prompt({ message, behavior: "follow_up", images }).catch(reportError);
-    markRunning();
+    if (!running) {
+      markRunning();
+    }
   }
 
   /**

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -15,6 +15,6 @@ export const COLORS = {
 } as const;
 
 export const HINT_IDLE =
-  "Enter: send · drag-select + Cmd+C to copy · Esc: quit · Ctrl+C: force quit";
+  "Enter: send · Shift+Enter: newline · drag-select + Cmd+C to copy · Esc: quit";
 export const HINT_RUNNING =
-  "Enter: steer · Shift+Enter: queue follow-up · drag-select + Cmd+C to copy · Esc: interrupt";
+  "Enter: queue follow-up · drag-select + Cmd+C to copy · Esc: interrupt";

--- a/test/tui-hints.test.ts
+++ b/test/tui-hints.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, test } from "bun:test";
 import { HINT_IDLE, HINT_RUNNING } from "../src/tui/theme.js";
 
 // The Enter key contract is documented to users solely through these footer
-// hints. Lock the wording so the "Shift+Enter inserts a newline" behaviour
-// keeps a visible affordance in the idle state, and so the running state
-// does not advertise the removed steer/queue split.
+// hints, so lock the wording. Idle: Shift+Enter inserts a newline, so that
+// affordance must stay visible. Running: Enter queues a follow-up, with no
+// Shift+Enter branch — a single gesture, single mental model.
 describe("TUI hint strings", () => {
   test("idle hint advertises Enter to send and Shift+Enter for a newline", () => {
     expect(HINT_IDLE).toContain("Enter: send");

--- a/test/tui-hints.test.ts
+++ b/test/tui-hints.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { HINT_IDLE, HINT_RUNNING } from "../src/tui/theme.js";
+
+// The Enter key contract is documented to users solely through these footer
+// hints. Lock the wording so the "Shift+Enter inserts a newline" behaviour
+// keeps a visible affordance in the idle state, and so the running state
+// does not advertise the removed steer/queue split.
+describe("TUI hint strings", () => {
+  test("idle hint advertises Enter to send and Shift+Enter for a newline", () => {
+    expect(HINT_IDLE).toContain("Enter: send");
+    expect(HINT_IDLE).toContain("Shift+Enter: newline");
+    expect(HINT_IDLE).toContain("Esc");
+  });
+
+  test("running hint advertises a single queue gesture and no Shift+Enter branch", () => {
+    expect(HINT_RUNNING).toContain("Enter: queue follow-up");
+    expect(HINT_RUNNING).not.toContain("Shift+Enter");
+    expect(HINT_RUNNING).not.toContain("steer");
+    expect(HINT_RUNNING).toContain("Esc");
+  });
+});


### PR DESCRIPTION
## Summary

Make the compose box behave like every modern chat app — **Shift+Enter** drops a newline at the cursor, **plain Enter** submits. Removes the old 'plain Enter steers / Shift+Enter queues follow-up' branch in favor of a single mental model: type, press Enter, your message lands.

## Behavior

| State | Plain Enter | Shift+Enter |
|---|---|---|
| Idle | Submits new turn | Inserts newline |
| Running | Queues as follow-up | Inserts newline |

While the agent is running, anything submitted is queued. There is no longer a discrete "steer mid-turn" gesture — the previous one was coupled to plain-Enter-while-running and got removed alongside the rest of the modifier overload.

## Files

- `src/tui/app.ts` (+17 / −16) — `inputField.insertText('\n')` on Shift+Enter; `submit()` lost its `shiftEnter` parameter; the `running ? 'steer' : 'follow_up'` branch collapsed to always `follow_up`. Dropped the `lastEnterShift` tracking variable.
- `src/tui/theme.ts` (+2 / −3) — `HINT_IDLE` advertises `Shift+Enter: newline`. `HINT_RUNNING` shows a single `Enter: queue follow-up` gesture with no Shift+Enter or steer branch.
- `test/tui-hints.test.ts` (new, +22) — locks the hint wording so the contract stays visible to users.

## Tradeoff to flag

**Mid-turn steering is gone.** If the product later wants a discrete steer keystroke, it should be its own keybinding (e.g. `Ctrl+S`), not coupled to submit. Worth tracking as a follow-up if reviewers want it back.

## Test plan

- [x] `bun run check-types` ✅
- [x] `bun run lint` ✅ (0 / 0)
- [x] `bun test test/` ✅ **215 pass / 88 skip / 0 fail**
- [x] Live TUI smoke test: Shift+Enter drops to next line; Enter submits multi-line message; queueing while running works

## Branched off

`main @ 552f138`. Sibling branch `feat/cli-fast-ice-break` is open in parallel and updates the same `HINT_IDLE` string — merge order doesn't matter, conflicts will be trivial.