### PR TITLE
feat(memory): align embedding client with gemini-embedding-2 at 3072 dims

### DIFF
--- a/src/memory/embedding.ts
+++ b/src/memory/embedding.ts
@@ -8,6 +8,12 @@ import { resolveDuetAppBaseUrl } from "../lib/duet-app-url.js";
  * for free as a CLI perk; we deliberately do not expose a way to plug
  * in a different provider key here so the runtime stays single-path.
  *
+ * The endpoint hardcodes `google/gemini-embedding-2` on the server side
+ * — we match that here as a constant so every stored vector is tagged
+ * with the model that produced it. When we switch models in the future,
+ * the migration that bumps `EMBEDDING_MODEL` can selectively invalidate
+ * rows by `model` instead of nuking the entire embeddings table.
+ *
  * Behavior:
  *   - Inputs are batched up to `EMBEDDING_BATCH_LIMIT` per HTTP call so
  *     a single backfill batch never goes over the request body cap.
@@ -20,8 +26,13 @@ import { resolveDuetAppBaseUrl } from "../lib/duet-app-url.js";
  *     sleeps until the user logs in).
  */
 
-/** Default embedding model identifier sent with every request. */
-export const DEFAULT_EMBEDDING_MODEL = "openai/text-embedding-3-small";
+/**
+ * Embedding model identifier. Hardcoded here to match the server, and
+ * exported so the storage layer can tag each stored vector with it.
+ */
+export const EMBEDDING_MODEL = "google/gemini-embedding-2";
+/** Embedding dimensions. Sent on every request and matches the pgvector column width. */
+export const EMBEDDING_DIMENSIONS = 3072;
 /** Maximum input strings sent in a single embedding request. */
 export const EMBEDDING_BATCH_LIMIT = 100;
 
