### PR TITLE
feat(tui): Ctrl+Enter steers — dispatch composer text at next agent boundary

### DIFF
--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -1916,13 +1916,29 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     }
 
     if (key.name === "return" || key.name === "enter") {
-      // Shift+Enter inserts a literal newline at the cursor, matching every
-      // modern chat composer (Slack, Claude Code, ChatGPT, Discord). Plain
-      // Enter always submits — when the agent is running the submit path
-      // queues the message as a follow-up; otherwise it kicks off a new turn.
+      // Three modifier flavors on the Enter key. The modifier is only
+      // distinguishable when the terminal speaks the kitty-keyboard
+      // protocol (or modifyOtherKeys); in a legacy terminal Ctrl+Enter
+      // and Shift+Enter collapse to plain Enter. We accept that
+      // tradeoff for the same reason Shift+Enter accepts it: modern
+      // terminals are the target.
+      //
+      //   Plain Enter   → submit (idle = fresh turn, running = soft queue
+      //                  via follow_up).
+      //   Shift+Enter   → insert a literal newline at the cursor, matching
+      //                  every modern chat composer (Slack, ChatGPT,
+      //                  Discord, Cursor, Claude Code).
+      //   Ctrl+Enter    → steer: dispatch with behavior:"steer" so the
+      //                  runner hands it to agent.steer() at the next
+      //                  inference boundary instead of waiting for the
+      //                  full turn to wrap up.
       key.preventDefault();
       if (key.shift) {
         inputField.insertText("\n");
+        return;
+      }
+      if (key.ctrl) {
+        handleSteerKeystroke();
         return;
       }
       const value = inputField.plainText.trim();
@@ -1950,6 +1966,44 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
   function handleEscape(): void {
     if (!running) return;
     void input.session.interrupt().catch(reportError);
+  }
+
+  // Ctrl+Enter sends the composer text with behavior:"steer" — the
+  // runner routes this to agent.steer() when the agent is mid-inference
+  // (most of an active turn), which preempts the current LLM call and
+  // injects the message into the next iteration. If the runner is
+  // between inference calls (e.g. mid-tool-call) the steer-flagged
+  // command enqueues and gets picked up at the next agent boundary.
+  // Either way the user gets "at next sensible task boundary" pickup,
+  // which is sooner than the soft-queue follow_up (which only fires at
+  // end of the full turn).
+  //
+  // Empty composer: no-op. The keybind is dedicated to send-with-steer,
+  // and a bare Ctrl+Enter should not interrupt or otherwise affect state.
+  function handleSteerKeystroke(): void {
+    const message = inputField.plainText.trim();
+    if (message.length === 0) return;
+    // Snapshot before clearing so attachments ride with the steer
+    // dispatch and the user-facing labels render correctly.
+    const submittedImages = pendingImages;
+    inputField.clear();
+    clearPendingImages();
+    refreshHint();
+    recordTranscriptEntry("user", message);
+    appendBlock("you:", message, COLORS.user);
+    if (submittedImages.length > 0) {
+      const lines = submittedImages
+        .map((p) => `📎 ${p.label}: ${p.path}`)
+        .join("\n");
+      appendBlock(null, lines, COLORS.hint);
+    }
+    const images = submittedImages.map((p) => p.attachment);
+    void input.session
+      .prompt({ message, behavior: "steer", images })
+      .catch(reportError);
+    if (!running) {
+      markRunning();
+    }
   }
 
   // ---- /diag diagnostics -----------------------------------------------------

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -17,8 +17,14 @@ export const COLORS = {
 // Esc is intentionally absent from the idle hint: when no turn is running
 // it is a no-op (it only closes open pickers, which is self-evident). Use
 // Ctrl+C to quit the TUI — the universal terminal convention.
-export const HINT_IDLE = "Enter: send · Shift+Enter: newline · PgUp/PgDn: scroll · Ctrl+C: quit";
-export const HINT_RUNNING = "Enter: queue follow-up · PgUp/PgDn: scroll · Esc: interrupt";
+export const HINT_IDLE =
+  "Enter: send · Shift+Enter: newline · PgUp/PgDn: scroll · Ctrl+C: quit";
+// Ctrl+Enter surfaces in the running hint only; advertising it on the
+// idle hint would be noise (idle has nothing to steer against). The
+// keystroke is a no-op when the composer is empty, so a single line
+// covers both running cases without flicker.
+export const HINT_RUNNING =
+  "Enter: queue follow-up · Ctrl+Enter: steer · PgUp/PgDn: scroll · Esc: interrupt";
 
 /**
  * Terminal-aware copy keystroke shown in the hint only while a non-empty

--- a/test/tui-ctrl-enter-steer.test.ts
+++ b/test/tui-ctrl-enter-steer.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect } from "bun:test";
+
+import { bootTui, type TuiHarness } from "./helpers/tui-harness.js";
+import { testIfDocker } from "./helpers/docker-only.js";
+
+/**
+ * Ctrl+Enter is the dedicated "steer" keybind: dispatch the composer's
+ * text via `behavior: "steer"` so the runner injects it at the agent's
+ * next inference boundary (rather than at end-of-turn the way Enter-
+ * while-running's `follow_up` does). The Enter key now carries three
+ * modifier-flavored intents, each tagged by its modifier:
+ *
+ *   Plain Enter  → submit (idle = fresh turn, running = soft queue)
+ *   Shift+Enter  → newline in composer
+ *   Ctrl+Enter   → steer (interrupt at next inference boundary, send)
+ *
+ * Three contract points locked here:
+ *
+ *  - Ctrl+Enter with non-empty composer dispatches exactly one prompt
+ *    call with `behavior: "steer"` and the snapshotted message text.
+ *  - Ctrl+Enter with empty composer is a no-op (no prompt, no
+ *    interrupt, nothing visible).
+ *  - Ctrl+Enter while idle is a valid send — kicks off a fresh turn
+ *    flagged with `behavior: "steer"`, matching the rule that the
+ *    keybind is composer-state-agnostic.
+ *
+ * The modifier is only distinguishable in terminals that speak the
+ * kitty-keyboard protocol (the harness enables it); legacy terminals
+ * would collapse Ctrl+Enter to plain Enter and dispatch follow_up
+ * instead. We accept the same tradeoff we already accepted for
+ * Shift+Enter — modern terminals are the target.
+ */
+
+describe("TUI Ctrl+Enter steer keystroke", () => {
+  let harness: TuiHarness;
+
+  beforeEach(async () => {
+    harness = await bootTui();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  async function startLongRunningTurn(): Promise<void> {
+    await harness.mockInput.typeText("/working 30");
+    await harness.flush();
+    harness.mockInput.pressEnter();
+    await harness.waitForPrompt();
+  }
+
+  testIfDocker(
+    "Ctrl+Enter with non-empty composer mid-turn dispatches a steer prompt",
+    async () => {
+      await startLongRunningTurn();
+      const promptsBefore = harness.promptCalls.length;
+
+      await harness.mockInput.typeText("redirect to the docs site");
+      await harness.flush();
+      harness.mockInput.pressEnter({ ctrl: true });
+      await harness.waitForPrompt({ count: promptsBefore + 1 });
+
+      expect(harness.promptCalls.length).toBe(promptsBefore + 1);
+      const steer = harness.promptCalls[promptsBefore]!;
+      expect(steer.message).toBe("redirect to the docs site");
+      expect(steer.behavior).toBe("steer");
+    },
+  );
+
+  testIfDocker("Ctrl+Enter with empty composer mid-turn is a no-op", async () => {
+    await startLongRunningTurn();
+    const promptsBefore = harness.promptCalls.length;
+
+    // Composer is empty after the previous submit. Pressing Ctrl+Enter
+    // here should not dispatch anything; it is a dedicated send-with-
+    // steer keybind, not an alternative interrupt.
+    harness.mockInput.pressEnter({ ctrl: true });
+    await harness.flush();
+    await harness.flush();
+
+    expect(harness.promptCalls.length).toBe(promptsBefore);
+  });
+
+  testIfDocker(
+    "Ctrl+Enter while idle dispatches the composer text as a steer-flagged fresh turn",
+    async () => {
+      const promptsBefore = harness.promptCalls.length;
+
+      await harness.mockInput.typeText("kick this off as a steer");
+      await harness.flush();
+      harness.mockInput.pressEnter({ ctrl: true });
+      await harness.waitForPrompt({ count: promptsBefore + 1 });
+
+      const steer = harness.promptCalls[promptsBefore]!;
+      expect(steer.message).toBe("kick this off as a steer");
+      expect(steer.behavior).toBe("steer");
+    },
+  );
+});

--- a/test/tui-hints.test.ts
+++ b/test/tui-hints.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, test } from "bun:test";
 
 import { HINT_IDLE, HINT_RUNNING } from "../src/tui/theme.js";
 
-// The Enter and Esc key contracts are documented to users solely through
-// these footer hints, so lock the wording. Idle: Shift+Enter inserts a
-// newline; Esc is intentionally absent because it is a no-op when no turn
-// is running, and Ctrl+C is the way out. Running: Enter queues a
-// follow-up (single gesture, single mental model) and Esc interrupts the
-// in-flight turn.
+// The Enter, Ctrl+Enter, and Esc key contracts are documented to users
+// solely through these footer hints, so lock the wording. Idle:
+// Shift+Enter inserts a newline; Esc is intentionally absent because it
+// is a no-op when no turn is running, and Ctrl+C is the way out.
+// Running: Enter queues a soft follow-up, Ctrl+Enter steers (pickup at
+// next agent boundary), Esc interrupts the in-flight turn. Three
+// gestures, three semantics, each tagged with the verb that matches
+// what it does.
 describe("TUI hint strings", () => {
   test("idle hint advertises Enter to send, Shift+Enter for newline, and Ctrl+C to quit", () => {
     expect(HINT_IDLE).toContain("Enter: send");
@@ -16,12 +18,15 @@ describe("TUI hint strings", () => {
     // Idle Esc is a no-op (only closes open pickers); do not advertise it
     // as a quit affordance.
     expect(HINT_IDLE).not.toContain("Esc");
+    // Ctrl+Enter is a no-op while idle (plain Enter already submits), so
+    // leave it off the idle hint to avoid noise.
+    expect(HINT_IDLE).not.toContain("Ctrl+Enter");
   });
 
-  test("running hint advertises queue, Esc-to-interrupt, and no Shift+Enter branch", () => {
+  test("running hint advertises queue, Ctrl+Enter steer, Esc-to-interrupt, and no Shift+Enter branch", () => {
     expect(HINT_RUNNING).toContain("Enter: queue follow-up");
-    expect(HINT_RUNNING).not.toContain("Shift+Enter");
-    expect(HINT_RUNNING).not.toContain("steer");
+    expect(HINT_RUNNING).toContain("Ctrl+Enter: steer");
     expect(HINT_RUNNING).toContain("Esc: interrupt");
+    expect(HINT_RUNNING).not.toContain("Shift+Enter");
   });
 });


### PR DESCRIPTION
Adds a dedicated send-with-priority keystroke that does not overload Enter (soft queue) or Esc (pure interrupt). The Enter key now carries three modifier-flavored intents, all stateless gestures within session mode — no new mode, no new view state.

## Gesture model

| Keystroke | Behavior |
|---|---|
| **Plain Enter** | submit — idle = fresh turn, running = soft queue via `follow_up` (agent reads at end of turn) |
| **Shift+Enter** | insert a literal newline at the cursor |
| **Ctrl+Enter** | steer — dispatch with `behavior: \"steer\"` so the runner hands it to \`agent.steer()\` at the next inference boundary |
| **Esc** | unchanged — interrupt / no-op-when-idle |

## Why Ctrl+Enter (not Ctrl+S)

- Semantically natural: Enter = send, Ctrl+Enter = send-with-priority. Cursor / Slack / Linear all use this pattern.
- No XOFF risk: avoids the Ctrl+S terminal flow-control trap entirely.
- Composes with what we already have: Shift+Enter = newline, plain Enter = send, Ctrl+Enter = steer. One key, three modifiers, three meanings.

## Implementation

\`handleSteerKeystroke()\` snapshots composer text + pending images before clearing, records the user-turn block, and dispatches \`session.prompt({ message, behavior: \"steer\", images })\`. Empty composer is a no-op — the keybind is dedicated to send-with-steer, bare Ctrl+Enter should not affect state. Idle + Ctrl+Enter is a valid send (starts a fresh turn with the steer flag).

The runner routes \`behavior: \"steer\"\` to \`agent.steer()\` when the agent is mid-inference, which preempts the current LLM call and injects the message into the next iteration. If the runner is mid-tool-call, the steer-flagged command enqueues and gets picked up at the next agent boundary. Either way the user gets pickup at the next sensible task boundary — sooner than the end-of-turn pickup that \`follow_up\` provides.

## Footer hints

\`\`\`
Idle:    Enter: send · Shift+Enter: newline · PgUp/PgDn: scroll · Ctrl+C: quit
Running: Enter: queue follow-up · Ctrl+Enter: steer · PgUp/PgDn: scroll · Esc: interrupt
\`\`\`

Ctrl+Enter only surfaces in the running hint — advertising it on the idle hint would be noise (idle has nothing to steer against). The keystroke is a no-op when the composer is empty, so a single line covers both running cases without flicker.

## Tests

New \`test/tui-ctrl-enter-steer.test.ts\` locks three contract points:
- Ctrl+Enter with non-empty composer mid-turn dispatches exactly one prompt with \`behavior: \"steer\"\` and the snapshotted text.
- Ctrl+Enter with empty composer mid-turn is a no-op (no prompt, no interrupt, nothing visible).
- Ctrl+Enter while idle dispatches the composer text as a steer-flagged fresh turn.

\`test/tui-hints.test.ts\` updated to assert the new hint contract.

## Terminal caveat

The Ctrl modifier on Enter is only distinguishable when the terminal speaks the kitty-keyboard protocol (or modifyOtherKeys). Legacy terminals collapse Ctrl+Enter to plain Enter and dispatch \`follow_up\` instead. Same tradeoff already accepted for Shift+Enter — modern terminals are the target.

## Gates

- \`tsc --noEmit\` ✅
- \`oxlint\` 0 errors ✅
- \`bun test\` 515 pass / 236 skip / 0 fail ✅