### PR TITLE
[david] feat(tui): /feedback slash command

### DIFF
--- a/src/cli/send-feedback.ts
+++ b/src/cli/send-feedback.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { createInterface } from "node:readline/promises";
-import { resolveDuetAppBaseUrl } from "../lib/duet-app-url.js";
+import { submitDuetFeedback } from "../lib/feedback.js";
 import { printSendFeedbackHelp } from "./help.js";
 import { fail, isInteractive, resolveUserPath } from "./shared.js";
 
@@ -11,8 +11,6 @@ export interface SendFeedbackCommandIO {
   /** Inject a stand-in for fetch so tests can intercept the upload. */
   fetch?: typeof fetch;
 }
-
-const FEEDBACK_SOURCE = "duet-agent-cli";
 
 /**
  * Run `duet send-feedback`.
@@ -76,20 +74,12 @@ export async function runSendFeedbackCommand(
     fail("Feedback content is required.");
   }
 
-  const url = `${resolveDuetAppBaseUrl()}/api/v1/feedback`;
-  const fetchImpl = io.fetch ?? globalThis.fetch;
-  const response = await fetchImpl(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ content, source: FEEDBACK_SOURCE }),
-  });
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    fail(`Feedback submission failed (${response.status}): ${text || response.statusText}`);
+  try {
+    const { baseUrl } = await submitDuetFeedback({ content, fetch: io.fetch });
+    console.error(`Thanks! Feedback sent to ${baseUrl}.`);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
   }
-
-  console.error(`Thanks! Feedback sent to ${resolveDuetAppBaseUrl()}.`);
 }
 
 async function readStdin(): Promise<string> {

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,0 +1,57 @@
+import { resolveDuetAppBaseUrl } from "./duet-app-url.js";
+
+/**
+ * Source identifier stamped on every CLI/TUI feedback row so the admin
+ * inbox can distinguish them from the in-product web sidebar dialog.
+ */
+export const DUET_AGENT_FEEDBACK_SOURCE = "duet-agent-cli";
+
+export interface SubmitFeedbackOptions {
+  content: string;
+  /** Override the source string used by web admin filters. */
+  source?: string;
+  /** Inject a stand-in for fetch so tests can intercept the upload. */
+  fetch?: typeof fetch;
+}
+
+export interface SubmitFeedbackResult {
+  /** Base URL the feedback was POSTed to, for confirmation messages. */
+  baseUrl: string;
+}
+
+/**
+ * POST a free-form markdown feedback string to the Duet web app's public
+ * feedback endpoint. Shared between `duet send-feedback` (CLI) and the
+ * `/feedback` TUI slash command. The endpoint is intentionally
+ * unauthenticated — anonymous notes are fine.
+ *
+ * Throws on non-2xx responses so callers can surface the error in their
+ * own UI surface (stderr for the CLI, an error block for the TUI).
+ */
+export async function submitDuetFeedback(
+  options: SubmitFeedbackOptions,
+): Promise<SubmitFeedbackResult> {
+  const trimmed = options.content.trim();
+  if (!trimmed) throw new Error("Feedback content is required.");
+
+  const baseUrl = resolveDuetAppBaseUrl();
+  const url = `${baseUrl}/api/v1/feedback`;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      content: trimmed,
+      source: options.source ?? DUET_AGENT_FEEDBACK_SOURCE,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `Feedback submission failed (${response.status}): ${text || response.statusText}`,
+    );
+  }
+
+  return { baseUrl };
+}

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -48,6 +48,7 @@ import {
   skillAutocompleteMatches,
   type SlashAutocompleteGroup,
 } from "./autocomplete.js";
+import { submitDuetFeedback } from "../lib/feedback.js";
 import { buildFileIndex } from "./file-index.js";
 import {
   DUET_BANNER_LINES,
@@ -1493,6 +1494,10 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
       appendBlock("[paste]", "cleared pending image attachments", COLORS.system);
       return;
     }
+    if (message === "/feedback" || message.startsWith("/feedback ")) {
+      void handleFeedbackSlashCommand(message);
+      return;
+    }
 
     const submittedImages = pendingImages;
     appendBlock("you:", message, COLORS.user);
@@ -1521,6 +1526,29 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
     void input.session.prompt({ message, behavior: "follow_up", images }).catch(reportError);
     markRunning();