@@ -43,8 +54,6 @@ export class EmbeddingUnavailableError extends Error {
 }
 
 export interface CreateEmbeddingClientOptions {
-  /** Embedding model identifier sent with each request. */
-  model?: string;
   /**
    * Override the API key resolver. Defaults to reading `DUET_API_KEY`
    * from `process.env`. Tests inject a fixed value to exercise the
@@ -70,7 +79,6 @@ export interface CreateEmbeddingClientOptions {
  * `recall_memory` query so connection reuse can amortize TLS setup.
  */
 export function createEmbeddingClient(options: CreateEmbeddingClientOptions = {}): EmbedFn {
-  const model = options.model ?? DEFAULT_EMBEDDING_MODEL;
   const baseUrl = options.baseUrl ?? resolveDuetAppBaseUrl();
   const fetchImpl = options.fetch ?? fetch;
 
@@ -91,7 +99,6 @@ export function createEmbeddingClient(options: CreateEmbeddingClientOptions = {}
       const vectors = await postBatch({
         url: `${baseUrl}${ENDPOINT_PATH}`,
         apiKey,
-        model,
         inputs: slice,
         fetchImpl,
       });
@@ -109,7 +116,6 @@ export function createEmbeddingClient(options: CreateEmbeddingClientOptions = {}
 interface PostBatchOptions {
   url: string;
   apiKey: string;
-  model: string;
   inputs: string[];
   fetchImpl: typeof fetch;
 }
@@ -124,12 +130,12 @@ async function postBatch(options: PostBatchOptions): Promise<number[][]> {
           authorization: `Bearer ${options.apiKey}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({ input: options.inputs, model: options.model }),
+        body: JSON.stringify({ input: options.inputs, dimensions: EMBEDDING_DIMENSIONS }),
       });
 
       if (response.ok) {
-        const body = (await response.json()) as EmbeddingResponseBody;
-        return body.embeddings;
+        const body = (await response.json()) as EmbeddingResponseEnvelope;
+        return body.data.embeddings;
       }
 
       // 4xx errors (auth, malformed input) will not improve on retry;
@@ -158,11 +164,17 @@ async function postBatch(options: PostBatchOptions): Promise<number[][]> {
     : new Error(`Embedding request failed after ${MAX_RETRIES} attempts`);
 }
 
-interface EmbeddingResponseBody {
-  /** Vectors in the same order as `input`. */
-  embeddings: number[][];
-  /** Echoed model identifier so callers can verify the server agreed with their request. */
-  model?: string;
+/**
+ * Server response envelope. The route wraps the action result in
+ * `{ data }`; `dimensions` and `model` are echoed back for verification
+ * but the server is the source of truth.
+ */
+interface EmbeddingResponseEnvelope {
+  data: {
+    embeddings: number[][];
+    dimensions: number;
+    model: string;
+  };
 }
 
 function resolveApiKey(override: CreateEmbeddingClientOptions["apiKey"]): string | undefined {

--- a/src/memory/migrations.ts
+++ b/src/memory/migrations.ts
@@ -334,6 +334,35 @@ const MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    version: 6,
+    description: "rebuild embeddings table at 3072 dims for google/gemini-embedding-2",
+    up: async (tx) => {
+      // The Duet embed endpoint now serves `google/gemini-embedding-2`
+      // at 3072 dimensions, replacing the previous text-embedding-3-small
+      // path. Every existing 1536-dim vector lives in a different latent
+      // space, so keeping them around would mean cosine similarity
+      // against new query embeddings is noise. Drop the table and let
+      // the backfill worker repopulate it lazily after upgrade.
+      //
+      // No HNSW index on the new table: pgvector's default
+      // `vector_cosine_ops` opclass caps HNSW at 2,000 dimensions, and
+      // adding `halfvec(3072)` + a half-precision opclass complicates
+      // the schema for a corpus that brute-force-scans in well under
+      // 10 ms at the thousands-of-rows scale this database operates at.
+      // The existing tsvector GIN index on `observations.content`
+      // survives untouched and continues to serve the keyword path.
+      await tx.exec(`DROP TABLE IF EXISTS observation_embeddings`);
+      await tx.exec(`
+        CREATE TABLE observation_embeddings (
+          observation_id TEXT PRIMARY KEY REFERENCES observations(id) ON DELETE CASCADE,
+          model TEXT NOT NULL,
+          vector vector(3072) NOT NULL,
+          created_at BIGINT NOT NULL
+        )
+      `);
+    },
+  },
 ];
 
 export interface MigrationResult {

--- a/src/memory/storage.ts
+++ b/src/memory/storage.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { PGlite, Transaction } from "@electric-sql/pglite";
 import type { Observation, ObservationalMemorySettings } from "../types/memory.js";
-import { DEFAULT_EMBEDDING_MODEL, type EmbedFn } from "./embedding.js";
+import { EMBEDDING_MODEL, type EmbedFn } from "./embedding.js";
 import { EmbeddingBackfillWorker } from "./embedding-worker.js";
 import { rebuildMemoryContextPack } from "./context-pack.js";
 import { runMigrations } from "./migrations.js";
@@ -26,7 +26,6 @@ export interface MemoryPersistenceHandle {
 
 export interface LoadStoredMemoryOptions {
   embed?: EmbedFn;
-  embeddingModel?: string;
   embeddingLogPath?: string;
   /** When set, freeze the initial context pack into the cache before the first turn dispatches. */
   contextPack?: {
@@ -57,7 +56,10 @@ export async function loadStoredMemory(
     ? new EmbeddingBackfillWorker({
         db: database,
         embed: options.embed,
-        model: options.embeddingModel ?? DEFAULT_EMBEDDING_MODEL,
+        // Hardcoded so every stored vector is tagged with the model that
+        // produced it; when we swap the server-side model in the future
+        // this tag is how we'll selectively invalidate stale rows.
+        model: EMBEDDING_MODEL,
         logPath: options.embeddingLogPath ?? defaultEmbeddingLogPath(),
       })
     : undefined;

--- a/test/memory-embedding-worker.test.ts
+++ b/test/memory-embedding-worker.test.ts
@@ -18,7 +18,7 @@ describe("EmbeddingBackfillWorker", () => {
           calls.push(inputs);
           // Deterministic stub: encode index into vector slot 0 so
           // assertions can verify a one-to-one input/output mapping.
-          return inputs.map((_, index) => fillVector(1536, index + 1));
+          return inputs.map((_, index) => fillVector(3072, index + 1));
         },
         model: "test-model",
       });
@@ -63,7 +63,7 @@ describe("EmbeddingBackfillWorker", () => {
       await db.query(
         `INSERT INTO observation_embeddings (observation_id, model, vector, created_at)
          VALUES ('mem_high', 'preexisting', $1, $2)`,
-        [`[${Array(1536).fill(0).join(",")}]`, Date.now()],
+        [`[${Array(3072).fill(0).join(",")}]`, Date.now()],
       );
 
       const calls: string[][] = [];
@@ -71,7 +71,7 @@ describe("EmbeddingBackfillWorker", () => {
         db,
         embed: async (inputs) => {
           calls.push(inputs);
-          return inputs.map(() => fillVector(1536, 1));
+          return inputs.map(() => fillVector(3072, 1));
         },
         model: "test-model",
       });
@@ -102,7 +102,7 @@ describe("EmbeddingBackfillWorker", () => {
         embed: async (inputs) => {
           attempt++;
           if (attempt === 1) throw new Error("simulated transient failure");
-          return inputs.map(() => fillVector(1536, 1));
+          return inputs.map(() => fillVector(3072, 1));
         },
         model: "test-model",
       });

--- a/test/memory-embedding.test.ts
+++ b/test/memory-embedding.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
   createEmbeddingClient,
-  EmbeddingUnavailableError,
   EMBEDDING_BATCH_LIMIT,
+  EMBEDDING_DIMENSIONS,
+  EmbeddingUnavailableError,
 } from "../src/memory/embedding.js";
 
 describe("Embedding client", () => {
-  test("posts inputs and the model to the embed endpoint", async () => {
+  test("posts inputs and dimensions to the embed endpoint", async () => {
     let capturedUrl = "";
     let capturedBody: unknown = null;
     let capturedAuth = "";
@@ -15,17 +16,20 @@ describe("Embedding client", () => {
       capturedAuth = String((init?.headers as Record<string, string>)?.authorization ?? "");
       capturedBody = JSON.parse(String(init?.body));
       return jsonResponse({
-        embeddings: [
-          [0.1, 0.2],
-          [0.3, 0.4],
-        ],
+        data: {
+          embeddings: [
+            [0.1, 0.2],
+            [0.3, 0.4],
+          ],
+          dimensions: EMBEDDING_DIMENSIONS,
+          model: "google/gemini-embedding-2",
+        },
       });
     }) as unknown as typeof fetch;
     const embed = createEmbeddingClient({
       apiKey: "test-key",
       baseUrl: "https://example.test",
       fetch: fetchStub,
-      model: "openai/text-embedding-3-small",
     });
 
     const result = await embed(["alpha", "beta"]);
@@ -38,7 +42,7 @@ describe("Embedding client", () => {
     expect(capturedAuth).toBe("Bearer test-key");
     expect(capturedBody).toEqual({
       input: ["alpha", "beta"],
-      model: "openai/text-embedding-3-small",
+      dimensions: EMBEDDING_DIMENSIONS,
     });
   });
 
@@ -49,7 +53,11 @@ describe("Embedding client", () => {
       calls.push(body.input);
       // Echo: each input becomes a one-element vector with its length.
       return jsonResponse({
-        embeddings: body.input.map((value) => [value.length]),
+        data: {
+          embeddings: body.input.map((value) => [value.length]),
+          dimensions: EMBEDDING_DIMENSIONS,
+          model: "google/gemini-embedding-2",
+        },
       });
     }) as unknown as typeof fetch;
     const embed = createEmbeddingClient({ apiKey: "k", fetch: fetchStub });
@@ -90,7 +98,13 @@ describe("Embedding client", () => {
     const fetchStub = (async () => {
       calls++;
       if (calls < 3) return new Response("oops", { status: 503 });
-      return jsonResponse({ embeddings: [[1, 2, 3]] });
+      return jsonResponse({
+        data: {
+          embeddings: [[1, 2, 3]],
+          dimensions: EMBEDDING_DIMENSIONS,
+          model: "google/gemini-embedding-2",
+        },
+      });
     }) as unknown as typeof fetch;
     const embed = createEmbeddingClient({ apiKey: "k", fetch: fetchStub });
 

--- a/test/memory-recall.test.ts
+++ b/test/memory-recall.test.ts
@@ -115,7 +115,7 @@ describe("recall_memory", () => {
       async () => {
         await withSeededDb(async (db) => {
           // Seed embeddings so the vector path returns rows. Each
-          // embedding is a one-hot 1536-dim vector keyed off the
+          // embedding is a one-hot 3072-dim vector keyed off the
           // observation id so the test can predict cosine similarity:
           // mem_wire_budget gets a vector that exactly matches the
           // query embedding the stub returns.
@@ -192,7 +192,7 @@ async function seedEmbeddings(db: PGlite): Promise<void> {
 }
 
 function oneHotVector(activeIndex: number): number[] {
-  const result = new Array<number>(1536).fill(0);
+  const result = new Array<number>(3072).fill(0);
   result[activeIndex] = 1;
   return result;
 }


### PR DESCRIPTION
## Summary

The Duet \`/api/v1/embed\` endpoint now serves \`google/gemini-embedding-2\` at 3072 dimensions, replacing the previous OpenAI text-embedding-3-small / 1536-dim path. The duet-agent client was built against the older shape and would not have worked against the live endpoint — three things had to change in lockstep:

- **Request body:** drop \`model\`, send \`{ input, dimensions: 3072 }\`. Server hardcodes the model.
- **Response shape:** read \`body.data.embeddings\` — the route wraps the action result in \`{ data }\`. The old \`body.embeddings\` was \`undefined\`, which would have thrown on the \`.length\` check at \`embedding.ts:98\` on the first live call.
- **pgvector column:** migration v6 drops and recreates \`observation_embeddings\` at \`vector(3072)\`. Existing 1536-dim vectors live in a different latent space and are invalidated; the backfill worker repopulates after upgrade.

\`EMBEDDING_MODEL = "google/gemini-embedding-2"\` is exported from \`src/memory/embedding.ts\` and stamped into the \`model\` column on every stored row, so the next model swap can invalidate by tag instead of nuking the table again.

## Notes

- **No HNSW index** on the new table: pgvector's default \`vector_cosine_ops\` opclass caps HNSW at 2,000 dimensions. Brute-force cosine scans are sub-10 ms on the thousands-of-rows scale this database operates at. The existing tsvector GIN index on \`observations.content\` is untouched and continues to serve the keyword path.
- Dropped \`embeddingModel\` from \`LoadStoredMemoryOptions\` — no longer plumbed from above; storage uses the constant directly.

## Test plan
- [x] \`bun run check-types\` clean
- [x] \`bun run lint\` clean
- [x] \`bun test ./test/memory-embedding.test.ts\` (5 pass)
- [ ] \`bun run test\` (docker-gated migration/worker/recall tests) on CI
- [ ] Manual: \`duet login\` + observe backfill log shows 3072-dim rows landing tagged with \`google/gemini-embedding-2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)