### PR TITLE
refactor(memory): receive embedding model from the server, drop client constant

### DIFF
--- a/src/memory/embedding-worker.ts
+++ b/src/memory/embedding-worker.ts
@@ -32,8 +32,6 @@ export interface EmbeddingBackfillWorkerOptions {
   db: PGlite;
   /** Embedding callable. Defaults to the gateway client; tests inject a stub. */
   embed: EmbedFn;
-  /** Identifier for the embedding model, written alongside each vector for future re-embedding. */
-  model: string;
   /** Path to append progress lines to. Optional; when omitted the worker logs nothing. */
   logPath?: string;
 }
@@ -71,14 +69,14 @@ export class EmbeddingBackfillWorker {
           continue;
         }
 
-        const vectors = await this.options.embed(batch.map((row) => row.content));
-        if (vectors.length !== batch.length) {
+        const result = await this.options.embed(batch.map((row) => row.content));
+        if (result.embeddings.length !== batch.length) {
           throw new Error(
-            `Embedding response length (${vectors.length}) did not match batch size (${batch.length})`,
+            `Embedding response length (${result.embeddings.length}) did not match batch size (${batch.length})`,
           );
         }
 
-        await this.persistBatch(batch, vectors);
+        await this.persistBatch(batch, result.embeddings, result.model);
         this.log(`Embedded ${batch.length} observations`);
         await sleep(INTER_BATCH_SLEEP_MS, signal);
       } catch (error) {
@@ -112,10 +110,14 @@ export class EmbeddingBackfillWorker {
   private async persistBatch(
     batch: { id: string; content: string }[],
     vectors: number[][],
+    model: string,
   ): Promise<void> {
     // One transaction so a partial network or write failure does not
     // leave the embeddings table half-populated relative to the
-    // candidate set we just queried.
+    // candidate set we just queried. `model` is the identifier the
+    // server reported for this batch; storing it verbatim lets a
+    // future re-embedding pass match the deprecated tag and refresh
+    // only the affected rows.
     await this.options.db.transaction(async (tx) => {
       const now = Date.now();
       for (let index = 0; index < batch.length; index++) {
@@ -128,7 +130,7 @@ export class EmbeddingBackfillWorker {
              model = EXCLUDED.model,
              vector = EXCLUDED.vector,
              created_at = EXCLUDED.created_at`,
-          [row.id, this.options.model, formatVector(vector), now],
+          [row.id, model, formatVector(vector), now],
         );
       }
     });

--- a/src/memory/embedding.ts
+++ b/src/memory/embedding.ts
@@ -8,11 +8,12 @@ import { resolveDuetAppBaseUrl } from "../lib/duet-app-url.js";
  * for free as a CLI perk; we deliberately do not expose a way to plug
  * in a different provider key here so the runtime stays single-path.
  *
- * The endpoint hardcodes `google/gemini-embedding-2` on the server side
- * — we match that here as a constant so every stored vector is tagged
- * with the model that produced it. When we switch models in the future,
- * the migration that bumps `EMBEDDING_MODEL` can selectively invalidate
- * rows by `model` instead of nuking the entire embeddings table.
+ * Model identity is owned by the server. The endpoint hardcodes the
+ * model and echoes it back on every response; we store the echoed
+ * value alongside each vector so a future server-side model swap can
+ * invalidate stale rows by tag. This client knows nothing about the
+ * concrete model name — only the dimension width, which has to match
+ * the pgvector column.
  *
  * Behavior:
  *   - Inputs are batched up to `EMBEDDING_BATCH_LIMIT` per HTTP call so
@@ -26,11 +27,6 @@ import { resolveDuetAppBaseUrl } from "../lib/duet-app-url.js";
  *     sleeps until the user logs in).
  */
 
-/**
- * Embedding model identifier. Hardcoded here to match the server, and
- * exported so the storage layer can tag each stored vector with it.
- */
-export const EMBEDDING_MODEL = "google/gemini-embedding-2";
 /** Embedding dimensions. Sent on every request and matches the pgvector column width. */
 export const EMBEDDING_DIMENSIONS = 3072;
 /** Maximum input strings sent in a single embedding request. */
@@ -41,10 +37,20 @@ const MAX_RETRIES = 3;
 const BASE_BACKOFF_MS = 500;
 
 /**
- * Callable shape consumed by the backfill worker and the recall_memory
- * tool. Inputs map 1:1 to output vectors.
+ * Result of an `EmbedFn` call. `model` is the identifier the server
+ * reported alongside the vectors; storage tags each row with it so a
+ * later model swap can invalidate stale rows by string match.
  */
-export type EmbedFn = (inputs: string[]) => Promise<number[][]>;
+export interface EmbedResult {
+  embeddings: number[][];
+  model: string;
+}
+
+/**
+ * Callable shape consumed by the backfill worker and the recall_memory
+ * tool. Inputs map 1:1 to `embeddings`.
+ */
+export type EmbedFn = (inputs: string[]) => Promise<EmbedResult>;
 
 export class EmbeddingUnavailableError extends Error {
   constructor(message: string) {
@@ -83,7 +89,7 @@ export function createEmbeddingClient(options: CreateEmbeddingClientOptions = {}
   const fetchImpl = options.fetch ?? fetch;
 
   return async (inputs) => {
-    if (inputs.length === 0) return [];
+    if (inputs.length === 0) return { embeddings: [], model: "" };
     const apiKey = resolveApiKey(options.apiKey);
     if (!apiKey) {
       // Throwing a typed error lets callers branch on graceful
@@ -93,23 +99,29 @@ export function createEmbeddingClient(options: CreateEmbeddingClientOptions = {}
       );
     }
 
-    const results: number[][] = [];
+    const embeddings: number[][] = [];
+    let model = "";
     for (let offset = 0; offset < inputs.length; offset += EMBEDDING_BATCH_LIMIT) {
       const slice = inputs.slice(offset, offset + EMBEDDING_BATCH_LIMIT);
-      const vectors = await postBatch({
+      const batch = await postBatch({
         url: `${baseUrl}${ENDPOINT_PATH}`,
         apiKey,
         inputs: slice,
         fetchImpl,
       });
-      if (vectors.length !== slice.length) {
+      if (batch.embeddings.length !== slice.length) {
         throw new Error(
-          `Embedding response length (${vectors.length}) did not match request size (${slice.length})`,
+          `Embedding response length (${batch.embeddings.length}) did not match request size (${slice.length})`,
         );
       }
-      results.push(...vectors);
+      embeddings.push(...batch.embeddings);
+      // The server returns the same model on every batch within a call.
+      // Take the last one so the caller sees what the server most
+      // recently agreed to; mid-call mismatches are not a thing we
+      // currently need to reconcile.
+      model = batch.model;
     }
-    return results;
+    return { embeddings, model };
   };
 }
 
@@ -120,7 +132,7 @@ interface PostBatchOptions {
   fetchImpl: typeof fetch;
 }
 
-async function postBatch(options: PostBatchOptions): Promise<number[][]> {
+async function postBatch(options: PostBatchOptions): Promise<EmbedResult> {
   let lastError: unknown;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
@@ -135,7 +147,7 @@ async function postBatch(options: PostBatchOptions): Promise<number[][]> {
 
       if (response.ok) {
         const body = (await response.json()) as EmbeddingResponseEnvelope;
-        return body.data.embeddings;
+        return { embeddings: body.data.embeddings, model: body.data.model };
       }
 
       // 4xx errors (auth, malformed input) will not improve on retry;
@@ -166,8 +178,8 @@ async function postBatch(options: PostBatchOptions): Promise<number[][]> {
 
 /**
  * Server response envelope. The route wraps the action result in
- * `{ data }`; `dimensions` and `model` are echoed back for verification
- * but the server is the source of truth.
+ * `{ data }`; `dimensions` is echoed back for verification but the
+ * server is the source of truth.
  */
 interface EmbeddingResponseEnvelope {
   data: {

--- a/src/memory/recall.ts
+++ b/src/memory/recall.ts
@@ -152,7 +152,8 @@ async function vectorSearch(
   const trimmed = query.trim();
   if (!trimmed) return [];
 
-  const [vector] = await embed([trimmed]);
+  const { embeddings } = await embed([trimmed]);
+  const vector = embeddings[0];
   if (!vector) return [];
 
   const baseSql = `SELECT o.id

--- a/src/memory/storage.ts
+++ b/src/memory/storage.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { PGlite, Transaction } from "@electric-sql/pglite";
 import type { Observation, ObservationalMemorySettings } from "../types/memory.js";
-import { EMBEDDING_MODEL, type EmbedFn } from "./embedding.js";
+import type { EmbedFn } from "./embedding.js";
 import { EmbeddingBackfillWorker } from "./embedding-worker.js";
 import { rebuildMemoryContextPack } from "./context-pack.js";
 import { runMigrations } from "./migrations.js";
@@ -56,10 +56,6 @@ export async function loadStoredMemory(
     ? new EmbeddingBackfillWorker({
         db: database,
         embed: options.embed,
-        // Hardcoded so every stored vector is tagged with the model that
-        // produced it; when we swap the server-side model in the future
-        // this tag is how we'll selectively invalidate stale rows.
-        model: EMBEDDING_MODEL,
         logPath: options.embeddingLogPath ?? defaultEmbeddingLogPath(),
       })
     : undefined;

--- a/test/memory-embedding-worker.test.ts
+++ b/test/memory-embedding-worker.test.ts
@@ -18,9 +18,11 @@ describe("EmbeddingBackfillWorker", () => {
           calls.push(inputs);
           // Deterministic stub: encode index into vector slot 0 so
           // assertions can verify a one-to-one input/output mapping.
-          return inputs.map((_, index) => fillVector(3072, index + 1));
+          return {
+            embeddings: inputs.map((_, index) => fillVector(3072, index + 1)),
+            model: "test-model",
+          };
         },
-        model: "test-model",
       });
 
       worker.start();
@@ -71,9 +73,11 @@ describe("EmbeddingBackfillWorker", () => {
         db,
         embed: async (inputs) => {
           calls.push(inputs);
-          return inputs.map(() => fillVector(3072, 1));
+          return {
+            embeddings: inputs.map(() => fillVector(3072, 1)),
+            model: "test-model",
+          };
         },
-        model: "test-model",
       });
 
       worker.start();
@@ -102,9 +106,11 @@ describe("EmbeddingBackfillWorker", () => {
         embed: async (inputs) => {
           attempt++;
           if (attempt === 1) throw new Error("simulated transient failure");
-          return inputs.map(() => fillVector(3072, 1));
+          return {
+            embeddings: inputs.map(() => fillVector(3072, 1)),
+            model: "test-model",
+          };
         },
-        model: "test-model",
       });
 
       // Stop the worker quickly so we do not actually wait the full

--- a/test/memory-embedding.test.ts
+++ b/test/memory-embedding.test.ts
@@ -34,10 +34,13 @@ describe("Embedding client", () => {
 
     const result = await embed(["alpha", "beta"]);
 
-    expect(result).toEqual([
-      [0.1, 0.2],
-      [0.3, 0.4],
-    ]);
+    expect(result).toEqual({
+      embeddings: [
+        [0.1, 0.2],
+        [0.3, 0.4],
+      ],
+      model: "google/gemini-embedding-2",
+    });
     expect(capturedUrl).toBe("https://example.test/api/v1/embed");
     expect(capturedAuth).toBe("Bearer test-key");
     expect(capturedBody).toEqual({
@@ -68,7 +71,8 @@ describe("Embedding client", () => {
     expect(calls).toHaveLength(2);
     expect(calls[0]).toHaveLength(EMBEDDING_BATCH_LIMIT);
     expect(calls[1]).toHaveLength(5);
-    expect(result).toHaveLength(inputs.length);
+    expect(result.embeddings).toHaveLength(inputs.length);
+    expect(result.model).toBe("google/gemini-embedding-2");
   });
 
   test("throws EmbeddingUnavailableError when the API key is missing", async () => {
@@ -109,7 +113,8 @@ describe("Embedding client", () => {
     const embed = createEmbeddingClient({ apiKey: "k", fetch: fetchStub });
 
     const result = await embed(["recovers"]);
-    expect(result).toEqual([[1, 2, 3]]);
+    expect(result.embeddings).toEqual([[1, 2, 3]]);
+    expect(result.model).toBe("google/gemini-embedding-2");
     expect(calls).toBe(3);
   });
 });

--- a/test/memory-recall.test.ts
+++ b/test/memory-recall.test.ts
@@ -123,7 +123,7 @@ describe("recall_memory", () => {
 
           const result = await recallMemory({
             db,
-            embed: async () => [oneHotVector(0)],
+            embed: async () => ({ embeddings: [oneHotVector(0)], model: "test-model" }),
             query: "anything",
             scope: "all",
           });


### PR DESCRIPTION
## Summary

Stops hardcoding the embedding model on the duet-agent side. The Duet \`/api/v1/embed\` endpoint already returns the model identifier on every response — we now read that and store it verbatim, so the CLI is agnostic to whatever model the server happens to be running.

Why: if we swap the server-side model tomorrow, old CLI builds will keep tagging rows with whatever the server reports back, and a future re-embedding pass can invalidate deprecated tags by string match. The CLI never needs a new release to track a model change.

## Shape change

\`EmbedFn\` now returns the model alongside the vectors:

\`\`\`ts
// before
type EmbedFn = (inputs: string[]) => Promise<number[][]>

// after
type EmbedFn = (inputs: string[]) => Promise<{ embeddings: number[][]; model: string }>
\`\`\`

- \`EMBEDDING_MODEL\` constant removed from \`src/memory/embedding.ts\`.
- \`EmbeddingBackfillWorker\` drops the \`model\` constructor option; the per-batch \`result.model\` is plumbed into \`persistBatch\` and written to the row's \`model\` column.
- \`src/memory/storage.ts\` no longer imports or plumbs a model identifier.
- \`src/memory/recall.ts\` destructures \`embeddings[0]\` instead of the old tuple.
- Tests updated for the new return shape.

\`EMBEDDING_DIMENSIONS\` stays put — the pgvector column width is part of the local schema, so the client still has to enforce 3072 on each request.

## Note on chat-app

No PR needed on \`aomni-com/chat-app\` — the deployed \`POST /api/v1/embed\` action already returns \`{ data: { embeddings, dimensions, model } }\` with \`model: 'google/gemini-embedding-2'\`. The contract is already in place; this PR just reads it.

## Test plan
- [x] \`bun run check-types\` clean
- [x] \`bun run lint\` clean
- [x] \`bun test ./test/memory-embedding.test.ts\` (5 pass)
- [ ] \`bun run test\` (docker-gated worker/recall tests) on CI
- [ ] Manual: \`duet login\` + observe backfill log shows rows landing tagged with the model string the server reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)