### PR TITLE
feat(memory): SQL-ranked global pack + lastUsedAt usage decay; drop i…

### DIFF
--- a/evals/continuous-memory.eval.ts
+++ b/evals/continuous-memory.eval.ts
@@ -13,7 +13,7 @@ import {
   OBSERVATION_CONTEXT_PROMPT,
   OBSERVATION_CONTINUATION_HINT,
 } from "../src/memory/observational-prompts.js";
-import { MemoryStore } from "../src/memory/store.js";
+import { createMemoryFixture, type MemoryFixture } from "../test/helpers/memory-fixture.js";
 import { createInitialHorizon } from "../src/turn-runner/wire-shaping.js";
 import { SessionManager } from "../src/session/session-manager.js";
 import type { ObservationalMemoryActivityEvent } from "../src/types/memory.js";
@@ -67,28 +67,26 @@ describe("continuous memory", () => {
   testIfDocker(
     "uses hasMemory=false for two low-signal user prompts",
     async () => {
-      const memory = new MemoryStore();
+      const fixture = await createMemoryFixture();
       const events: ObservationalMemoryActivityEvent[] = [];
-      const firstPrompt: AgentMessage[] = [
-        {
-          role: "user",
-          content: [{ type: "text", text: "hello world" }],
-          timestamp: Date.now(),
-        },
-      ];
-      const secondPrompt: AgentMessage[] = [
-        ...firstPrompt,
-        {
-          role: "user",
-          content: [{ type: "text", text: "hey can you hear me?" }],
-          timestamp: Date.now() + 1,
-        },
-      ];
+      try {
+        const firstPrompt: AgentMessage[] = [
+          {
+            role: "user",
+            content: [{ type: "text", text: "hello world" }],
+            timestamp: Date.now(),
+          },
+        ];
+        const secondPrompt: AgentMessage[] = [
+          ...firstPrompt,
+          {
+            role: "user",
+            content: [{ type: "text", text: "hey can you hear me?" }],
+            timestamp: Date.now() + 1,
+          },
+        ];
 
-      await updateObservationalMemory({
-        memory,
-        actorModel: memoryModel,
-        settings: {
+        const settings = {
           observation: {
             messageTokens: 10_000,
             maxTokensPerBatch: 200,
@@ -98,35 +96,36 @@ describe("continuous memory", () => {
             observationTokens: 10_000,
             bufferActivation: 5_000,
           },
-        },
-        messages: firstPrompt,
-        onActivity: (event) => events.push(event),
-      });
-      await updateObservationalMemory({
-        memory,
-        actorModel: memoryModel,
-        settings: {
-          observation: {
-            messageTokens: 10_000,
-            maxTokensPerBatch: 200,
-            bufferActivation: 1_000,
-          },
-          reflection: {
-            observationTokens: 10_000,
-            bufferActivation: 5_000,
-          },
-        },
-        messages: secondPrompt,
-        onActivity: (event) => events.push(event),
-      });
+        };
+        await updateObservationalMemory({
+          db: fixture.db,
+          memory: fixture.cache,
+          sessionId: "session_eval",
+          actorModel: memoryModel,
+          settings,
+          messages: firstPrompt,
+          onActivity: (event) => events.push(event),
+        });
+        await updateObservationalMemory({
+          db: fixture.db,
+          memory: fixture.cache,
+          sessionId: "session_eval",
+          actorModel: memoryModel,
+          settings,
+          messages: secondPrompt,
+          onActivity: (event) => events.push(event),
+        });
 
-      const snapshot = await memory.getSnapshot();
-      expect(snapshot.observations).toEqual([]);
-      expect(events).toContainEqual({
-        phase: "observation",
-        status: "completed",
-        message: "Memory observation complete.",
-      });
+        const snapshot = await fixture.snapshot("session_eval");
+        expect(snapshot.observations).toEqual([]);
+        expect(events).toContainEqual({
+          phase: "observation",
+          status: "completed",
+          message: "Memory observation complete.",
+        });
+      } finally {
+        await fixture.dispose();
+      }
     },
     30_000,
   );
@@ -134,65 +133,72 @@ describe("continuous memory", () => {
   testIfDocker(
     "keeps previous observations bounded for low-signal prompts",
     async () => {
-      const memory = new MemoryStore();
+      const fixture = await createMemoryFixture();
       const events: ObservationalMemoryActivityEvent[] = [];
-      for (let index = 0; index < 80; index++) {
-        await memory.appendObservation({
-          kind: "observation",
-          observedDate: "2026-05-08",
-          priority: "high",
-          source: { kind: "system" },
-          content: `Date: May 8, 2026\n* 🔴 Existing durable memory ${index}: ${"detail ".repeat(200)}`,
-          tags: ["seeded"],
+      try {
+        for (let index = 0; index < 80; index++) {
+          await fixture.append({
+            sessionId: "session_eval",
+            kind: "observation",
+            observedDate: "2026-05-08",
+            priority: "high",
+            source: { kind: "system" },
+            content: `Date: May 8, 2026\n* 🔴 Existing durable memory ${index}: ${"detail ".repeat(200)}`,
+            tags: ["seeded"],
+          });
+        }
+
+        const injectedMemory = await snapshotObservationText(fixture);
+        await updateObservationalMemory({
+          db: fixture.db,
+          memory: fixture.cache,
+          sessionId: "session_eval",
+          actorModel: memoryModel,
+          settings: {
+            observation: {
+              messageTokens: 10_000,
+              maxTokensPerBatch: 200,
+              bufferActivation: 1_000,
+            },
+            reflection: {
+              observationTokens: 500_000,
+              bufferActivation: 100_000,
+            },
+          },
+          messages: [
+            {
+              role: "user",
+              content: `<system-reminder>${OBSERVATION_CONTEXT_PROMPT}\n\n<observations>\n${injectedMemory}\n</observations>\n\n${OBSERVATION_CONTEXT_INSTRUCTIONS}</system-reminder>`,
+              timestamp: Date.now(),
+            },
+            {
+              role: "user",
+              content: `<system-reminder>${OBSERVATION_CONTINUATION_HINT}</system-reminder>`,
+              timestamp: Date.now(),
+            },
+            {
+              role: "user",
+              content: [{ type: "text", text: "hi" }],
+              timestamp: Date.now(),
+            },
+          ],
+          onActivity: (event) => events.push(event),
         });
+
+        const snapshot = await fixture.snapshot("session_eval");
+        expect(
+          snapshot.observations.some((observation) =>
+            observation.content.includes("Existing durable memory 79"),
+          ),
+        ).toBe(true);
+        expect(events).toContainEqual({
+          phase: "observation",
+          status: "completed",
+          message: "Memory observation complete.",
+        });
+      } finally {
+        await fixture.dispose();
       }
-
-      const injectedMemory = await snapshotObservationText(memory);
-      await updateObservationalMemory({
-        memory,
-        actorModel: memoryModel,
-        settings: {
-          observation: {
-            messageTokens: 10_000,
-            maxTokensPerBatch: 200,
-            bufferActivation: 1_000,
-          },
-          reflection: {
-            observationTokens: 500_000,
-            bufferActivation: 100_000,
-          },
-        },
-        messages: [
-          {
-            role: "user",
-            content: `<system-reminder>${OBSERVATION_CONTEXT_PROMPT}\n\n<observations>\n${injectedMemory}\n</observations>\n\n${OBSERVATION_CONTEXT_INSTRUCTIONS}</system-reminder>`,
-            timestamp: Date.now(),
-          },
-          {
-            role: "user",
-            content: `<system-reminder>${OBSERVATION_CONTINUATION_HINT}</system-reminder>`,
-            timestamp: Date.now(),
-          },
-          {
-            role: "user",
-            content: [{ type: "text", text: "hi" }],
-            timestamp: Date.now(),
-          },
-        ],
-        onActivity: (event) => events.push(event),
-      });
-
-      const snapshot = await memory.getSnapshot();
-      expect(
-        snapshot.observations.some((observation) =>
-          observation.content.includes("Existing durable memory 79"),
-        ),
-      ).toBe(true);
-      expect(events).toContainEqual({
-        phase: "observation",
-        status: "completed",
-        message: "Memory observation complete.",
-      });
     },
     30_000,
   );
@@ -200,7 +206,7 @@ describe("continuous memory", () => {
   testIfDocker(
     "observes pi-turn messages before compaction is required",
     async () => {
-      const memory = new MemoryStore();
+      const fixture = await createMemoryFixture();
       const events: ObservationalMemoryActivityEvent[] = [];
       const settings = {
         observation: {
@@ -228,45 +234,51 @@ describe("continuous memory", () => {
         },
       ];
 
-      await updateObservationalMemory({
-        memory,
-        actorModel: memoryModel,
-        settings,
-        messages,
-        onActivity: (event) => events.push(event),
-      });
+      try {
+        await updateObservationalMemory({
+          db: fixture.db,
+          memory: fixture.cache,
+          sessionId: "session_eval",
+          actorModel: memoryModel,
+          settings,
+          messages,
+          onActivity: (event) => events.push(event),
+        });
 
-      const snapshot = await memory.getSnapshot();
-      const observations = snapshot.observations
-        .map((observation) => observation.content)
-        .join("\n");
-      expect(observations).toContain("continuous-memory-318");
-      expect(
-        events.some((event) => event.status === "completed" && event.observations?.length),
-      ).toBe(true);
+        const snapshot = await fixture.snapshot("session_eval");
+        const observations = snapshot.observations
+          .map((observation) => observation.content)
+          .join("\n");
+        expect(observations).toContain("continuous-memory-318");
+        expect(
+          events.some((event) => event.status === "completed" && event.observations?.length),
+        ).toBe(true);
 
-      const transform = createObservationalContextTransform({
-        memory,
-        settings,
-        horizon: createInitialHorizon(),
-      });
-      const transformed = await transform(messages);
-      expect(transformed.at(-1)).toMatchObject({
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: expect.stringContaining("continuous-memory-318"),
-          },
-        ],
-      });
+        const transform = createObservationalContextTransform({
+          memory: fixture.cache,
+          settings,
+          horizon: createInitialHorizon(),
+        });
+        const transformed = await transform(messages);
+        expect(transformed.at(-1)).toMatchObject({
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: expect.stringContaining("continuous-memory-318"),
+            },
+          ],
+        });
+      } finally {
+        await fixture.dispose();
+      }
     },
     30_000,
   );
 });
 
-async function snapshotObservationText(memory: MemoryStore): Promise<string> {
-  const snapshot = await memory.getSnapshot();
+async function snapshotObservationText(fixture: MemoryFixture): Promise<string> {
+  const snapshot = await fixture.snapshot("session_eval");
   return snapshot.observations.map((observation) => observation.content).join("\n\n");
 }
 

--- a/evals/last-used-ranking.eval.ts
+++ b/evals/last-used-ranking.eval.ts
@@ -1,0 +1,165 @@
+import { describe, expect } from "bun:test";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { rebuildMemoryContextPack } from "../src/memory/context-pack.js";
+import {
+  resolveObservationalMemorySettings,
+  updateObservationalMemory,
+} from "../src/memory/observational.js";
+import { DEFAULT_CLI_MEMORY_MODEL } from "../src/model-resolution/resolver.js";
+import { createAssistantMessage } from "../test/helpers/messages.js";
+import { createMemoryFixture } from "../test/helpers/memory-fixture.js";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+/**
+ * End-to-end check that the `lastUsedAt` usage signal actually moves
+ * memories in the global ranking when a real observer model identifies
+ * one of them as having informed the assistant's response.
+ *
+ * Setup:
+ *   - Two cross-session memories pre-seeded with `lastUsedAt = createdAt = -10d`,
+ *     identical priority and kind so age is the only differentiator.
+ *   - One memory ("kept_marker") describes a unique fact the simulated
+ *     turn obviously leans on; the other ("unused_marker") describes a
+ *     completely unrelated fact.
+ *   - The simulated turn has the assistant explicitly cite the kept
+ *     marker so the observer model has unambiguous signal.
+ *
+ * Expected:
+ *   - After the observer pass, the kept marker's `lastUsedAt` is
+ *     advanced to roughly "now"; the unused marker's stays at the
+ *     seeded -10d timestamp.
+ *   - On the next context-pack rebuild the kept marker outranks the
+ *     unused marker. Without the bump, both rows would tie in the
+ *     ranking formula and order would be undefined.
+ *
+ * If the observer model fails to populate `usedObservationIds` for a
+ * blatantly cited memory, this eval is the canary.
+ */
+
+const memoryModel = process.env.EVAL_MEMORY_MODEL ?? DEFAULT_CLI_MEMORY_MODEL;
+
+const TEN_DAYS_MS = 10 * 24 * 60 * 60 * 1000;
+
+describe("last-used ranking", () => {
+  testIfDocker(
+    "observer-reported usage bumps lastUsedAt and re-ranks the global pack",
+    async () => {
+      const fixture = await createMemoryFixture();
+      try {
+        const seedTime = Date.now() - TEN_DAYS_MS;
+
+        const kept = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: new Date(seedTime).toISOString().slice(0, 10),
+          priority: "high",
+          source: { kind: "system" },
+          content:
+            "User's deploy command is `pnpm deploy:prod` — they confirmed this is the canonical way to ship the api service.",
+          tags: ["seeded"],
+        });
+        const unused = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: new Date(seedTime).toISOString().slice(0, 10),
+          priority: "high",
+          source: { kind: "system" },
+          content:
+            "User mentioned their cat is named Pixel and is a 3-year-old tabby. Unrelated to any technical work.",
+          tags: ["seeded"],
+        });
+
+        // Backdate both so the only thing that can move them in the
+        // ranking is a lastUsedAt bump from the observer pass.
+        await fixture.db.query(
+          "UPDATE observations SET created_at = $1, last_used_at = $1 WHERE id = ANY($2::text[])",
+          [seedTime, [kept.id, unused.id]],
+        );
+
+        // Freeze the pack against the current session so the observer
+        // sees both memories with their `[memory id: ...]` markers.
+        const settings = resolveObservationalMemorySettings({
+          observation: {
+            messageTokens: 10_000,
+            maxTokensPerBatch: 800,
+            bufferActivation: 1_000,
+          },
+          reflection: {
+            observationTokens: 200_000,
+            bufferActivation: 100_000,
+          },
+        });
+        await rebuildMemoryContextPack({
+          db: fixture.db,
+          cache: fixture.cache,
+          settings,
+          sessionId: "session_eval",
+        });
+
+        const messages: AgentMessage[] = [
+          {
+            role: "user",
+            content: [{ type: "text", text: "How do I deploy the api?" }],
+            timestamp: Date.now(),
+          },
+          createAssistantMessage({
+            text: "Run `pnpm deploy:prod` — that's the canonical command you confirmed earlier for shipping the api service.",
+            timestamp: Date.now() + 1,
+          }),
+        ];
+
+        await updateObservationalMemory({
+          db: fixture.db,
+          memory: fixture.cache,
+          sessionId: "session_eval",
+          actorModel: memoryModel,
+          settings,
+          messages,
+        });
+
+        const refreshedKept = await fetchById(fixture.db, kept.id);
+        const refreshedUnused = await fetchById(fixture.db, unused.id);
+
+        // Kept marker should be bumped to roughly "now" (within the
+        // duration of this test). Unused marker should still match its
+        // backdated seed time.
+        const now = Date.now();
+        expect(refreshedKept.lastUsedAt).toBeGreaterThan(seedTime + 60_000);
+        expect(refreshedKept.lastUsedAt).toBeLessThanOrEqual(now);
+        expect(refreshedUnused.lastUsedAt).toBe(seedTime);
+
+        // Concrete proof of re-ranking: rebuild the pack and verify the
+        // kept marker now precedes the unused marker. With identical
+        // priority+kind and only the kept marker bumped, this ordering
+        // is the direct consequence of the lastUsedAt update.
+        await rebuildMemoryContextPack({
+          db: fixture.db,
+          cache: fixture.cache,
+          settings,
+          sessionId: "session_eval",
+        });
+        const pack = fixture.cache.getContextPack();
+        const ids = pack.global.map((row) => row.id);
+        expect(ids).toContain(kept.id);
+        expect(ids).toContain(unused.id);
+        expect(ids.indexOf(kept.id)).toBeLessThan(ids.indexOf(unused.id));
+      } finally {
+        await fixture.dispose();
+      }
+    },
+    60_000,
+  );
+});
+
+async function fetchById(
+  db: Awaited<ReturnType<typeof createMemoryFixture>>["db"],
+  id: string,
+): Promise<{ lastUsedAt: number; createdAt: number }> {
+  const result = await db.query<{ created_at: number; last_used_at: number }>(
+    "SELECT created_at, last_used_at FROM observations WHERE id = $1",
+    [id],
+  );
+  const row = result.rows[0];
+  if (!row) throw new Error(`No observation with id ${id}`);
+  return { createdAt: row.created_at, lastUsedAt: row.last_used_at };
+}

--- a/evals/multimodal-memory.eval.ts
+++ b/evals/multimodal-memory.eval.ts
@@ -2,8 +2,8 @@ import { describe, expect } from "bun:test";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { type ImageContent } from "@earendil-works/pi-ai";
 import { updateObservationalMemory } from "../src/memory/observational.js";
-import { MemoryStore } from "../src/memory/store.js";
 import { DEFAULT_CLI_MEMORY_MODEL } from "../src/model-resolution/resolver.js";
+import { createMemoryFixture } from "../test/helpers/memory-fixture.js";
 import { testIfDocker } from "../test/helpers/docker-only.js";
 
 const memoryModel = DEFAULT_CLI_MEMORY_MODEL;
@@ -12,46 +12,52 @@ describe("multimodal memory", () => {
   testIfDocker(
     "observes visual details from compacted image messages",
     async () => {
-      const memory = new MemoryStore();
-      await updateObservationalMemory({
-        memory,
-        actorModel: memoryModel,
-        settings: {
-          observation: {
-            messageTokens: 5,
-            maxTokensPerBatch: 200,
-            bufferActivation: 1,
-            instruction:
-              "For this eval, preserve the visual color and shape from attached images when they are relevant.",
+      const fixture = await createMemoryFixture();
+      try {
+        await updateObservationalMemory({
+          db: fixture.db,
+          memory: fixture.cache,
+          sessionId: "session_eval",
+          actorModel: memoryModel,
+          settings: {
+            observation: {
+              messageTokens: 5,
+              maxTokensPerBatch: 200,
+              bufferActivation: 1,
+              instruction:
+                "For this eval, preserve the visual color and shape from attached images when they are relevant.",
+            },
+            reflection: {
+              observationTokens: 1_000,
+              bufferActivation: 500,
+            },
           },
-          reflection: {
-            observationTokens: 1_000,
-            bufferActivation: 500,
-          },
-        },
-        messages: [
-          {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                text: "Remember the visual details in the attached image under marker image-memory-472.",
-              },
-              redSquareImage,
-            ],
-            timestamp: Date.now(),
-          } satisfies AgentMessage,
-        ],
-      });
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: "Remember the visual details in the attached image under marker image-memory-472.",
+                },
+                redSquareImage,
+              ],
+              timestamp: Date.now(),
+            } satisfies AgentMessage,
+          ],
+        });
 
-      const snapshot = await memory.getSnapshot();
-      const observations = snapshot.observations
-        .map((observation) => observation.content)
-        .join("\n");
+        const snapshot = await fixture.snapshot("session_eval");
+        const observations = snapshot.observations
+          .map((observation) => observation.content)
+          .join("\n");
 
-      expect(observations).toContain("image-memory-472");
-      expect(observations.toLowerCase()).toContain("red");
-      expect(observations.toLowerCase()).toMatch(/square|rectangle/);
+        expect(observations).toContain("image-memory-472");
+        expect(observations.toLowerCase()).toContain("red");
+        expect(observations.toLowerCase()).toMatch(/square|rectangle/);
+      } finally {
+        await fixture.dispose();
+      }
     },
     30_000,
   );
@@ -60,5 +66,5 @@ describe("multimodal memory", () => {
 const redSquareImage: ImageContent = {
   type: "image",
   mimeType: "image/png",
-  data: "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAb0lEQVR4nO3PAQkAAAyEwO9feoshgnABdLep8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3IPanc8OLDQitxAAAAAElFTkSuQmCC",
+  data: "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAb0lEQVR4nO3PAQkAAAyEwO9feoshgnABdLep8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3IPanc8OLDQitxAAAAAElFTkSuQmCC",
 };

--- a/evals/observer-priority.eval.ts
+++ b/evals/observer-priority.eval.ts
@@ -1,9 +1,9 @@
 import { describe, expect } from "bun:test";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { updateObservationalMemory } from "../src/memory/observational.js";
-import { MemoryStore } from "../src/memory/store.js";
 import { DEFAULT_CLI_MEMORY_MODEL } from "../src/model-resolution/resolver.js";
 import type { ObservationPriority } from "../src/types/memory.js";
+import { createMemoryFixture } from "../test/helpers/memory-fixture.js";
 import { testIfDocker } from "../test/helpers/docker-only.js";
 import { createAssistantMessage } from "../test/helpers/messages.js";
 
@@ -126,22 +126,28 @@ describe("observer priority inference", () => {
     testIfDocker(
       scenario.name,
       async () => {
-        const memory = new MemoryStore();
-        await updateObservationalMemory({
-          memory,
-          actorModel: memoryModel,
-          settings: baseSettings,
-          messages: scenario.messages,
-        });
+        const fixture = await createMemoryFixture();
+        try {
+          await updateObservationalMemory({
+            db: fixture.db,
+            memory: fixture.cache,
+            sessionId: "session_eval",
+            actorModel: memoryModel,
+            settings: baseSettings,
+            messages: scenario.messages,
+          });
 
-        const snapshot = await memory.getSnapshot();
-        const observation = snapshot.observations.at(0);
-        console.log(
-          `\n[${scenario.name}] expected=${scenario.expected} got=${observation?.priority ?? "<no observation>"}\n--- content ---\n${observation?.content ?? "(empty)"}\n---`,
-        );
+          const snapshot = await fixture.snapshot("session_eval");
+          const observation = snapshot.observations.at(0);
+          console.log(
+            `\n[${scenario.name}] expected=${scenario.expected} got=${observation?.priority ?? "<no observation>"}\n--- content ---\n${observation?.content ?? "(empty)"}\n---`,
+          );
 
-        expect(observation).toBeDefined();
-        expect(observation!.priority).toBe(scenario.expected);
+          expect(observation).toBeDefined();
+          expect(observation!.priority).toBe(scenario.expected);
+        } finally {
+          await fixture.dispose();
+        }
       },
       45_000,
     );

--- a/evals/observer-used-ids.eval.ts
+++ b/evals/observer-used-ids.eval.ts
@@ -1,0 +1,218 @@
+import { describe, expect } from "bun:test";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { rebuildMemoryContextPack } from "../src/memory/context-pack.js";
+import {
+  resolveObservationalMemorySettings,
+  updateObservationalMemory,
+} from "../src/memory/observational.js";
+import { DEFAULT_CLI_MEMORY_MODEL } from "../src/model-resolution/resolver.js";
+import { createAssistantMessage } from "../test/helpers/messages.js";
+import { createMemoryFixture } from "../test/helpers/memory-fixture.js";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+/**
+ * Live-model checks on the observer's `usedObservationIds` output.
+ *
+ * The structured-output schema and the prompt both ask the observer
+ * to cite memory ids drawn from the rendered `[memory id: mem_xxx]`
+ * markers. These tests pin two contracts:
+ *
+ *   1. When the assistant clearly leans on one memory among several
+ *      decoys, the observer cites that one and only that one.
+ *   2. When the assistant's response has nothing to do with any of
+ *      the rendered memories, the observer does not invent ids.
+ *
+ * Failures here usually mean the prompt section in
+ * `observational-prompts.ts` drifted away from the schema description
+ * or that the observer model regressed on instruction following.
+ */
+
+const memoryModel = process.env.EVAL_MEMORY_MODEL ?? DEFAULT_CLI_MEMORY_MODEL;
+
+const settings = resolveObservationalMemorySettings({
+  observation: {
+    messageTokens: 10_000,
+    maxTokensPerBatch: 800,
+    bufferActivation: 1_000,
+  },
+  reflection: {
+    observationTokens: 200_000,
+    bufferActivation: 100_000,
+  },
+});
+
+describe("observer usedObservationIds", () => {
+  testIfDocker(
+    "cites the single relevant memory and ignores unrelated decoys",
+    async () => {
+      const fixture = await createMemoryFixture();
+      try {
+        const deployCmd = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: "2026-04-30",
+          priority: "high",
+          source: { kind: "system" },
+          content:
+            "User confirmed the canonical deploy command for the api service is `pnpm deploy:prod`.",
+          tags: ["seeded"],
+        });
+        const cat = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: "2026-04-30",
+          priority: "high",
+          source: { kind: "system" },
+          content: "User mentioned their cat is named Pixel and is a 3-year-old tabby.",
+          tags: ["seeded"],
+        });
+        const breakfast = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: "2026-04-30",
+          priority: "medium",
+          source: { kind: "system" },
+          content: "User typically eats oatmeal for breakfast on weekdays.",
+          tags: ["seeded"],
+        });
+
+        await rebuildMemoryContextPack({
+          db: fixture.db,
+          cache: fixture.cache,
+          settings,
+          sessionId: "session_eval",
+        });
+
+        const messages: AgentMessage[] = [
+          {
+            role: "user",
+            content: [{ type: "text", text: "How do I deploy the api service?" }],
+            timestamp: Date.now(),
+          },
+          createAssistantMessage({
+            text: "Run `pnpm deploy:prod` — that's the canonical command you confirmed earlier for shipping the api service.",
+            timestamp: Date.now() + 1,
+          }),
+        ];
+
+        const seedTime = Date.now() - 24 * 60 * 60 * 1000;
+        await fixture.db.query(
+          "UPDATE observations SET created_at = $1, last_used_at = $1 WHERE id = ANY($2::text[])",
+          [seedTime, [deployCmd.id, cat.id, breakfast.id]],
+        );
+
+        await updateObservationalMemory({
+          db: fixture.db,
+          memory: fixture.cache,
+          sessionId: "session_eval",
+          actorModel: memoryModel,
+          settings,
+          messages,
+        });
+
+        const rows = await readLastUsed(fixture.db, [deployCmd.id, cat.id, breakfast.id]);
+
+        // The deploy command is the only memory the assistant could
+        // have leaned on. lastUsedAt advanced means the observer
+        // emitted that id; the decoys staying at the seeded -1d
+        // timestamp means the observer did not over-cite.
+        expect(rows[deployCmd.id]).toBeGreaterThan(seedTime + 60_000);
+        expect(rows[cat.id]).toBe(seedTime);
+        expect(rows[breakfast.id]).toBe(seedTime);
+      } finally {
+        await fixture.dispose();
+      }
+    },
+    60_000,
+  );
+
+  testIfDocker(
+    "does not cite any memory when the response is unrelated to the rendered pack",
+    async () => {
+      const fixture = await createMemoryFixture();
+      try {
+        const cat = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: "2026-04-30",
+          priority: "high",
+          source: { kind: "system" },
+          content: "User mentioned their cat is named Pixel and is a 3-year-old tabby.",
+          tags: ["seeded"],
+        });
+        const breakfast = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: "2026-04-30",
+          priority: "medium",
+          source: { kind: "system" },
+          content: "User typically eats oatmeal for breakfast on weekdays.",
+          tags: ["seeded"],
+        });
+
+        await rebuildMemoryContextPack({
+          db: fixture.db,
+          cache: fixture.cache,
+          settings,
+          sessionId: "session_eval",
+        });
+
+        // The exchange below is a pure factual question with no
+        // overlap to the seeded memories.
+        const messages: AgentMessage[] = [
+          {
+            role: "user",
+            content: [{ type: "text", text: "What is 17 times 23? Just the number." }],
+            timestamp: Date.now(),
+          },
+          createAssistantMessage({
+            text: "391",
+            timestamp: Date.now() + 1,
+          }),
+        ];
+
+        const seedTime = Date.now() - 24 * 60 * 60 * 1000;
+        await fixture.db.query(
+          "UPDATE observations SET created_at = $1, last_used_at = $1 WHERE id = ANY($2::text[])",
+          [seedTime, [cat.id, breakfast.id]],
+        );
+
+        await updateObservationalMemory({
+          db: fixture.db,
+          memory: fixture.cache,
+          sessionId: "session_eval",
+          actorModel: memoryModel,
+          settings,
+          messages,
+        });
+
+        const rows = await readLastUsed(fixture.db, [cat.id, breakfast.id]);
+
+        // Neither memory was used; both timestamps must stay at the
+        // seeded backdate. A bump would mean the observer hallucinated
+        // a citation, which is exactly the failure mode the prompt
+        // and id-validation guard are supposed to prevent.
+        expect(rows[cat.id]).toBe(seedTime);
+        expect(rows[breakfast.id]).toBe(seedTime);
+      } finally {
+        await fixture.dispose();
+      }
+    },
+    60_000,
+  );
+});
+
+async function readLastUsed(
+  db: Awaited<ReturnType<typeof createMemoryFixture>>["db"],
+  ids: string[],
+): Promise<Record<string, number>> {
+  const result = await db.query<{ id: string; last_used_at: number }>(
+    "SELECT id, last_used_at FROM observations WHERE id = ANY($1::text[])",
+    [ids],
+  );
+  const out: Record<string, number> = {};
+  for (const row of result.rows) {
+    out[row.id] = row.last_used_at;
+  }
+  return out;
+}