+  }
+
+  async function handleFeedbackSlashCommand(raw: string): Promise<void> {
+    const content = raw.slice("/feedback".length).trim();
+    if (!content) {
+      appendBlock(
+        "[feedback]",
+        "Usage: /feedback <message>  — send free-form feedback to the Duet team",
+        COLORS.system,
+      );
+      return;
+    }
+    appendBlock("[feedback]", "sending…", COLORS.system);
+    try {
+      const { baseUrl } = await submitDuetFeedback({ content });
+      appendBlock("[feedback]", `Thanks! Feedback sent to ${baseUrl}.`, COLORS.system);
+    } catch (error) {
+      appendBlock(
+        "[feedback]",
+        error instanceof Error ? error.message : String(error),
+        COLORS.error,
+      );
+    }
   }
 
   async function handleImageSlashCommand(raw: string): Promise<void> {

--- a/src/tui/autocomplete.ts
+++ b/src/tui/autocomplete.ts
@@ -59,6 +59,11 @@ export const BUILT_IN_SLASH_COMMANDS: readonly SkillAutocompleteItem[] = [
     description: "Drop pending image attachments before submit",
     group: "commands",
   },
+  {
+    name: "feedback",
+    description: "Send free-form feedback to the Duet team: /feedback <message>",
+    group: "commands",
+  },
 ];
 
 /**

--- a/test/lib-feedback.test.ts
+++ b/test/lib-feedback.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DUET_AGENT_FEEDBACK_SOURCE, submitDuetFeedback } from "../src/lib/feedback.js";
+
+let originalBaseUrl: string | undefined;
+
+beforeEach(() => {
+  originalBaseUrl = process.env.DUET_APP_BASE_URL;
+  process.env.DUET_APP_BASE_URL = "https://test";
+});
+
+afterEach(() => {
+  if (originalBaseUrl === undefined) delete process.env.DUET_APP_BASE_URL;
+  else process.env.DUET_APP_BASE_URL = originalBaseUrl;
+});
+
+describe("submitDuetFeedback", () => {
+  test("POSTs trimmed content with the duet-agent-cli source by default", async () => {
+    const calls: { url: string; method: string; body: string }[] = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({
+        url: typeof input === "string" ? input : (input as URL).toString(),
+        method: init?.method ?? "GET",
+        body: typeof init?.body === "string" ? init.body : "",
+      });
+      return new Response(JSON.stringify({ data: { ok: true } }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await submitDuetFeedback({
+      content: "  the TUI flickers when resuming  ",
+      fetch: fetchImpl,
+    });
+
+    expect(result.baseUrl).toBe("https://test");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("https://test/api/v1/feedback");
+    expect(calls[0]!.method).toBe("POST");
+    expect(JSON.parse(calls[0]!.body)).toEqual({
+      content: "the TUI flickers when resuming",
+      source: DUET_AGENT_FEEDBACK_SOURCE,
+    });
+  });
+
+  test("rejects when content is empty after trimming", async () => {
+    const fetchImpl = (async () => new Response("", { status: 200 })) as unknown as typeof fetch;
+    await expect(submitDuetFeedback({ content: "   \n  ", fetch: fetchImpl })).rejects.toThrow(
+      "Feedback content is required",
+    );
+  });
+
+  test("throws on non-2xx with the response status and body", async () => {
+    const fetchImpl = (async () =>
+      new Response("server boom", { status: 500 })) as unknown as typeof fetch;
+    await expect(submitDuetFeedback({ content: "broken", fetch: fetchImpl })).rejects.toThrow(
+      "Feedback submission failed (500): server boom",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `/feedback <message>` slash command to the TUI. Discoverable from the `/` autocomplete picker under the `commands` group; runs locally and renders the result inline.
- Extracts the POST to `/api/v1/feedback` into a shared `src/lib/feedback.ts` helper so the existing `duet send-feedback` CLI and the new slash command share one code path.

Stacked on top of #15. Once that lands, this becomes a tiny diff against `main`.

## How it looks

```
> /feedback the TUI flickers when resuming
[feedback] sending…
[feedback] Thanks! Feedback sent to https://duet.so.
```

Empty `/feedback` prints the usage hint in a system block and stays in the input loop.

## Test plan

- [x] `bun run check-types` clean
- [x] `bun run lint` clean
- [x] `bun test test/` — 219 pass / 0 fail; 6 of those cover send-feedback + the new helper
- [ ] Manual: `DUET_APP_BASE_URL=https://staging.duet.so duet`, type `/feedback hello world`, confirm it lands in the admin feedback list under source `duet-agent-cli`