--- a/evals/reflection-session-isolation.eval.ts
+++ b/evals/reflection-session-isolation.eval.ts
@@ -1,0 +1,139 @@
+import { describe, expect } from "bun:test";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { updateObservationalMemory } from "../src/memory/observational.js";
+import { DEFAULT_CLI_MEMORY_MODEL } from "../src/model-resolution/resolver.js";
+import { createMemoryFixture } from "../test/helpers/memory-fixture.js";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+/**
+ * Reflection must touch only the current session's rows. The
+ * reflector reads its snapshot via `readSessionObservations(db,
+ * sessionId)` and writes the result through
+ * `replaceSessionObservations`, whose DELETE is scoped
+ * `WHERE session_id = $1`. This eval drives the live reflector model
+ * to fire a reflection in session B and asserts that session A's
+ * rows survive byte-for-byte (id, content, last_used_at) so the
+ * global pack stays intact.
+ */
+
+const memoryModel = process.env.EVAL_MEMORY_MODEL ?? DEFAULT_CLI_MEMORY_MODEL;
+
+describe("reflection session isolation", () => {
+  testIfDocker(
+    "reflecting session B leaves session A's rows on disk untouched",
+    async () => {
+      const fixture = await createMemoryFixture();
+      try {
+        // Two memories on session A. They must survive verbatim.
+        const aDeploy = await fixture.append({
+          sessionId: "session_a",
+          kind: "reflection",
+          observedDate: "2026-04-29",
+          priority: "high",
+          source: { kind: "system" },
+          content:
+            "User confirmed `pnpm deploy:prod` is the canonical deploy command for the api service.",
+          tags: ["seeded"],
+        });
+        const aPet = await fixture.append({
+          sessionId: "session_a",
+          kind: "reflection",
+          observedDate: "2026-04-29",
+          priority: "high",
+          source: { kind: "system" },
+          content: "User mentioned their cat is named Pixel and is a 3-year-old tabby.",
+          tags: ["seeded"],
+        });
+
+        // Backdate session A's lastUsedAt so we can detect any
+        // unintended write activity on those rows.
+        const aSeedTime = Date.now() - 24 * 60 * 60 * 1000;
+        await fixture.db.query(
+          "UPDATE observations SET created_at = $1, last_used_at = $1 WHERE id = ANY($2::text[])",
+          [aSeedTime, [aDeploy.id, aPet.id]],
+        );
+
+        // Seed session B with enough observation content to trip the
+        // reflection threshold on the next update pass. The threshold
+        // is on `ceil(content.length / 4)`, so ~3.2k chars across
+        // rows comfortably exceeds the 600-token cap below.
+        for (let index = 0; index < 4; index++) {
+          await fixture.append({
+            sessionId: "session_b",
+            kind: "observation",
+            observedDate: "2026-05-08",
+            priority: "medium",
+            source: { kind: "system" },
+            content: `Date: May 8, 2026 step-${index}-prefix-padding\n* \ud83d\udfe1 (10:0${index}) Working on feature ${"X".repeat(800)} step ${index} suffix details about file paths /var/log/app-${index}.log and metric value ${index * 137}`,
+            tags: ["observational-memory"],
+          });
+        }
+
+        // No new tail \u2014 observer has nothing to observe. Reflection
+        // still fires because it checks session-local observation
+        // tokens against the threshold regardless of observer output.
+        const messages: AgentMessage[] = [];
+
+        const result = await updateObservationalMemory({
+          db: fixture.db,
+          memory: fixture.cache,
+          sessionId: "session_b",
+          actorModel: memoryModel,
+          settings: {
+            observation: {
+              messageTokens: 10_000,
+              maxTokensPerBatch: 800,
+              bufferActivation: 1_000,
+            },
+            reflection: {
+              observationTokens: 600,
+              bufferActivation: 300,
+            },
+          },
+          messages,
+        });
+
+        // Sanity: a reflection must actually have happened, otherwise
+        // the assertions below would pass trivially.
+        expect(result.reflections.length).toBe(1);
+        expect(result.reflections[0]?.sessionId).toBe("session_b");
+
+        // Session A rows survived: same ids, same content, same
+        // last_used_at (no spurious bump).
+        const aRows = await fixture.db.query<{
+          id: string;
+          content: string;
+          last_used_at: number;
+          session_id: string | null;
+        }>(
+          "SELECT id, content, last_used_at, session_id FROM observations WHERE session_id = $1 ORDER BY created_at ASC",
+          ["session_a"],
+        );
+        expect(aRows.rows.map((row) => row.id)).toEqual([aDeploy.id, aPet.id]);
+        expect(aRows.rows[0]?.content).toBe(aDeploy.content);
+        expect(aRows.rows[1]?.content).toBe(aPet.content);
+        expect(aRows.rows[0]?.last_used_at).toBe(aSeedTime);
+        expect(aRows.rows[1]?.last_used_at).toBe(aSeedTime);
+
+        // Session B rows: the four seeded observations were replaced
+        // by exactly one reflection row.
+        const bRows = await fixture.db.query<{ id: string; kind: string }>(
+          "SELECT id, kind FROM observations WHERE session_id = $1",
+          ["session_b"],
+        );
+        expect(bRows.rows.length).toBe(1);
+        expect(bRows.rows[0]?.kind).toBe("reflection");
+        expect(bRows.rows[0]?.id).toBe(result.reflections[0]?.id);
+
+        // Total: 2 surviving session A rows + 1 session B reflection.
+        const total = await fixture.db.query<{ count: string }>(
+          "SELECT COUNT(*)::text AS count FROM observations",
+        );
+        expect(Number(total.rows[0]?.count)).toBe(3);
+      } finally {
+        await fixture.dispose();
+      }
+    },
+    60_000,
+  );
+});

--- a/src/cli/memory-db.ts
+++ b/src/cli/memory-db.ts
@@ -4,7 +4,7 @@ import { openPGlite } from "../memory/pglite.js";
 import type { Observation } from "../types/memory.js";
 
 /**
- * Thin read/edit/delete wrapper over the PGlite database `MemoryStore` writes
+ * Thin read/edit/delete wrapper over the PGlite database the memory pipeline writes
  * to. The `duet memory` command opens the same on-disk file, so changes
  * made here are visible to subsequent runner sessions.
  */
@@ -32,7 +32,7 @@ export class MemoryDb {
   /** Load all observations ordered most recent first. */
   async list(): Promise<Observation[]> {
     const result = await this.db.query<ObservationRow>(
-      `SELECT id, created_at, session_id, kind, observed_date, referenced_date, relative_date,
+      `SELECT id, created_at, last_used_at, session_id, kind, observed_date, referenced_date, relative_date,
               time_of_day, priority, source_json, content, tags_json
        FROM observations
        ORDER BY created_at DESC`,
@@ -58,6 +58,7 @@ export class MemoryDb {
 interface ObservationRow {
   id: string;
   created_at: number;
+  last_used_at: number;
   session_id: string | null;
   kind: Observation["kind"];
   observed_date: string;
@@ -74,6 +75,7 @@ function rowToObservation(row: ObservationRow): Observation {
   return {
     id: row.id,
     createdAt: row.created_at,
+    lastUsedAt: row.last_used_at,
     ...(row.session_id !== null ? { sessionId: row.session_id } : {}),
     kind: row.kind,
     observedDate: row.observed_date,

--- a/src/memory/context-pack.ts
+++ b/src/memory/context-pack.ts
@@ -1,11 +1,11 @@
 import type { PGlite } from "@electric-sql/pglite";
 import type { ObservationalMemorySettings } from "../types/memory.js";
 import { loadGlobalPack, loadLocalPack } from "./loader.js";
-import type { MemoryStore } from "./store.js";
+import type { MemoryContextCache } from "./store.js";
 
 /**
  * Compaction trigger: rebuild the frozen memory pack rendered above
- * the message tail, then store it on the runner's MemoryStore.
+ * the message tail, then store it on the runner's MemoryContextCache.
  *
  * Three events trigger a refresh and exactly three:
  *   1. `loadStoredMemory()` finishes — initial seed.
@@ -24,7 +24,7 @@ import type { MemoryStore } from "./store.js";
  */
 export async function rebuildMemoryContextPack(options: {
   db: PGlite | undefined;
-  store: MemoryStore;
+  cache: MemoryContextCache;
   settings: ObservationalMemorySettings;
   sessionId?: string;
 }): Promise<void> {
@@ -45,5 +45,5 @@ export async function rebuildMemoryContextPack(options: {
       : Promise.resolve([]),
   ]);
 
-  options.store.setContextPack({ global: globalPack, local: localPack });
+  options.cache.setContextPack({ global: globalPack, local: localPack });
 }

--- a/src/memory/loader.ts
+++ b/src/memory/loader.ts
@@ -14,7 +14,7 @@ import type { Observation, ObservationKind, ObservationPriority } from "../types
  *     compaction summary; reordering it would lose the time signal.
  *
  *   - Global layer: every other session's rows, ranked by
- *     `priority * recencyDecay * kindBias`. Reflections rank higher than
+ *     `priority * usageDecay * kindBias`. Reflections rank higher than
  *     raw observations through `reflectionBias`. Greedy-fitted to a
  *     fixed token budget so the prompt prefix stays bounded regardless
  *     of how big the durable memory database has grown.
@@ -26,6 +26,16 @@ import type { Observation, ObservationKind, ObservationPriority } from "../types
  * pack is the most stable prefix (rebuilt only on compaction), local
  * is medium-stability (replaced on each reflection), and the message
  * tail is the only part that grows turn over turn.
+ *
+ * Ranking is pushed entirely into SQL. The full score
+ * `priority * 0.5^((now - last_used_at) / h) * kindBias` factors as
+ * `const(now) * priority * 2^(last_used_at / h) * kindBias`; the
+ * `const(now)` term is the same for every candidate in one ranking
+ * pass and so cannot affect order. Equivalently in log space,
+ * `rank = ln(priority) + ln(kindBias) + last_used_at / h`. That is a
+ * pure function of columns and config — Postgres does the work, the
+ * `idx_obs_kind_priority_lastused` index covers the ORDER BY, and JS
+ * only does the final greedy token-budget fit.
  */
 
 const PRIORITY_WEIGHT: Record<ObservationPriority, number> = {
@@ -33,43 +43,6 @@ const PRIORITY_WEIGHT: Record<ObservationPriority, number> = {
   medium: 2,
   low: 1,
 };
-
-export interface ScoreInputs {
-  /** Wall-clock time at which scoring is happening. Same value across one ranking pass. */
-  now: number;
-  /** Half-life for the recency exponential decay. Same units as createdAt (milliseconds). */
-  halfLifeMs: number;
-  /** Multiplier applied when an observation is a reflection rather than a raw observation. */
-  reflectionBias: number;
-}
-
-/**
- * Combined relevance score used to rank the global layer.
- *
- *   score = priorityWeight * recencyDecay * kindBias
- *
- * - priorityWeight: 3 / 2 / 1 for high / medium / low.
- * - recencyDecay: `0.5 ^ (ageMs / halfLifeMs)`. Equals 1.0 at age 0,
- *   0.5 at one half-life, ~0.0625 at four half-lives. Smooth and
- *   parameterizable; no cliffs.
- * - kindBias: `reflectionBias` for reflections, 1.0 for raw
- *   observations. Default 1.3 keeps reflections preferred at matched
- *   priority/recency without shutting raw observations out.
- *
- * Examples at the default 7d half-life and 1.3 reflection bias:
- *   - high reflection, 0d:    3 * 1.0    * 1.3 = 3.9
- *   - high observation, 0d:   3 * 1.0    * 1.0 = 3.0
- *   - medium reflection, 0d:  2 * 1.0    * 1.3 = 2.6
- *   - high reflection, 7d:    3 * 0.5    * 1.3 = 1.95
- *   - low observation, 30d:   1 * 0.0508 * 1.0 = 0.05  (effectively pruned)
- */
-export function score(observation: Observation, inputs: ScoreInputs): number {
-  const priorityWeight = PRIORITY_WEIGHT[observation.priority];
-  const ageMs = Math.max(0, inputs.now - observation.createdAt);
-  const recencyDecay = Math.pow(0.5, ageMs / inputs.halfLifeMs);
-  const kindBias = observation.kind === "reflection" ? inputs.reflectionBias : 1.0;
-  return priorityWeight * recencyDecay * kindBias;
-}
 
 export interface LoadGlobalPackOptions {
   /**
@@ -83,91 +56,82 @@ export interface LoadGlobalPackOptions {
   excludeSessionId?: string;
   /** Maximum tokens of `content` packed into the result. Defaults to 8000. */
   tokenBudget?: number;
-  /** Recency half-life in milliseconds. */
+  /** Half-life in milliseconds applied to time since `last_used_at`. */
   recencyHalfLifeMs: number;
-  /** Reflection bias multiplier. */
+  /** Reflection bias multiplier applied as a `kind = 'reflection'` factor. */
   reflectionBias: number;
-  /**
-   * Override for `Date.now()`, used by tests so fixture data with
-   * fixed `created_at` values produces deterministic scores.
-   */
-  now?: number;
 }
 
 /**
- * Load the highest-scoring rows from every session except the caller's,
- * up to the token budget. Returns rows ordered by descending score so
+ * Load the highest-ranked rows from every session except the caller's,
+ * up to the token budget. Returns rows ordered by descending rank so
  * the renderer can preserve the ranking visually.
  *
- * Implementation note: the database query orders by `created_at DESC`
- * (cheap with the `idx_obs_kind_priority_created` index) and a generous
- * over-fetch limit; the actual ranking happens in JS so the recency
- * decay term can be applied without trying to express `0.5 ^ x` in
- * portable SQL. With a 8k-token budget and ~250-token rows this means
- * a worst case of ~32 rows packed; the over-fetch keeps the planner
- * cheap even when the budget is set higher.
+ * The SQL `ORDER BY` materializes
+ * `ln(priority) + ln(kindBias) + last_used_at / h`, which is monotone
+ * in the full score, so the database returns rows in the exact order
+ * the runtime ranking would. JS then walks the result greedily,
+ * skipping rows that would overflow the token budget but continuing
+ * past them — a smaller row later in the ranking may still fit, and
+ * leaving the budget half-empty just because the highest-ranked row
+ * is a long reflection would waste prompt space.
  */
 export async function loadGlobalPack(
   db: PGlite,
   options: LoadGlobalPackOptions,
 ): Promise<Observation[]> {
   const tokenBudget = options.tokenBudget ?? 8000;
-  const now = options.now ?? Date.now();
 
-  // Over-fetch by a comfortable factor so the JS-side scorer has enough
-  // candidates to find the top-N regardless of priority distribution.
-  // 4x the typical row count fitting in the budget keeps the SQL cheap
-  // while leaving headroom for a long tail of low-priority rows.
-  const overFetchLimit = Math.max(200, Math.ceil(tokenBudget / 50));
+  // Upper bound on how many rows could ever fit: assume each row is
+  // at least ~50 tokens of content. Asking the planner for more than
+  // this is wasted work; asking for fewer risks the greedy-fit
+  // exhausting candidates before the budget closes.
+  const candidateLimit = Math.max(50, Math.ceil(tokenBudget / 50));
 
-  let result: { rows: GlobalRow[] };
-  if (options.excludeSessionId === undefined) {
-    result = await db.query<GlobalRow>(
-      `SELECT id, created_at, session_id, kind, observed_date, referenced_date,
-              relative_date, time_of_day, priority, source_json, content, tags_json
-       FROM observations
-       ORDER BY created_at DESC
-       LIMIT $1`,
-      [overFetchLimit],
-    );
-  } else {
-    // NULL session_id rows (legacy, pre-sessionId tracking) are kept in
-    // the global pool because they cannot match any current session.
-    // Without `IS DISTINCT FROM` Postgres would treat NULL = X as NULL,
-    // which filters those legacy rows out of every query.
-    result = await db.query<GlobalRow>(
-      `SELECT id, created_at, session_id, kind, observed_date, referenced_date,
-              relative_date, time_of_day, priority, source_json, content, tags_json
-       FROM observations
-       WHERE session_id IS DISTINCT FROM $1
-       ORDER BY created_at DESC
-       LIMIT $2`,
-      [options.excludeSessionId, overFetchLimit],
-    );
+  const params: unknown[] = [
+    PRIORITY_WEIGHT.high,
+    PRIORITY_WEIGHT.medium,
+    PRIORITY_WEIGHT.low,
+    options.reflectionBias,
+    options.recencyHalfLifeMs,
+  ];
+  let scopeClause = "";
+  if (options.excludeSessionId !== undefined) {
+    // NULL session_id rows (legacy, pre-sessionId tracking) are kept
+    // in the global pool because they cannot match any current
+    // session. Without `IS DISTINCT FROM` Postgres would treat
+    // NULL = X as NULL, which filters those legacy rows out of every
+    // query.
+    scopeClause = `WHERE session_id IS DISTINCT FROM $${params.length + 1}`;
+    params.push(options.excludeSessionId);
   }
+  params.push(candidateLimit);
+  const limitParam = params.length;
 
-  const candidates = result.rows.map(rowToObservation);
-  const scoreInputs: ScoreInputs = {
-    now,
-    halfLifeMs: options.recencyHalfLifeMs,
-    reflectionBias: options.reflectionBias,
-  };
-  const ranked = candidates
-    .map((observation) => ({ observation, score: score(observation, scoreInputs) }))
-    .sort((a, b) => b.score - a.score);
+  const sql = `SELECT id, created_at, last_used_at, session_id, kind, observed_date, referenced_date,
+              relative_date, time_of_day, priority, source_json, content, tags_json
+       FROM observations
+       ${scopeClause}
+       ORDER BY
+         ln(CASE priority WHEN 'high' THEN $1::float
+                          WHEN 'medium' THEN $2::float
+                          ELSE $3::float END)
+         + ln(CASE kind WHEN 'reflection' THEN $4::float ELSE 1.0 END)
+         + last_used_at::float / $5::float
+         DESC
+       LIMIT $${limitParam}`;
+
+  const result = await db.query<GlobalRow>(sql, params);
+  const ranked = result.rows.map(rowToObservation);
 
   const packed: Observation[] = [];
   let usedTokens = 0;
-  for (const entry of ranked) {
-    const tokens = estimateTokens(entry.observation.content);
+  for (const observation of ranked) {
+    const tokens = estimateTokens(observation.content);
     if (usedTokens + tokens > tokenBudget) {
-      // Skip oversize rows but keep iterating: a smaller row later in
-      // the ranking may still fit, which avoids leaving the budget
-      // half-empty just because one high-scoring row was a long
-      // reflection.
       continue;
     }
-    packed.push(entry.observation);
+    packed.push(observation);
     usedTokens += tokens;
   }
   return packed;
@@ -191,7 +155,7 @@ export async function loadLocalPack(
   options: LoadLocalPackOptions,
 ): Promise<Observation[]> {
   const result = await db.query<GlobalRow>(
-    `SELECT id, created_at, session_id, kind, observed_date, referenced_date,
+    `SELECT id, created_at, last_used_at, session_id, kind, observed_date, referenced_date,
             relative_date, time_of_day, priority, source_json, content, tags_json
      FROM observations
      WHERE session_id = $1
@@ -204,6 +168,7 @@ export async function loadLocalPack(
 interface GlobalRow {
   id: string;
   created_at: number;
+  last_used_at: number;
   session_id: string | null;
   kind: ObservationKind;
   observed_date: string;
@@ -220,6 +185,7 @@ function rowToObservation(row: GlobalRow): Observation {
   return {
     id: row.id,
     createdAt: row.created_at,
+    lastUsedAt: row.last_used_at,
     ...(row.session_id !== null ? { sessionId: row.session_id } : {}),
     kind: row.kind,
     observedDate: row.observed_date,

--- a/src/memory/migrations.ts
+++ b/src/memory/migrations.ts
@@ -207,6 +207,37 @@ const MIGRATIONS: Migration[] = [
       );
     },
   },
+  {
+    version: 4,
+    description: "add last_used_at column for usage-decay ranking",
+    up: async (tx) => {
+      // last_used_at drives the global-layer ranking instead of
+      // created_at. Bumped at end of turn for every observation the
+      // observer reports as having informed the assistant's response,
+      // so memories that keep being used keep surfacing.
+      //
+      // Two-step add: column comes in nullable, backfills to
+      // created_at for every existing row (so legacy rows enter the
+      // ranking with their original recency), then we tighten to
+      // NOT NULL. PGlite doesn't accept column-level defaults that
+      // reference other columns, which is why this can't be a single
+      // ALTER TABLE.
+      await tx.exec(`ALTER TABLE observations ADD COLUMN IF NOT EXISTS last_used_at BIGINT`);
+      await tx.exec(`UPDATE observations SET last_used_at = created_at WHERE last_used_at IS NULL`);
+      await tx.exec(`ALTER TABLE observations ALTER COLUMN last_used_at SET NOT NULL`);
+
+      // Replace the created_at-keyed ranking index with a
+      // last_used_at-keyed one. The loader's ORDER BY now sorts by
+      // last_used_at; keeping the old index would be dead weight
+      // since no query path consults created_at as the ranking key
+      // any more.
+      await tx.exec(`DROP INDEX IF EXISTS idx_obs_kind_priority_created`);
+      await tx.exec(
+        `CREATE INDEX IF NOT EXISTS idx_obs_kind_priority_lastused
+         ON observations(kind, priority, last_used_at DESC)`,
+      );
+    },
+  },
 ];
 
 export interface MigrationResult {

--- a/src/memory/observational-prompts.ts
+++ b/src/memory/observational-prompts.ts
@@ -142,6 +142,9 @@ export function buildObserverOutputFormat(includeThreadTitle = false): string {
     - Secondary: other pending tasks, marked "waiting for user" when appropriate
     - If the agent started doing something without user approval, note that it is off-task
 
+    usedObservationIds:
+    The existing observations block above lists prior cross-session memories with explicit \`[memory id: mem_xxx]\` markers. If the assistant's response in this exchange leaned on one or more of those memories — referenced facts, preferences, prior decisions, or context drawn from them — list the matching ids here. Omit or return [] when no prior memory was actually used. Only cite ids that appear verbatim in the markers above; do not invent ids.
+
     suggestedContinuation:
     Hint for the agent's immediate next message. If the assistant needs to respond to the user, say that it should pause for user reply before continuing other tasks.
     ${threadTitleSection}

--- a/src/memory/observational.ts
+++ b/src/memory/observational.ts
@@ -11,7 +11,14 @@ import {
   WIRE_BYTE_TRIGGER,
   type WireGuardHorizon,
 } from "../turn-runner/wire-shaping.js";
-import type { MemoryStore } from "./store.js";
+import type { MemoryContextCache } from "./store.js";
+import {
+  appendObservation,
+  bumpLastUsed,
+  readSessionObservations,
+  replaceSessionObservations,
+  type MemoryDatabase,
+} from "./storage.js";
 import type {
   Observation,
   ObservationPriority,
@@ -78,6 +85,14 @@ export interface ObserverResult {
   hasMemory: boolean;
   /** New observation log text extracted from raw messages. */
   observations: string;
+  /**
+   * Ids of prior memories that the observer reports as having actually
+   * informed the assistant's response in this exchange. The runner
+   * advances `lastUsedAt` on these rows so reused memories keep
+   * climbing in the global ranking even as their original
+   * `createdAt` recedes.
+   */
+  usedObservationIds?: string[];
   /** Current task state distilled for continuity and optional thread metadata. */
   currentTask?: string;
   /** Hint for the actor's next response after context has been compressed. */
@@ -106,6 +121,12 @@ const observerResultSchema = Type.Object({
     description:
       "New observation log text extracted from the raw message history. When hasMemory is false, return an empty string.",
   }),
+  usedObservationIds: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        "Ids of prior memories from the [memory id: mem_...] markers in the existing observations block whose content actually informed the assistant's response in this exchange. Drives the lastUsedAt freshness signal so reused memories keep surfacing. Omit or return [] when no prior memory was leaned on.",
+    }),
+  ),
   currentTask: Type.Optional(
     Type.String({ description: "Current task state distilled for continuity." }),
   ),
@@ -184,7 +205,7 @@ export class ModelByInputTokens {
 }
 
 export interface ObservationalContextTransformOptions {
-  memory: MemoryStore;
+  memory: MemoryContextCache;
   settings?: ObservationalMemorySettingsInput;
   /**
    * Compaction trigger fired when the wire-shaping eviction horizon
@@ -208,7 +229,10 @@ export interface ObservationalContextTransformOptions {
 }
 
 export interface ObservationalMemoryUpdateOptions {
-  memory: MemoryStore;
+  /** PGlite database that owns the durable memory rows. */
+  db: MemoryDatabase;
+  /** Frozen context-pack cache; queried for the global memories the observer can attribute usage against. */
+  memory: MemoryContextCache;
   /**
    * Session that owns the runner. Stamped onto every observation and
    * reflection produced by this update so the loader can later split
@@ -393,8 +417,16 @@ export async function updateObservationalMemory(
   const settings = resolveObservationalMemorySettings(options.settings);
   validateObservationalMemorySettings(settings);
   const rawMessages = agentMessagesToRaw(stripObservationalContextMessages(options.messages));
-  const snapshot = await options.memory.getSnapshot();
-  const unobservedMessages = getUnobservedMessageTail(rawMessages, snapshot.observations);
+  // Local snapshot is the only set whose range markers gate
+  // `getUnobservedMessageTail`. The observer's prior-context input
+  // includes both this and the global pack rendered with id markers
+  // so the model can attribute usage back to specific cross-session
+  // memories.
+  const localSnapshot = options.sessionId
+    ? await readSessionObservations(options.db, options.sessionId)
+    : { observations: [], estimatedObservationTokens: 0 };
+  const globalPack = options.memory.getContextPack().global;
+  const unobservedMessages = getUnobservedMessageTail(rawMessages, localSnapshot.observations);
   const result: ObservationalMemoryUpdateResult = { observations: [], reflections: [] };
 
   if (unobservedMessages.length > 0) {
@@ -403,15 +435,16 @@ export async function updateObservationalMemory(
       status: "running",
       message: "Observing conversation into memory...",
     });
-    const observation = await activateObservations(
-      options.memory,
-      unobservedMessages,
-      snapshot.observations,
+    const observation = await activateObservations({
+      db: options.db,
+      messages: unobservedMessages,
+      previousLocalObservations: localSnapshot.observations,
+      attributableMemories: globalPack,
       settings,
-      options.sessionId,
-      options.actorModel,
-      options.onUsage,
-    );
+      sessionId: options.sessionId,
+      model: options.actorModel,
+      onUsage: options.onUsage,
+    });
     if (observation) {
       result.observations.push(observation);
     }
@@ -423,30 +456,32 @@ export async function updateObservationalMemory(
     });
   }
 
-  const refreshed = await options.memory.getSnapshot();
-  const observationTokens = refreshed.estimatedTokens.observations;
-  if (observationTokens >= settings.reflection.observationTokens) {
-    emitMemoryActivity(options.onActivity, {
-      phase: "reflection",
-      status: "running",
-      message: "Reflecting memory observations...",
-    });
-    const reflections = await reflectObservations(
-      options.memory,
-      settings,
-      options.sessionId,
-      options.actorModel,
-      options.onUsage,
-    );
-    if (reflections) {
-      result.reflections.push(...reflections);
+  if (options.sessionId) {
+    const refreshed = await readSessionObservations(options.db, options.sessionId);
+    if (refreshed.estimatedObservationTokens >= settings.reflection.observationTokens) {
+      emitMemoryActivity(options.onActivity, {
+        phase: "reflection",
+        status: "running",
+        message: "Reflecting memory observations...",
+      });
+      const reflections = await reflectObservations({
+        db: options.db,
+        sessionObservations: refreshed.observations,
+        settings,
+        sessionId: options.sessionId,
+        model: options.actorModel,
+        onUsage: options.onUsage,
+      });
+      if (reflections) {
+        result.reflections.push(...reflections);
+      }
+      emitMemoryActivity(options.onActivity, {
+        phase: "reflection",
+        status: "completed",
+        message: reflections ? "Memory reflection recorded." : "Memory reflection complete.",
+        ...(reflections ? { observations: reflections } : {}),
+      });
     }
-    emitMemoryActivity(options.onActivity, {
-      phase: "reflection",
-      status: "completed",
-      message: reflections ? "Memory reflection recorded." : "Memory reflection complete.",
-      ...(reflections ? { observations: reflections } : {}),
-    });
   }
 
   return result;
@@ -504,27 +539,45 @@ function isObservationalContextMessage(message: AgentMessage): boolean {
   );
 }
 
+interface ActivateObservationsArgs {
+  db: MemoryDatabase;
+  messages: RawMemoryMessage[];
+  /** Prior observations from the same session, used for dedupe context. */
+  previousLocalObservations: Observation[];
+  /** Cross-session memories rendered to the actor; the observer attributes usage against these. */
+  attributableMemories: Observation[];
+  settings: ObservationalMemorySettings;
+  sessionId: string | undefined;
+  model: string;
+  onUsage?: (usage: Usage) => void;
+}
+
 async function activateObservations(
-  store: MemoryStore,
-  messages: RawMemoryMessage[],
-  previousObservations: Observation[],
-  settings: ObservationalMemorySettings,
-  sessionId: string | undefined,
-  model: string,
-  onUsage?: (usage: Usage) => void,
+  args: ActivateObservationsArgs,
 ): Promise<Observation | undefined> {
-  const observations = await observe(messages, previousObservations, settings, model, onUsage);
+  const observations = await observe(
+    args.messages,
+    args.previousLocalObservations,
+    args.attributableMemories,
+    args.settings,
+    args.model,
+    args.onUsage,
+  );
+  // Usage attribution applies whether or not the observer had new
+  // memory worth recording — a turn can lean on a prior memory even
+  // when nothing new is durable.
+  await applyUsageBumps(args.db, args.attributableMemories, observations.usedObservationIds);
 
   if (!observations.hasMemory || !observations.observations.trim()) {
-    // Empty observer output intentionally does not create a checkpoint. The
-    // same low-signal messages may become useful context for a later suffix.
+    // The same low-signal messages may become useful context for a
+    // later suffix, so do not record an empty checkpoint.
     return undefined;
   }
 
-  const range = `${messages[0]?.id ?? "unknown"}:${messages[messages.length - 1]?.id ?? "unknown"}`;
-  return store.appendObservation({
+  const range = `${args.messages[0]?.id ?? "unknown"}:${args.messages[args.messages.length - 1]?.id ?? "unknown"}`;
+  return appendObservation(args.db, {
     kind: "observation",
-    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(args.sessionId !== undefined ? { sessionId: args.sessionId } : {}),
     observedDate: new Date().toISOString().slice(0, 10),
     timeOfDay: new Date().toISOString().slice(11, 16),
     priority: inferPriority(observations.observations),
@@ -534,15 +587,40 @@ async function activateObservations(
   });
 }
 
+/**
+ * Bump `last_used_at` for the subset of `usedObservationIds` that
+ * actually corresponds to an attributable memory id rendered to the
+ * observer. Filtering against the candidate set rejects hallucinated
+ * ids without an extra round-trip; the database column accepts any
+ * ids unconditionally so a strict guard here is the only line of
+ * defense.
+ */
+async function applyUsageBumps(
+  db: MemoryDatabase,
+  candidates: Observation[],
+  usedIds: string[] | undefined,
+): Promise<void> {
+  if (!usedIds || usedIds.length === 0) return;
+  const candidateIds = new Set(candidates.map((c) => c.id));
+  const validated = usedIds.filter((id) => candidateIds.has(id));
+  if (validated.length === 0) return;
+  await bumpLastUsed(db, validated, Date.now());
+}
+
+interface ReflectObservationsArgs {
+  db: MemoryDatabase;
+  sessionObservations: Observation[];
+  settings: ObservationalMemorySettings;
+  sessionId: string;
+  model: string;
+  onUsage?: (usage: Usage) => void;
+}
+
 async function reflectObservations(
-  store: MemoryStore,
-  settings: ObservationalMemorySettings,
-  sessionId: string | undefined,
-  model: string,
-  onUsage?: (usage: Usage) => void,
+  args: ReflectObservationsArgs,
 ): Promise<Observation[] | undefined> {
-  const snapshot = await store.getSnapshot();
-  const source = snapshot.observations.map((observation) => observation.content).join("\n\n");
+  const { db, sessionObservations, settings, sessionId, model, onUsage } = args;
+  const source = sessionObservations.map((observation) => observation.content).join("\n\n");
   const rendered = renderObservationGroupsForReflection(source) ?? source;
   const targetTokens = settings.reflection.bufferActivation;
   const result = await generateStructuredOutput({
@@ -571,11 +649,13 @@ async function reflectObservations(
   }
 
   const reconciled = reconcileObservationGroupsFromReflection(text, source) ?? text;
+  const now = Date.now();
   const reflected: Observation = {
     id: createMemoryId(),
-    createdAt: Date.now(),
+    createdAt: now,
+    lastUsedAt: now,
     kind: "reflection",
-    ...(sessionId !== undefined ? { sessionId } : {}),
+    sessionId,
     observedDate: new Date().toISOString().slice(0, 10),
     timeOfDay: new Date().toISOString().slice(11, 16),
     priority: "high",
@@ -583,13 +663,18 @@ async function reflectObservations(
     content: reconciled,
     tags: ["observational-memory", "reflection"],
   };
-  await store.replaceObservations([reflected]);
+  // Session-scoped replace: only this session's rows are removed and
+  // replaced by the new reflection. Other sessions' rows in the
+  // global pool are untouched, which is what makes cross-session
+  // memory durable past a reflection event.
+  await replaceSessionObservations(db, sessionId, [reflected]);
   return [reflected];
 }
 
 async function observe(
   messages: RawMemoryMessage[],
-  previousObservations: Observation[],
+  previousLocalObservations: Observation[],
+  attributableMemories: Observation[],
   settings: ObservationalMemorySettings,
   model: string,
   onUsage?: (usage: Usage) => void,
@@ -599,8 +684,13 @@ async function observe(
     settings.observation.instruction,
     settings.observation.threadTitle,
   );
+  // Local prior observations support dedupe; attributable memories
+  // (the cross-session global pack the actor saw) are the only set
+  // the observer is allowed to reference back via
+  // `usedObservationIds`.
   const previousObservationText = renderPreviousObservationsForObserver(
-    previousObservations,
+    previousLocalObservations,
+    attributableMemories,
     settings.observation.previousObserverTokens,
   );
   const prompt = buildObserverPrompt(messages, previousObservationText, targetTokens);
@@ -640,21 +730,37 @@ async function observe(
 }
 
 function renderPreviousObservationsForObserver(
-  observations: Observation[],
+  localObservations: Observation[],
+  attributableMemories: Observation[],
   tokenBudget: number | false | undefined,
 ): string {
   if (tokenBudget === false || tokenBudget === 0) return "";
   const budget = tokenBudget ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.previousObserverTokens;
-  const selected: string[] = [];
+  // Render attributable cross-session memories first with explicit id
+  // markers so the observer can cite them in `usedObservationIds`.
+  // Local-session observations follow without ids — they exist for
+  // dedupe context only and the lastUsedAt bump does not apply
+  // within the current session anyway (their createdAt is always
+  // recent).
+  const sections: string[] = [];
   let tokens = 0;
-  for (let index = observations.length - 1; index >= 0; index--) {
-    const content = observations[index]!.content;
+  for (const memory of attributableMemories) {
+    const block = `[memory id: ${memory.id}]\n${memory.content}`;
+    const next = estimateTokens(block);
+    if (tokens + next > budget) break;
+    sections.push(block);
+    tokens += next;
+  }
+  const selected: string[] = [];
+  for (let index = localObservations.length - 1; index >= 0; index--) {
+    const content = localObservations[index]!.content;
     const nextTokens = estimateTokens(content);
     if (tokens + nextTokens > budget) break;
     selected.unshift(content);
     tokens += nextTokens;
   }
-  return selected.join("\n\n");
+  if (selected.length > 0) sections.push(selected.join("\n\n"));
+  return sections.join("\n\n");
 }
 
 export async function enforceObservationTokenBudget(options: {

--- a/src/memory/recall.ts
+++ b/src/memory/recall.ts
@@ -246,7 +246,7 @@ export function reciprocalRankFusion(rankedLists: ScoredHit[][]): string[] {
 async function hydrate(db: PGlite, ids: string[]): Promise<Observation[]> {
   if (ids.length === 0) return [];
   const { rows } = await db.query<HydratedRow>(
-    `SELECT id, created_at, session_id, kind, observed_date, referenced_date,
+    `SELECT id, created_at, last_used_at, session_id, kind, observed_date, referenced_date,
             relative_date, time_of_day, priority, source_json, content, tags_json
      FROM observations
      WHERE id = ANY($1::text[])`,
@@ -265,6 +265,7 @@ async function hydrate(db: PGlite, ids: string[]): Promise<Observation[]> {
 interface HydratedRow {
   id: string;
   created_at: number;
+  last_used_at: number;
   session_id: string | null;
   kind: ObservationKind;
   observed_date: string;
@@ -281,6 +282,7 @@ function rowToObservation(row: HydratedRow): Observation {
   return {
     id: row.id,
     createdAt: row.created_at,
+    lastUsedAt: row.last_used_at,
     ...(row.session_id !== null ? { sessionId: row.session_id } : {}),
     kind: row.kind,
     observedDate: row.observed_date,

--- a/src/memory/storage.ts
+++ b/src/memory/storage.ts
@@ -1,53 +1,36 @@
-import type { PGlite } from "@electric-sql/pglite";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type {
-  MemoryStoreEvent,
-  Observation,
-  ObservationalMemorySettings,
-  ObservationalMemorySnapshot,
-} from "../types/memory.js";
-import { rebuildMemoryContextPack } from "./context-pack.js";
+import type { PGlite, Transaction } from "@electric-sql/pglite";
+import type { Observation, ObservationalMemorySettings } from "../types/memory.js";
 import { DEFAULT_EMBEDDING_MODEL, type EmbedFn } from "./embedding.js";
 import { EmbeddingBackfillWorker } from "./embedding-worker.js";
+import { rebuildMemoryContextPack } from "./context-pack.js";
 import { runMigrations } from "./migrations.js";
 import { openPGlite } from "./pglite.js";
-import type { MemoryStore } from "./store.js";
+import type { MemoryContextCache } from "./store.js";
+import { nanoid } from "nanoid";
 
-type MemoryDatabase = PGlite;
+export type MemoryDatabase = PGlite;
+
+/**
+ * Handle returned by `loadStoredMemory`. Callers use `db` directly with
+ * the helpers in this module — there is no in-memory mirror to keep in
+ * sync, so writes are inline awaits against PGlite. Memory disabled
+ * leaves `db` undefined and persistence becomes a no-op.
+ */
 export interface MemoryPersistenceHandle {
-  flush: () => Promise<void>;
+  db: MemoryDatabase | undefined;
+  embed: EmbedFn | undefined;
   dispose: () => Promise<void>;
-  /**
-   * The opened PGlite handle, exposed so tools (recall_memory, future
-   * loaders) can run their own queries against the same database the
-   * MemoryStore writes through. Undefined when memory persistence is
-   * disabled (the no-op handle); callers must not close it.
-   */
-  db?: PGlite;
-  /** Embedding callable shared with the backfill worker, when configured. */
-  embed?: EmbedFn;
 }
 
 export interface LoadStoredMemoryOptions {
-  /**
-   * Embedding callable used by the background backfill worker. Omit to
-   * skip embedding work entirely — useful in tests that do not exercise
-   * `recall_memory`. The worker is built only when this is provided.
-   */
   embed?: EmbedFn;
-  /** Embedding model identifier written alongside each vector. */
   embeddingModel?: string;
-  /** Optional override for the backfill log path; defaults to ~/.duet/logs/memory-backfill.log. */
   embeddingLogPath?: string;
-  /**
-   * Settings + sessionId used to build the initial context pack. When
-   * provided, `loadStoredMemory` builds and freezes the rendered
-   * memory pack as part of the load so the first turn already sees a
-   * stable prefix. Omit to skip the initial build (the runner can
-   * trigger it later).
-   */
+  /** When set, freeze the initial context pack into the cache before the first turn dispatches. */
   contextPack?: {
+    cache: MemoryContextCache;
     settings: ObservationalMemorySettings;
     sessionId?: string;
   };
@@ -56,24 +39,14 @@ export interface LoadStoredMemoryOptions {
 export async function loadStoredMemory(
   memoryPath: string | false | undefined,
   cwd: string,
-  store: MemoryStore,
   options: LoadStoredMemoryOptions = {},
 ): Promise<MemoryPersistenceHandle> {
   if (!memoryPath) {
     const noop = async () => {};
-    return { flush: noop, dispose: noop };
+    return { db: undefined, embed: undefined, dispose: noop };
   }
 
   const database = await openMemoryDatabase(resolveMemoryPath(memoryPath, cwd));
-  const snapshot = await readMemorySnapshot(database);
-  await store.replaceObservations(snapshot.observations);
-
-  let writeQueue = Promise.resolve();
-  const enqueueWrite = (event: MemoryStoreEvent) => {
-    writeQueue = writeQueue.then(() => persistMemoryEvent(database, event));
-    void writeQueue;
-  };
-  const unsubscribe = store.on(enqueueWrite);
 
   // The backfill worker runs whenever the CLI is up. Observers and
   // reflectors write rows during turns; embeddings catch up in the
@@ -98,7 +71,7 @@ export async function loadStoredMemory(
     try {
       await rebuildMemoryContextPack({
         db: database,
-        store,
+        cache: options.contextPack.cache,
         settings: options.contextPack.settings,
         ...(options.contextPack.sessionId !== undefined
           ? { sessionId: options.contextPack.sessionId }
@@ -111,16 +84,11 @@ export async function loadStoredMemory(
     }
   }
 
-  const flush = async () => {
-    await writeQueue;
-  };
   const dispose = async () => {
-    unsubscribe();
     await worker?.stop();
-    await flush();
     await database.close();
   };
-  return { flush, dispose, db: database, embed: options.embed };
+  return { db: database, embed: options.embed, dispose };
 }
 
 function defaultEmbeddingLogPath(): string {
@@ -139,63 +107,117 @@ async function openMemoryDatabase(path: string): Promise<MemoryDatabase> {
   });
 }
 
-async function readMemorySnapshot(database: MemoryDatabase): Promise<ObservationalMemorySnapshot> {
-  const result = await database.query<ObservationRow>(
-    `SELECT id, created_at, session_id, kind, observed_date, referenced_date, relative_date, time_of_day, priority, source_json, content, tags_json
-     FROM observations
-     ORDER BY created_at ASC`,
-  );
-  const observations = result.rows.map(rowToObservation);
-  return {
-    observations,
-    estimatedTokens: {
-      observations: estimateTokens(observations.map((item) => item.content).join("\n")),
-    },
-    updatedAt: Date.now(),
+/**
+ * Insert a new observation row, materializing `id`, `createdAt`, and
+ * `lastUsedAt = createdAt`. Returns the populated `Observation` so
+ * callers can refer to the freshly-assigned id (e.g. to keep
+ * observation-group range markers consistent).
+ */
+export async function appendObservation(
+  db: MemoryDatabase,
+  input: Omit<Observation, "id" | "createdAt" | "lastUsedAt">,
+): Promise<Observation> {
+  const observation: Observation = {
+    ...input,
+    id: createMemoryId(),
+    createdAt: Date.now(),
+    lastUsedAt: Date.now(),
   };
+  await upsertObservation(db, observation);
+  return observation;
 }
 
-async function persistMemoryEvent(
-  database: MemoryDatabase,
-  event: MemoryStoreEvent,
-): Promise<void> {
-  if (event.type === "observation_appended") {
-    await upsertObservation(database, event.observation);
-    return;
-  }
-
-  await syncObservations(database, event.observations);
-}
-
-async function syncObservations(
-  database: MemoryDatabase,
+/**
+ * Replace this session's rows with the given list. Used by reflection,
+ * which condenses the session's observation log into one reflection
+ * row. Scoping the delete to `session_id = $1` is what makes the
+ * cross-session global pool durable: another session's rows are never
+ * touched by the current session's reflection.
+ */
+export async function replaceSessionObservations(
+  db: MemoryDatabase,
+  sessionId: string,
   observations: readonly Observation[],
 ): Promise<void> {
   const ids = observations.map((observation) => observation.id);
-  await database.transaction(async (tx) => {
+  await db.transaction(async (tx) => {
     if (ids.length === 0) {
-      await tx.exec("DELETE FROM observations");
+      await tx.query("DELETE FROM observations WHERE session_id = $1", [sessionId]);
     } else {
-      await tx.query("DELETE FROM observations WHERE NOT (id = ANY($1::text[]))", [ids]);
+      await tx.query(
+        "DELETE FROM observations WHERE session_id = $1 AND NOT (id = ANY($2::text[]))",
+        [sessionId, ids],
+      );
     }
-
     for (const observation of observations) {
       await upsertObservation(tx, observation);
     }
   });
 }
 
+/**
+ * Read this session's observations in chronological order along with a
+ * rough token count. Used by the observer (to gate reflection on
+ * cumulative session-local observation tokens) and by
+ * `getUnobservedMessageTail` to find the highest message id already
+ * folded into an observation-group range.
+ */
+export interface SessionObservationsSnapshot {
+  observations: Observation[];
+  estimatedObservationTokens: number;
+}
+
+export async function readSessionObservations(
+  db: MemoryDatabase,
+  sessionId: string,
+): Promise<SessionObservationsSnapshot> {
+  const result = await db.query<ObservationRow>(
+    `SELECT id, created_at, last_used_at, session_id, kind, observed_date, referenced_date,
+            relative_date, time_of_day, priority, source_json, content, tags_json
+     FROM observations
+     WHERE session_id = $1
+     ORDER BY created_at ASC`,
+    [sessionId],
+  );
+  const observations = result.rows.map(rowToObservation);
+  return {
+    observations,
+    estimatedObservationTokens: estimateTokens(
+      observations.map((observation) => observation.content).join("\n"),
+    ),
+  };
+}
+
+/**
+ * Bump `last_used_at` for the given ids to `now`. Fire-and-forget
+ * usage signal: if the model's response leaned on a particular
+ * memory, that memory's ranking refreshes so it stays surfaced. No-op
+ * when `ids` is empty.
+ */
+export async function bumpLastUsed(
+  db: MemoryDatabase,
+  ids: readonly string[],
+  now: number,
+): Promise<void> {
+  if (ids.length === 0) return;
+  await db.query("UPDATE observations SET last_used_at = $1 WHERE id = ANY($2::text[])", [
+    now,
+    ids,
+  ]);
+}
+
 async function upsertObservation(
-  database: Pick<MemoryDatabase, "query">,
+  database: Pick<MemoryDatabase, "query"> | Transaction,
   observation: Observation,
 ): Promise<void> {
   await database.query(
     `INSERT INTO observations (
-      id, created_at, session_id, kind, observed_date, referenced_date, relative_date, time_of_day,
+      id, created_at, last_used_at, session_id, kind, observed_date, referenced_date, relative_date, time_of_day,
       priority, source_json, content, tags_json
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
     ON CONFLICT (id) DO UPDATE SET
       created_at = EXCLUDED.created_at,
+      last_used_at = EXCLUDED.last_used_at,
       session_id = EXCLUDED.session_id,
       kind = EXCLUDED.kind,
       observed_date = EXCLUDED.observed_date,
@@ -209,6 +231,7 @@ async function upsertObservation(
     [
       observation.id,
       observation.createdAt,
+      observation.lastUsedAt,
       observation.sessionId ?? null,
       observation.kind,
       observation.observedDate,
@@ -231,9 +254,14 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
+function createMemoryId(): string {
+  return `mem_${nanoid(12)}`;
+}
+
 interface ObservationRow {
   id: string;
   created_at: number;
+  last_used_at: number;
   session_id: string | null;
   kind: Observation["kind"];
   observed_date: string;
@@ -250,6 +278,7 @@ function rowToObservation(row: ObservationRow): Observation {
   return {
     id: row.id,
     createdAt: row.created_at,
+    lastUsedAt: row.last_used_at,
     ...(row.session_id !== null ? { sessionId: row.session_id } : {}),
     kind: row.kind,
     observedDate: row.observed_date,

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,12 +1,4 @@
-import { nanoid } from "nanoid";
-import type {
-  MemoryStoreEvent,
-  MemoryStoreEventHandler,
-  Observation,
-  ObservationPriority,
-  ObservationQuery,
-  ObservationalMemorySnapshot,
-} from "../types/memory.js";
+import type { Observation } from "../types/memory.js";
 
 /**
  * Frozen view of memory rendered into the prompt prefix. Captured at
@@ -16,10 +8,10 @@ import type {
  * cache survives unchanged until the next compaction event, at which
  * point exactly one cache invalidation is paid — not one per turn.
  *
- * Observations the observer writes mid-session still flow to the
- * database in real time; they just do not enter `contextPack` until
- * the next refresh. The model still sees them through `recall_memory`
- * if it asks.
+ * Observations the observer writes mid-session still flow to PGlite in
+ * real time; they just do not enter `contextPack` until the next
+ * refresh. The model still sees them through `recall_memory` if it
+ * asks.
  */
 export interface ContextPack {
   /** Cross-session ranked memory; rendered above the local section. */
@@ -28,89 +20,25 @@ export interface ContextPack {
   local: Observation[];
 }
 
-export class MemoryStore {
-  private observations: Map<string, Observation> = new Map();
-  private handlers = new Set<MemoryStoreEventHandler>();
+/**
+ * Holds the frozen context pack rendered above the message tail.
+ *
+ * This is the only piece of memory state the runner keeps in process —
+ * everything else (observation rows, ranking, recall) lives in PGlite
+ * and is read on demand. Holding the pack here, rather than
+ * recomputing inside the transform on every dispatch, is what lets
+ * the rendered prefix stay byte-identical between compaction events
+ * so the provider's prompt cache survives.
+ */
+export class MemoryContextCache {
   private contextPack: ContextPack = { global: [], local: [] };
-
-  on(handler: MemoryStoreEventHandler): () => void {
-    this.handlers.add(handler);
-    return () => {
-      this.handlers.delete(handler);
-    };
-  }
-
-  async appendObservation(input: Omit<Observation, "id" | "createdAt">): Promise<Observation> {
-    const observation: Observation = {
-      ...input,
-      id: createMemoryId(),
-      createdAt: Date.now(),
-    };
-    this.observations.set(observation.id, observation);
-    this.emit({ type: "observation_appended", observation });
-    return observation;
-  }
-
-  async recall(query: ObservationQuery): Promise<Observation[]> {
-    let candidates = Array.from(this.observations.values());
-
-    if (query.sessionId !== undefined) {
-      candidates = candidates.filter((observation) => observation.sessionId === query.sessionId);
-    }
-    if (query.kind) {
-      candidates = candidates.filter((observation) => observation.kind === query.kind);
-    }
-    if (query.tags?.length) {
-      candidates = candidates.filter((observation) =>
-        query.tags!.some((tag) => observation.tags.includes(tag)),
-      );
-    }
-    if (query.minPriority) {
-      const minRank = priorityRank(query.minPriority);
-      candidates = candidates.filter(
-        (observation) => priorityRank(observation.priority) >= minRank,
-      );
-    }
-    if (query.query) {
-      const terms = tokenize(query.query);
-      candidates = candidates.sort((a, b) => textScore(b, terms) - textScore(a, terms));
-    } else {
-      candidates.sort((a, b) => b.createdAt - a.createdAt);
-    }
-    return candidates.slice(0, query.limit ?? 10);
-  }
-
-  async getSnapshot(): Promise<ObservationalMemorySnapshot> {
-    const observations = Array.from(this.observations.values()).sort(
-      (a, b) => a.createdAt - b.createdAt,
-    );
-    const updatedAt = Date.now();
-    return {
-      observations,
-      estimatedTokens: {
-        observations: estimateTokens(observations.map((item) => item.content).join("\n")),
-      },
-      updatedAt,
-    };
-  }
-
-  async replaceObservations(observations: Observation[]): Promise<void> {
-    this.observations.clear();
-    for (const observation of observations) {
-      this.observations.set(observation.id, observation);
-    }
-    this.emit({ type: "observations_replaced", observations });
-  }
 
   /**
    * Replace the frozen view used by the runner's context transform.
-   * Called by `rebuildMemoryContextPack()` at compaction events and by
-   * `loadStoredMemory()` after the initial database seed.
-   *
-   * Holding the pack here (rather than recomputing inside the transform
-   * on every dispatch) is the entire point of the cache-stability
-   * design: until the next refresh, every turn renders exactly the
-   * same memory prefix.
+   * Called by `rebuildMemoryContextPack()` at every compaction trigger
+   * (initial load, reflector completion, wire-shaping eviction
+   * horizon advance) and never anywhere else — that constraint is
+   * what makes the rendered prefix cache-stable.
    */
   setContextPack(pack: ContextPack): void {
     this.contextPack = pack;
@@ -120,42 +48,4 @@ export class MemoryStore {
   getContextPack(): ContextPack {
     return this.contextPack;
   }
-
-  private emit(event: MemoryStoreEvent): void {
-    for (const handler of this.handlers) {
-      handler(event);
-    }
-  }
-}
-
-function createMemoryId(): string {
-  return `mem_${nanoid(12)}`;
-}
-
-function priorityRank(priority: ObservationPriority): number {
-  return priority === "high" ? 3 : priority === "medium" ? 2 : 1;
-}
-
-function tokenize(text: string): Set<string> {
-  return new Set(
-    text
-      .toLowerCase()
-      .split(/[^a-z0-9]+/)
-      .filter(Boolean),
-  );
-}
-
-function textScore(observation: Observation, terms: Set<string>): number {
-  const text = `${observation.content} ${observation.tags.join(" ")}`.toLowerCase();
-  let score = priorityRank(observation.priority);
-  for (const term of terms) {
-    if (text.includes(term)) {
-      score += 1;
-    }
-  }
-  return score;
-}
-
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
 }

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -440,7 +440,7 @@ interface TurnRunnerToolsInput {
 
 export interface RecallMemoryToolStorage {
   /**
-   * Returns the database used by the runner's MemoryStore, or undefined
+   * Returns the database backing the runner's durable memory, or undefined
    * when memory persistence is disabled (one-shot tools, tests). The
    * recall_memory tool no-ops when undefined so the model never sees a
    * tool whose backing store is missing.

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -19,7 +19,7 @@ import { rebuildMemoryContextPack } from "../memory/context-pack.js";
 import { createEmbeddingClient } from "../memory/embedding.js";
 import { resolveObservationalMemorySettings } from "../memory/observational.js";
 import { loadStoredMemory, type MemoryPersistenceHandle } from "../memory/storage.js";
-import { MemoryStore } from "../memory/store.js";
+import { MemoryContextCache } from "../memory/store.js";
 import {
   DEFAULT_CLI_MEMORY_MODEL,
   DEFAULT_CLI_MODEL,
@@ -95,7 +95,7 @@ export interface AgentWorkerResult {
 export class TurnRunner {
   private readonly eventHandlers = new Set<TurnEventHandler>();
   /** In-memory observation store used by context transforms during agent turns. */
-  protected readonly memory = new MemoryStore();
+  protected readonly memory = new MemoryContextCache();
   /** Hydrates, flushes, and disposes durable observation storage. */
   private memoryPersistence?: MemoryPersistenceHandle;
   /**
@@ -1054,7 +1054,10 @@ export class TurnRunner {
     if (this.config.memoryDbPath === undefined) {
       return;
     }
+    const db = this.memoryPersistence?.db;
+    if (!db) return;
     const result = await updateObservationalMemory({
+      db,
       memory: this.memory,
       sessionId: this.config.sessionId,
       actorModel: this.resolveMemoryActorModel(options),
@@ -1063,7 +1066,6 @@ export class TurnRunner {
       onUsage: (usage) => this.recordUsage(usage),
       onActivity: (event) => this.emit({ type: "memory", ...event }),
     });
-    await this.memoryPersistence?.flush();
 
     // Compaction trigger: a reflection just replaced the durable
     // observation set, so rebuild the frozen context pack to pick up
@@ -1080,7 +1082,7 @@ export class TurnRunner {
     try {
       await rebuildMemoryContextPack({
         db: this.memoryPersistence.db,
-        store: this.memory,
+        cache: this.memory,
         settings: resolveObservationalMemorySettings(this.config.memory),
         ...(this.config.sessionId !== undefined ? { sessionId: this.config.sessionId } : {}),
       });
@@ -1209,10 +1211,10 @@ export class TurnRunner {
     this.memoryPersistence = await loadStoredMemory(
       this.config.memoryDbPath,
       this.config.cwd ?? process.cwd(),
-      this.memory,
       {
         embed: createEmbeddingClient(),
         contextPack: {
+          cache: this.memory,
           settings: resolveObservationalMemorySettings(this.config.memory),
           ...(this.config.sessionId !== undefined ? { sessionId: this.config.sessionId } : {}),
         },

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -28,6 +28,15 @@ export interface Observation {
   /** Unix timestamp in milliseconds when this observation was stored. */
   createdAt: number;
   /**
+   * Unix timestamp in milliseconds for the most recent turn that
+   * actually used this observation. Initialized to `createdAt` and
+   * advanced when the observer reports the row as having informed an
+   * assistant response (`usedObservationIds`). Drives the global-layer
+   * ranking decay so memories that keep getting used keep surfacing,
+   * regardless of how old they originally are.
+   */
+  lastUsedAt: number;
+  /**
    * Session that produced this observation. Optional only for rows that
    * predate sessionId tracking — new writes always set it. Loaders use
    * this as the local/global axis: rows whose sessionId matches the
@@ -118,19 +127,23 @@ export interface ObservationalMemorySettings {
   /**
    * Token budget for the global memory layer rendered ahead of the local
    * session's compacted view. Cross-session reflections and observations
-   * are scored by `priority * recencyDecay * kindBias` and packed greedily
+   * are ranked by `priority * usageDecay * kindBias` and packed greedily
    * until this budget is exhausted. Local memory has no separate budget —
    * it reuses the existing `observation` and `reflection` thresholds since
    * the local layer is just the current session's compaction output.
    */
   globalContextTokenBudget: number;
   /**
-   * Half-life for the recency decay term in the global-layer ranking.
-   * `recencyDecay = 0.5 ^ (ageMs / halfLifeMs)` — at one half-life a row
-   * is worth half what a brand-new row of the same priority is worth.
-   * Default 7 days: short enough that month-old chatter stops crowding
-   * out current week's decisions, long enough that yesterday's
-   * conclusions still surface tomorrow.
+   * Half-life applied to time since `lastUsedAt` in the global-layer
+   * ranking. `usageDecay = 0.5 ^ ((now - lastUsedAt) / halfLifeMs)` —
+   * at one half-life since last use a row is worth half what a
+   * just-used row of the same priority is worth. Default 7 days:
+   * short enough that month-old unused chatter stops crowding out
+   * current week's decisions, long enough that yesterday's
+   * conclusions still surface tomorrow. Ranking is a monotone
+   * function of `lastUsedAt`, so the ordering between any two rows
+   * is invariant to `now` within a single ranking pass — the loader
+   * exploits this to push the entire ORDER BY into SQL.
    */
   recencyHalfLifeMs: number;
   /**
@@ -163,29 +176,3 @@ export type ObservationalMemorySettingsInput = Partial<
   observation?: Partial<ObservationalMemorySettings["observation"]>;
   reflection?: Partial<ObservationalMemorySettings["reflection"]>;
 };
-
-/** Query used by MemoryStore.recall to filter and rank observations. */
-export interface ObservationQuery {
-  /** Text query for simple lexical ranking. */
-  query?: string;
-  /** Return observations matching at least one of these tags. */
-  tags?: string[];
-  /** Restrict recall to a specific session id; omit for all-session search. */
-  sessionId?: string;
-  /** Restrict recall to one observation kind. */
-  kind?: ObservationKind;
-  /** Maximum number of observations to return. */
-  limit?: number;
-  /** Minimum priority to include. */
-  minPriority?: ObservationPriority;
-}
-
-/** Events emitted by MemoryStore for external persistence. */
-export type MemoryStoreEvent =
-  /** A new observation was added without replacing the full memory set. */
-  | { type: "observation_appended"; observation: Observation }
-  /** The complete observation set was replaced, usually after reflection. */
-  | { type: "observations_replaced"; observations: Observation[] };
-
-/** Subscription callback for MemoryStore changes. */
-export type MemoryStoreEventHandler = (event: MemoryStoreEvent) => void;

--- a/test/helpers/memory-fixture.ts
+++ b/test/helpers/memory-fixture.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+import { runMigrations } from "../../src/memory/migrations.js";
+import {
+  appendObservation,
+  readSessionObservations,
+  type MemoryDatabase,
+} from "../../src/memory/storage.js";
+import { MemoryContextCache } from "../../src/memory/store.js";
+import type { Observation } from "../../src/types/memory.js";
+
+/**
+ * Test-only memory fixture: a fresh PGlite database under a tmpdir,
+ * a `MemoryContextCache`, and a few wrappers that mirror what tests
+ * need against the durable store. Used by tests/evals that need a
+ * real durable store without spinning up the full runner. Call
+ * `dispose()` from a `finally` block to clean up the temp directory
+ * and close the database.
+ */
+export interface MemoryFixture {
+  db: MemoryDatabase;
+  cache: MemoryContextCache;
+  /** Convenience wrapper around `appendObservation` for direct test seeding. */
+  append(input: Omit<Observation, "id" | "createdAt" | "lastUsedAt">): Promise<Observation>;
+  /** Returns this session's observations and a rough token estimate. */
+  snapshot(sessionId: string): ReturnType<typeof readSessionObservations>;
+  dispose(): Promise<void>;
+}
+
+export async function createMemoryFixture(): Promise<MemoryFixture> {
+  const tempDir = await mkdtemp(join(tmpdir(), "duet-memory-fixture-"));
+  const db = await PGlite.create({
+    dataDir: join(tempDir, "memory.db"),
+    extensions: { vector },
+  });
+  await runMigrations(db);
+  const cache = new MemoryContextCache();
+
+  return {
+    db,
+    cache,
+    append(input) {
+      return appendObservation(db, input);
+    },
+    snapshot(sessionId) {
+      return readSessionObservations(db, sessionId);
+    },
+    async dispose() {
+      await db.close();
+      await rm(tempDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/test/memory-context-pack.test.ts
+++ b/test/memory-context-pack.test.ts
@@ -7,49 +7,31 @@ import { join } from "node:path";
 import { rebuildMemoryContextPack } from "../src/memory/context-pack.js";
 import { runMigrations } from "../src/memory/migrations.js";
 import { resolveObservationalMemorySettings } from "../src/memory/observational.js";
-import { MemoryStore } from "../src/memory/store.js";
+import { MemoryContextCache } from "../src/memory/store.js";
+import { appendObservation } from "../src/memory/storage.js";
 import type { Observation } from "../src/types/memory.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 /**
  * Cache stability is the entire point of the frozen contextPack
- * design. These tests pin the invariant: appending observations or
- * recalling memory does NOT change what the transform renders. Only
+ * design. These tests pin the invariant: appending observations to
+ * the durable store does NOT change what the transform renders. Only
  * an explicit compaction trigger (rebuildMemoryContextPack) does.
  */
 describe("Memory context pack", () => {
-  test("MemoryStore.getContextPack returns empty arrays before any refresh", () => {
-    const store = new MemoryStore();
-    const pack = store.getContextPack();
-    expect(pack).toEqual({ global: [], local: [] });
-  });
-
-  test("appending observations does not mutate the frozen pack", async () => {
-    const store = new MemoryStore();
-    store.setContextPack({ global: [], local: [] });
-
-    await store.appendObservation({
-      kind: "observation",
-      observedDate: "2026-05-09",
-      priority: "high",
-      source: { kind: "system" },
-      content: "Mid-turn observation that must not leak into the prefix.",
-      tags: [],
-    });
-
-    // Reading after the append: the pack is still the empty value we
-    // froze. The append flowed to the in-memory map and to disk in
-    // production, but the rendered prefix did not change.
-    expect(store.getContextPack()).toEqual({ global: [], local: [] });
+  test("getContextPack returns empty arrays before any refresh", () => {
+    const cache = new MemoryContextCache();
+    expect(cache.getContextPack()).toEqual({ global: [], local: [] });
   });
 
   test("setContextPack is the only way to change what the transform renders", () => {
-    const store = new MemoryStore();
+    const cache = new MemoryContextCache();
     const next: { global: Observation[]; local: Observation[] } = {
       global: [
         {
           id: "g1",
           createdAt: 1,
+          lastUsedAt: 1,
           kind: "reflection",
           observedDate: "2026-05-09",
           priority: "high",
@@ -60,23 +42,47 @@ describe("Memory context pack", () => {
       ],
       local: [],
     };
-    store.setContextPack(next);
-    expect(store.getContextPack()).toBe(next);
+    cache.setContextPack(next);
+    expect(cache.getContextPack()).toBe(next);
   });
+
+  testIfDocker(
+    "appending observations to the database does not mutate the frozen pack",
+    async () => {
+      await withSeededDb(async (db) => {
+        const cache = new MemoryContextCache();
+        cache.setContextPack({ global: [], local: [] });
+
+        await appendObservation(db, {
+          sessionId: "session_current",
+          kind: "observation",
+          observedDate: "2026-05-09",
+          priority: "high",
+          source: { kind: "system" },
+          content: "Mid-turn observation that must not leak into the prefix.",
+          tags: [],
+        });
+
+        // The append flowed to disk but the rendered prefix did not
+        // change — only a compaction trigger does that.
+        expect(cache.getContextPack()).toEqual({ global: [], local: [] });
+      });
+    },
+  );
 
   testIfDocker("rebuildMemoryContextPack assembles global + local from the database", async () => {
     await withSeededDb(async (db) => {
-      const store = new MemoryStore();
+      const cache = new MemoryContextCache();
       const settings = resolveObservationalMemorySettings({});
 
       await rebuildMemoryContextPack({
         db,
-        store,
+        cache,
         settings,
         sessionId: "session_current",
       });
 
-      const pack = store.getContextPack();
+      const pack = cache.getContextPack();
 
       // Global pack carries cross-session rows ranked by score.
       expect(pack.global.map((row) => row.id)).toContain("mem_other_session");
@@ -90,12 +96,12 @@ describe("Memory context pack", () => {
 
   testIfDocker("rebuildMemoryContextPack with no sessionId leaves local empty", async () => {
     await withSeededDb(async (db) => {
-      const store = new MemoryStore();
+      const cache = new MemoryContextCache();
       const settings = resolveObservationalMemorySettings({});
 
-      await rebuildMemoryContextPack({ db, store, settings });
+      await rebuildMemoryContextPack({ db, cache, settings });
 
-      const pack = store.getContextPack();
+      const pack = cache.getContextPack();
       expect(pack.local).toEqual([]);
       // Global still loads everything since exclusion is undefined.
       expect(pack.global.length).toBeGreaterThan(0);
@@ -113,11 +119,11 @@ async function withSeededDb(fn: (db: PGlite) => Promise<void>): Promise<void> {
     await runMigrations(db);
     await db.exec(`
       INSERT INTO observations (
-        id, created_at, session_id, kind, observed_date, priority, source_json, content, tags_json
+        id, created_at, last_used_at, session_id, kind, observed_date, priority, source_json, content, tags_json
       ) VALUES
-        ('mem_current', 1, 'session_current', 'observation', '2026-05-09', 'high',
+        ('mem_current', 1, 1, 'session_current', 'observation', '2026-05-09', 'high',
          '{"kind":"system"}', 'Belongs to the current session.', '[]'),
-        ('mem_other_session', 2, 'session_a', 'reflection', '2026-05-09', 'high',
+        ('mem_other_session', 2, 2, 'session_a', 'reflection', '2026-05-09', 'high',
          '{"kind":"system"}', 'Belongs to another session.', '[]');
     `);
     await fn(db);

--- a/test/memory-embedding-worker.test.ts
+++ b/test/memory-embedding-worker.test.ts
@@ -134,13 +134,13 @@ async function withSeededDb(fn: (db: PGlite) => Promise<void>): Promise<void> {
     await runMigrations(db);
     await db.exec(`
       INSERT INTO observations (
-        id, created_at, kind, observed_date, priority, source_json, content, tags_json
+        id, created_at, last_used_at, kind, observed_date, priority, source_json, content, tags_json
       ) VALUES
-        ('mem_low', 1, 'observation', '2026-05-04', 'low',
+        ('mem_low', 1, 1, 'observation', '2026-05-04', 'low',
          '{"kind":"system"}', 'Low-priority memory.', '[]'),
-        ('mem_high', 2, 'observation', '2026-05-04', 'high',
+        ('mem_high', 2, 2, 'observation', '2026-05-04', 'high',
          '{"kind":"system"}', 'High-priority memory.', '[]'),
-        ('mem_medium', 3, 'observation', '2026-05-04', 'medium',
+        ('mem_medium', 3, 3, 'observation', '2026-05-04', 'medium',
          '{"kind":"system"}', 'Medium-priority memory.', '[]');
     `);
     await fn(db);

--- a/test/memory-loader.test.ts
+++ b/test/memory-loader.test.ts
@@ -1,22 +1,26 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect } from "bun:test";
 import { PGlite } from "@electric-sql/pglite";
 import { vector } from "@electric-sql/pglite/vector";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadGlobalPack, loadLocalPack, score } from "../src/memory/loader.js";
+import { loadGlobalPack, loadLocalPack } from "../src/memory/loader.js";
 import { runMigrations } from "../src/memory/migrations.js";
 import type { Observation } from "../src/types/memory.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 /**
- * Fixture-based tests that cover the ranking math and the local/global
- * split. Each scenario seeds a PGlite database with realistic-looking
+ * Fixture-based tests for the loader's two layers and the SQL ranking
+ * push-down. Each scenario seeds a PGlite database with realistic
  * observations spanning a 60-day window, runs the loader, and asserts
- * the resulting order is what the ranking formula promises.
+ * the resulting order matches what the rank formula
+ * `ln(priority) + ln(kindBias) + last_used_at / h` promises.
  *
- * If a test fails after a ranking change, read the printed pack to
- * understand the new ordering before chasing the failure.
+ * The full score is `priority * 0.5^((now - last_used_at)/h) * kindBias`,
+ * but `0.5^(now/h)` is constant within one ranking pass and so cannot
+ * affect order. The SQL ORDER BY uses the simplified monotone form
+ * directly; these tests assert the resulting ordering, not the absolute
+ * scores (which depend on `now` and would flake without it).
  */
 
 const NOW = Date.UTC(2026, 4, 9); // 2026-05-09 — anchors all `daysAgo` math
@@ -25,52 +29,6 @@ const HALF_LIFE_MS = 7 * DAY_MS;
 const REFLECTION_BIAS = 1.3;
 
 describe("Memory loader", () => {
-  describe("score function", () => {
-    test("rewards priority over equal-aged observations", () => {
-      const high = score(makeFixture({ priority: "high", daysAgo: 0 }), defaultInputs());
-      const medium = score(makeFixture({ priority: "medium", daysAgo: 0 }), defaultInputs());
-      const low = score(makeFixture({ priority: "low", daysAgo: 0 }), defaultInputs());
-      expect(high).toBeGreaterThan(medium);
-      expect(medium).toBeGreaterThan(low);
-    });
-
-    test("decays scores by half each half-life", () => {
-      const fresh = score(makeFixture({ priority: "high", daysAgo: 0 }), defaultInputs());
-      const oneHalfLife = score(makeFixture({ priority: "high", daysAgo: 7 }), defaultInputs());
-      const twoHalfLives = score(makeFixture({ priority: "high", daysAgo: 14 }), defaultInputs());
-      expect(oneHalfLife).toBeCloseTo(fresh * 0.5, 5);
-      expect(twoHalfLives).toBeCloseTo(fresh * 0.25, 5);
-    });
-
-    test("biases reflections above raw observations at the same priority and recency", () => {
-      const reflection = score(
-        makeFixture({ priority: "high", daysAgo: 0, kind: "reflection" }),
-        defaultInputs(),
-      );
-      const observation = score(
-        makeFixture({ priority: "high", daysAgo: 0, kind: "observation" }),
-        defaultInputs(),
-      );
-      expect(reflection).toBe(observation * REFLECTION_BIAS);
-    });
-
-    test("lets fresh medium reflections beat stale high observations (crossover at one half-life)", () => {
-      // medium reflection at 0d:  2 * 1.0 * 1.3 = 2.6
-      // high observation at 7d:   3 * 0.5 * 1.0 = 1.5
-      // Reflection wins, matching the design intent of biasing toward
-      // condensed signal even when raw memories are higher priority.
-      const mediumFresh = score(
-        makeFixture({ priority: "medium", daysAgo: 0, kind: "reflection" }),
-        defaultInputs(),
-      );
-      const highStale = score(
-        makeFixture({ priority: "high", daysAgo: 7, kind: "observation" }),
-        defaultInputs(),
-      );
-      expect(mediumFresh).toBeGreaterThan(highStale);
-    });
-  });
-
   describe("loadGlobalPack", () => {
     testIfDocker("ranks rows by combined score with the highest-scoring row first", async () => {
       await withSeededDb(async (db) => {
@@ -79,32 +37,54 @@ describe("Memory loader", () => {
           tokenBudget: 100_000,
           recencyHalfLifeMs: HALF_LIFE_MS,
           reflectionBias: REFLECTION_BIAS,
-          now: NOW,
         });
 
-        // Rank-1 invariant: the highest-scoring fixture is a high
-        // reflection from today (3 * 1.0 * 1.3 = 3.9). Nothing else in
-        // the seed set scores higher.
+        // Rank-1 invariant: the top fixture is a high reflection
+        // touched today (priority 3 × kindBias 1.3 dominates anything
+        // else in the seed set).
         expect(pack[0]?.id).toBe("g_high_reflection_today");
 
-        // Last place goes to the 60-day-old low-priority observation:
-        // 1 * 0.5^(60/7) * 1.0 = ~0.0028. Verifies decay is doing real work.
+        // Last place goes to the 60-day-old low-priority observation
+        // — verifies usage decay is doing real work.
         expect(pack.at(-1)?.id).toBe("g_low_obs_60d");
       });
     });
 
+    testIfDocker(
+      "a recently-used old row outranks a stale newer row of equal priority",
+      async () => {
+        await withSeededDb(async (db) => {
+          // last_used_at on `g_high_obs_used_recently` is 1 day ago,
+          // even though it was created 14 days ago. `g_high_observation_today`
+          // was created today but never re-used (last_used_at = createdAt = today),
+          // so they're close. We rely on the recency math: 0d vs 1d,
+          // both within one half-life — created-today edges out, but
+          // both must beat the 14-day-old high observation that was
+          // never reused.
+          const pack = await loadGlobalPack(db, {
+            excludeSessionId: "session_current",
+            tokenBudget: 100_000,
+            recencyHalfLifeMs: HALF_LIFE_MS,
+            reflectionBias: REFLECTION_BIAS,
+          });
+          const ids = pack.map((o) => o.id);
+          expect(ids.indexOf("g_high_obs_used_recently")).toBeLessThan(
+            ids.indexOf("g_low_observation_14d"),
+          );
+        });
+      },
+    );
+
     testIfDocker("enforces the token budget by stopping the greedy fill", async () => {
       await withSeededDb(async (db) => {
-        // Each fixture's content is short (~13-23 tokens). Setting a
-        // tight budget forces the loader to stop after the first
-        // couple of rows and validates the cap holds.
+        // Each fixture's content is short (~13-23 tokens). A tight
+        // budget forces the loader to stop after a couple rows.
         const tokenBudget = 30;
         const pack = await loadGlobalPack(db, {
           excludeSessionId: "session_current",
           tokenBudget,
           recencyHalfLifeMs: HALF_LIFE_MS,
           reflectionBias: REFLECTION_BIAS,
-          now: NOW,
         });
 
         const usedTokens = pack.reduce(
@@ -129,7 +109,6 @@ describe("Memory loader", () => {
             tokenBudget: 100_000,
             recencyHalfLifeMs: HALF_LIFE_MS,
             reflectionBias: REFLECTION_BIAS,
-            now: NOW,
           });
           const ids = pack.map((observation) => observation.id);
           for (const id of ids) {
@@ -146,11 +125,10 @@ describe("Memory loader", () => {
           tokenBudget: 100_000,
           recencyHalfLifeMs: HALF_LIFE_MS,
           reflectionBias: REFLECTION_BIAS,
-          now: NOW,
         });
         const ids = pack.map((observation) => observation.id);
-        // Legacy rows pre-date sessionId tracking; they should still be
-        // searchable as "from any other session".
+        // Legacy rows pre-date sessionId tracking; they should still
+        // surface as "from any other session".
         expect(ids).toContain("g_legacy_null_session");
       });
     });
@@ -163,7 +141,6 @@ describe("Memory loader", () => {
             tokenBudget: 100_000,
             recencyHalfLifeMs: HALF_LIFE_MS,
             reflectionBias: REFLECTION_BIAS,
-            now: NOW,
           });
           const ids = pack.map((observation) => observation.id);
           expect(ids).toContain("local_observation_today");
@@ -185,10 +162,6 @@ describe("Memory loader", () => {
           "local_reflection_yesterday",
           "local_observation_today",
         ]);
-
-        // Local layer is unranked: a low-priority observation written
-        // most recently still appears last, because chronology is what
-        // makes the local summary readable as a thread.
       });
     });
 
@@ -201,16 +174,8 @@ describe("Memory loader", () => {
   });
 });
 
-/**
- * Seeds a PGlite database with a deterministic fixture set spanning
- * 0-60 days back, mixed priorities, both kinds, two sessions plus
- * legacy NULL-session rows. Inserted directly via SQL so the test does
- * not depend on the runner machinery.
- */
 async function withSeededDb(fn: (db: PGlite) => Promise<void>): Promise<void> {
   const tempDir = await mkdtemp(join(tmpdir(), "duet-loader-"));
-  // Match the runtime's pgvector loading path so migration v3 can
-  // CREATE EXTENSION vector inside this test database too.
   const db = await PGlite.create({
     dataDir: join(tempDir, "memory.db"),
     extensions: { vector },
@@ -229,12 +194,13 @@ async function seedFixtures(db: PGlite): Promise<void> {
   for (const fixture of FIXTURES) {
     await db.query(
       `INSERT INTO observations (
-        id, created_at, session_id, kind, observed_date, referenced_date, relative_date,
+        id, created_at, last_used_at, session_id, kind, observed_date, referenced_date, relative_date,
         time_of_day, priority, source_json, content, tags_json
-      ) VALUES ($1, $2, $3, $4, $5, NULL, NULL, NULL, $6, '{"kind":"system"}', $7, '[]')`,
+      ) VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7, '{"kind":"system"}', $8, '[]')`,
       [
         fixture.id,
         fixture.createdAt,
+        fixture.lastUsedAt ?? fixture.createdAt,
         fixture.sessionId ?? null,
         fixture.kind,
         new Date(fixture.createdAt).toISOString().slice(0, 10),
@@ -251,6 +217,8 @@ interface Fixture {
   kind: Observation["kind"];
   priority: Observation["priority"];
   createdAt: number;
+  /** Defaults to `createdAt` when the row was never re-used. */
+  lastUsedAt?: number;
   content: string;
 }
 
@@ -259,7 +227,7 @@ function ago(days: number): number {
 }
 
 const FIXTURES: Fixture[] = [
-  // Local layer (current session) — these never appear in the global pack
+  // Local layer (current session) — never appears in the global pack
   // when excludeSessionId = "session_current".
   {
     id: "local_observation_yesterday",
@@ -302,6 +270,19 @@ const FIXTURES: Fixture[] = [
     priority: "high",
     createdAt: ago(0),
     content: "Image paste shipped in v0.1.47, PR #12.",
+  },
+  // 14 days old by createdAt but bumped to "1 day ago" via lastUsedAt
+  // — exercises the usage-decay path so an older-but-recently-reused
+  // memory still ranks above a fresher unrelated row of lower
+  // priority.
+  {
+    id: "g_high_obs_used_recently",
+    sessionId: "session_a",
+    kind: "observation",
+    priority: "high",
+    createdAt: ago(14),
+    lastUsedAt: ago(1),
+    content: "User confirmed the agent's choice of pgvector + tsvector hybrid.",
   },
   {
     id: "g_medium_reflection_3d",
@@ -347,28 +328,3 @@ const FIXTURES: Fixture[] = [
     content: "Pre-migration reflection that should still be globally retrievable.",
   },
 ];
-
-function makeFixture(opts: {
-  priority: Observation["priority"];
-  daysAgo: number;
-  kind?: Observation["kind"];
-}): Observation {
-  return {
-    id: "fixture",
-    createdAt: ago(opts.daysAgo),
-    kind: opts.kind ?? "observation",
-    observedDate: "2026-05-09",
-    priority: opts.priority,
-    source: { kind: "system" },
-    content: "x",
-    tags: [],
-  };
-}
-
-function defaultInputs() {
-  return {
-    now: NOW,
-    halfLifeMs: HALF_LIFE_MS,
-    reflectionBias: REFLECTION_BIAS,
-  };
-}

--- a/test/memory-migrations.test.ts
+++ b/test/memory-migrations.test.ts
@@ -68,6 +68,7 @@ describe("Memory migrations", () => {
           "created_at",
           "id",
           "kind",
+          "last_used_at",
           "observed_date",
           "priority",
           "referenced_date",

--- a/test/memory-recall.test.ts
+++ b/test/memory-recall.test.ts
@@ -151,17 +151,17 @@ async function withSeededDb(fn: (db: PGlite) => Promise<void>): Promise<void> {
     await runMigrations(db);
     await db.exec(`
       INSERT INTO observations (
-        id, created_at, session_id, kind, observed_date, priority, source_json, content, tags_json
+        id, created_at, last_used_at, session_id, kind, observed_date, priority, source_json, content, tags_json
       ) VALUES
-        ('mem_local_today', 1, 'session_local', 'observation', '2026-05-09', 'medium',
+        ('mem_local_today', 1, 1, 'session_local', 'observation', '2026-05-09', 'medium',
          '{"kind":"system"}', 'Started writing recall memory tests today.', '[]'),
-        ('mem_local_yesterday', 2, 'session_local', 'reflection', '2026-05-08', 'high',
+        ('mem_local_yesterday', 2, 2, 'session_local', 'reflection', '2026-05-08', 'high',
          '{"kind":"system"}', 'Local session memory landed yesterday.', '[]'),
-        ('mem_wire_budget', 3, 'session_a', 'reflection', '2026-05-07', 'high',
+        ('mem_wire_budget', 3, 3, 'session_a', 'reflection', '2026-05-07', 'high',
          '{"kind":"system"}', 'Wire-byte budget cap on the proxy is 4.5 MiB.', '[]'),
-        ('mem_state_machine', 4, 'session_b', 'observation', '2026-05-06', 'medium',
+        ('mem_state_machine', 4, 4, 'session_b', 'observation', '2026-05-06', 'medium',
          '{"kind":"system"}', 'State machine routing handles recurring tasks.', '[]'),
-        ('mem_legacy_null_session', 5, NULL, 'reflection', '2026-04-15', 'high',
+        ('mem_legacy_null_session', 5, 5, NULL, 'reflection', '2026-04-15', 'high',
          '{"kind":"system"}', 'Legacy memory predating session id tracking.', '[]');
     `);
     await fn(db);

--- a/test/memory-storage.test.ts
+++ b/test/memory-storage.test.ts
@@ -4,46 +4,39 @@ import { vector } from "@electric-sql/pglite/vector";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadStoredMemory } from "../src/memory/storage.js";
-import { MemoryStore } from "../src/memory/store.js";
+import {
+  appendObservation,
+  loadStoredMemory,
+  readSessionObservations,
+  replaceSessionObservations,
+} from "../src/memory/storage.js";
 import type { Observation } from "../src/types/memory.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 describe("Memory storage", () => {
-  test("is a no-op without a configured path", async () => {
-    const store = new MemoryStore();
-    const persistence = await loadStoredMemory(undefined, process.cwd(), store);
-
-    await store.appendObservation(createObservation("Not persisted."));
+  test("returns a no-op handle without a configured path", async () => {
+    const persistence = await loadStoredMemory(undefined, process.cwd());
+    expect(persistence.db).toBeUndefined();
     await persistence.dispose();
-
-    const snapshot = await store.getSnapshot();
-    expect(snapshot.observations).toHaveLength(1);
   });
 
-  test("is a no-op when storage is disabled", async () => {
-    const store = new MemoryStore();
-    const persistence = await loadStoredMemory(false, process.cwd(), store);
-
-    await store.appendObservation(createObservation("Not persisted."));
+  test("returns a no-op handle when storage is explicitly disabled", async () => {
+    const persistence = await loadStoredMemory(false, process.cwd());
+    expect(persistence.db).toBeUndefined();
     await persistence.dispose();
-
-    const snapshot = await store.getSnapshot();
-    expect(snapshot.observations[0]?.content).toBe("Not persisted.");
   });
 
   testIfDocker("creates a PGlite memory database and persists observations", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "duet-memory-"));
     const memoryPath = join(tempDir, "memory.db");
-    const store = new MemoryStore();
 
     try {
-      const persistence = await loadStoredMemory(memoryPath, tempDir, store);
-      await store.appendObservation(createObservation("Created database."));
+      const persistence = await loadStoredMemory(memoryPath, tempDir);
+      expect(persistence.db).toBeDefined();
+      await appendObservation(persistence.db!, observationInput("Created database.", "session_a"));
       await persistence.dispose();
 
-      const observations = await readObservationContents(memoryPath);
-      expect(observations).toEqual(["Created database."]);
+      expect(await readObservationContents(memoryPath)).toEqual(["Created database."]);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
@@ -54,19 +47,19 @@ describe("Memory storage", () => {
     const memoryPath = join(tempDir, "memory.db");
     const seeded = await openSeededDatabase(memoryPath);
     await seeded.close();
-    const store = new MemoryStore();
 
     try {
-      const persistence = await loadStoredMemory(memoryPath, tempDir, store);
-      const snapshot = await store.getSnapshot();
+      const persistence = await loadStoredMemory(memoryPath, tempDir);
+      const snapshot = await readSessionObservations(persistence.db!, "session_seed");
       await persistence.dispose();
 
       expect(snapshot.observations).toEqual([
         {
           id: "existing-observation",
           createdAt: 1,
-          // Pre-migration row had no session_id; migration v2 adds the
-          // column NULL-able and the loader leaves it undefined.
+          // Migration v4 backfills last_used_at from created_at for legacy rows.
+          lastUsedAt: 1,
+          sessionId: "session_seed",
           kind: "observation",
           observedDate: "2026-05-04",
           referencedDate: "2026-05-03",
@@ -83,70 +76,63 @@ describe("Memory storage", () => {
     }
   });
 
-  testIfDocker("replaceObservations deletes only removed observations", async () => {
+  testIfDocker(
+    "replaceSessionObservations only deletes the current session's removed rows",
+    async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), "duet-memory-"));
+      const memoryPath = join(tempDir, "memory.db");
+
+      try {
+        const persistence = await loadStoredMemory(memoryPath, tempDir);
+        const db = persistence.db!;
+
+        // Seed two sessions with one row each. Reflection in session_a
+        // must not affect session_b's row.
+        const a1 = await appendObservation(db, observationInput("session a row 1", "session_a"));
+        const a2 = await appendObservation(db, observationInput("session a row 2", "session_a"));
+        const b1 = await appendObservation(db, observationInput("session b row", "session_b"));
+
+        await replaceSessionObservations(db, "session_a", [
+          // Keep a1 (under its existing id), drop a2 entirely, append a fresh reflection.
+          a1,
+          {
+            ...observationInput("session a reflection", "session_a"),
+            id: "session_a_reflection",
+            createdAt: a2.createdAt + 1,
+            lastUsedAt: a2.createdAt + 1,
+            kind: "reflection",
+            tags: ["observational-memory", "reflection"],
+          },
+        ]);
+
+        const aSnapshot = await readSessionObservations(db, "session_a");
+        expect(aSnapshot.observations.map((o) => o.content)).toEqual([
+          "session a row 1",
+          "session a reflection",
+        ]);
+
+        const bSnapshot = await readSessionObservations(db, "session_b");
+        expect(bSnapshot.observations.map((o) => o.id)).toEqual([b1.id]);
+
+        await persistence.dispose();
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  testIfDocker("dispose closes the database and prevents further writes", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "duet-memory-"));
     const memoryPath = join(tempDir, "memory.db");
-    const seeded = await openSeededDatabase(memoryPath);
-    await seeded.close();
-    const store = new MemoryStore();
 
     try {
-      const persistence = await loadStoredMemory(memoryPath, tempDir, store);
-      await store.appendObservation(createObservation("Kept memory."));
-
-      await store.replaceObservations([
-        createPersistedObservation("mem_kept", "Kept memory.", 3),
-        createPersistedObservation("replacement", "Replacement memory."),
-      ]);
+      const persistence = await loadStoredMemory(memoryPath, tempDir);
+      const db = persistence.db!;
+      await appendObservation(db, observationInput("Before dispose.", "session_a"));
       await persistence.dispose();
 
-      expect(await readObservationContents(memoryPath)).toEqual([
-        "Kept memory.",
-        "Replacement memory.",
-      ]);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  testIfDocker("dispose stops future persistence writes", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "duet-memory-"));
-    const memoryPath = join(tempDir, "memory.db");
-    const store = new MemoryStore();
-
-    try {
-      const persistence = await loadStoredMemory(memoryPath, tempDir, store);
-      await store.appendObservation(createObservation("Before dispose."));
-      await persistence.dispose();
-
-      await store.appendObservation(createObservation("After dispose."));
+      // Reopen with a fresh handle to confirm only the pre-dispose row landed on disk.
       expect(await readObservationContents(memoryPath)).toEqual(["Before dispose."]);
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  testIfDocker("serializes rapid writes before dispose completes", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "duet-memory-"));
-    const memoryPath = join(tempDir, "memory.db");
-    const store = new MemoryStore();
-
-    try {
-      const persistence = await loadStoredMemory(memoryPath, tempDir, store);
-      await Promise.all(
-        Array.from({ length: 5 }, (_, index) =>
-          store.appendObservation(createObservation(`Queued memory ${index}.`)),
-        ),
-      );
-      await persistence.dispose();
-
-      expect(await readObservationContents(memoryPath)).toEqual([
-        "Queued memory 0.",
-        "Queued memory 1.",
-        "Queued memory 2.",
-        "Queued memory 3.",
-        "Queued memory 4.",
-      ]);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
@@ -155,6 +141,9 @@ describe("Memory storage", () => {
 
 async function openSeededDatabase(path: string): Promise<PGlite> {
   const database = await PGlite.create({ dataDir: path, extensions: { vector } });
+  // Seed the v1 schema directly so migration v2/v3/v4 have to upgrade
+  // an existing DB rather than running on an empty one. Tests the
+  // forward-only migration chain end-to-end.
   await database.exec(`
     CREATE TABLE observations (
       id TEXT PRIMARY KEY,
@@ -186,25 +175,27 @@ async function openSeededDatabase(path: string): Promise<PGlite> {
       '["test","persisted"]'
     );
   `);
+  // Migration v2 backfills session_id but leaves NULL for pre-migration rows.
+  // Set it explicitly so this fixture maps onto a session we can query.
+  await database.exec(
+    `ALTER TABLE observations ADD COLUMN IF NOT EXISTS session_id TEXT;
+     UPDATE observations SET session_id = 'session_seed' WHERE id = 'existing-observation';`,
+  );
   return database;
 }
 
-function createObservation(content: string): Omit<Observation, "id" | "createdAt"> {
+function observationInput(
+  content: string,
+  sessionId: string,
+): Omit<Observation, "id" | "createdAt" | "lastUsedAt"> {
   return {
+    sessionId,
     kind: "observation",
     observedDate: "2026-05-04",
     priority: "high",
     source: { kind: "system" },
     content,
     tags: ["test"],
-  };
-}
-
-function createPersistedObservation(id: string, content: string, createdAt = 2): Observation {
-  return {
-    id,
-    createdAt,
-    ...createObservation(content),
   };
 }
 

--- a/test/turn-runner-memory.test.ts
+++ b/test/turn-runner-memory.test.ts
@@ -22,24 +22,32 @@ class MemoryTransformTurnRunner extends TurnRunner {
     return this.createMemoryTransform();
   }
 
-  getMemorySnapshotForTest() {
-    return this.memory.getSnapshot();
-  }
-
-  async appendObservationForTest(content: string) {
-    const observation = await this.memory.appendObservation({
-      kind: "observation",
+  /**
+   * Test-only synthetic seeding: the runner has no PGlite database
+   * configured here, so we mint an Observation in process and shove
+   * it into the cache as if a compaction had just frozen it. That
+   * matches the production invariant (only the cache shape matters
+   * to the transform) without spinning up a real database.
+   */
+  async seedFrozenObservationForTest(content: string) {
+    const now = Date.now();
+    const observation = {
+      id: `mem_test_${now}`,
+      createdAt: now,
+      lastUsedAt: now,
+      kind: "observation" as const,
       observedDate: "2026-05-06",
-      priority: "high",
-      source: { kind: "system" },
+      priority: "high" as const,
+      source: { kind: "system" } as const,
       content,
       tags: ["test"],
-    });
-    // Seed the frozen pack so the transform actually renders this row.
-    // Real production refreshes happen at compaction events; in tests
-    // we set the pack directly to mimic post-compaction state.
+    };
     this.memory.setContextPack({ global: [observation], local: [] });
     return observation;
+  }
+
+  getFrozenContextPackForTest() {
+    return this.memory.getContextPack();
   }
 }
 
@@ -148,14 +156,21 @@ class MemoryEventTurnRunner extends TurnRunner {
       .map(agentMessageToRaw)
       .filter((message): message is NonNullable<typeof message> => Boolean(message));
     const range = `${raw[0]?.id ?? "unknown"}:${raw[raw.length - 1]?.id ?? "unknown"}`;
-    const observation = await this.memory.appendObservation({
-      kind: "observation",
+    // No DB configured for this test runner; mint a synthetic
+    // observation and emit it directly so subscribers see the
+    // expected memory event shape.
+    const now = Date.now();
+    const observation = {
+      id: `mem_test_${now}`,
+      createdAt: now,
+      lastUsedAt: now,
+      kind: "observation" as const,
       observedDate: "2026-05-08",
-      priority: "high",
-      source: { kind: "system" },
+      priority: "high" as const,
+      source: { kind: "system" } as const,
       content: `<observation-group id="test" range="${range}">\n* ✅ Remembered pi-run memory payload.\n</observation-group>`,
       tags: ["observational-memory"],
-    });
+    };
     this.emit({
       type: "memory",
       phase: "observation",
@@ -202,11 +217,10 @@ describe("TurnRunner memory", () => {
 
     await transform(messages);
 
-    const snapshot = await runner.getMemorySnapshotForTest();
-    expect(snapshot).toMatchObject({
-      observations: [],
-      estimatedTokens: { observations: 0 },
-    });
+    // Pack stays empty because the transform never refreshes it on
+    // its own — only compaction events do, and none fire below
+    // threshold.
+    expect(runner.getFrozenContextPackForTest()).toEqual({ global: [], local: [] });
   });
 
   test("observational transform only shapes context at compaction threshold", async () => {
@@ -252,7 +266,7 @@ describe("TurnRunner memory", () => {
         },
       },
     });
-    await runner.appendObservationForTest(
+    await runner.seedFrozenObservationForTest(
       '<observation-group id="test" range="msg_assistant_observed:msg_assistant_observed">\n* 🔴 Already observed the long message.\n</observation-group>',
     );
     const events: unknown[] = [];
@@ -364,6 +378,7 @@ describe("TurnRunner memory", () => {
         {
           id: "mem_test",
           createdAt: 1,
+          lastUsedAt: 1,
           kind: "observation",
           observedDate: "2026-05-08",
           priority: "high",


### PR DESCRIPTION
…n-memory store

- migration v4: last_used_at column (backfilled to created_at) and idx_obs_kind_priority_lastused
- loadGlobalPack pushes ranking entirely into SQL: ORDER BY ln(priority)
  + ln(kindBias) + last_used_at/h, monotone in the full score so JS only does the greedy token-budget fit
- replace MemoryStore class with thin MemoryContextCache that holds only the frozen ContextPack; reads, writes, and recalls all go straight to PGlite
- reflection is now session-scoped: readSessionObservations and replaceSessionObservations both filter on session_id, so a reflection in one session no longer wipes other sessions' rows
- observer prompt renders the global pack with hidden [memory id: ...] markers; observer schema gains usedObservationIds; bumpLastUsed advances last_used_at for the validated subset after every observation pass
- evals (live model): last-used-ranking, observer-used-ids, reflection-session-isolation; all pass