### PR TITLE
[david] feat(memory): only bump best of duplicate memories

### DIFF
--- a/evals/observer-best-of-duplicates.eval.ts
+++ b/evals/observer-best-of-duplicates.eval.ts
@@ -1,0 +1,150 @@
+import { describe, expect } from "bun:test";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { rebuildMemoryContextPack } from "../src/memory/context-pack.js";
+import {
+  DEFAULT_EFFECTIVE_CONTEXT,
+  resolveObservationalMemorySettings,
+  updateObservationalMemory,
+} from "../src/memory/observational.js";
+import { DEFAULT_CLI_MEMORY_MODEL } from "../src/model-resolution/resolver.js";
+import { createAssistantMessage } from "../test/helpers/messages.js";
+import { createMemoryFixture } from "../test/helpers/memory-fixture.js";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+/**
+ * Red/green eval: when several existing memories cover the SAME fact,
+ * the observer should only bump `last_used_at` on the single best one —
+ * not on every duplicate that happens to match.
+ *
+ * Without the "pick the best duplicate" instruction, the observer
+ * happily cites every overlapping memory id, which uniformly refreshes
+ * stale/vague duplicates and defeats the freshness-decay ranking.
+ * The fix lives in the `usedObservationIds` section of
+ * `observational-prompts.ts`.
+ */
+
+const memoryModel = process.env.EVAL_MEMORY_MODEL ?? DEFAULT_CLI_MEMORY_MODEL;
+
+const settings = resolveObservationalMemorySettings(DEFAULT_EFFECTIVE_CONTEXT);
+
+describe("observer bumps only the best duplicate memory", () => {
+  testIfDocker(
+    "with three overlapping memories about the same deploy command, only the best one's last_used_at advances",
+    async () => {
+      const fixture = await createMemoryFixture();
+      try {
+        // Best memory: most specific, highest priority, most recent
+        // wording. This is the one the observer should cite.
+        const best = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: "2026-04-30",
+          priority: "high",
+          source: { kind: "system" },
+          content:
+            "User confirmed the canonical deploy command for the api service is `pnpm deploy:prod` (run from repo root, requires VPN).",
+          tags: ["seeded", "best"],
+        });
+        // Duplicate: same fact, less specific. Should NOT be bumped.
+        const dupMedium = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: "2026-04-15",
+          priority: "medium",
+          source: { kind: "system" },
+          content: "User uses `pnpm deploy:prod` to ship the api service.",
+          tags: ["seeded", "dup"],
+        });
+        // Duplicate: vague restatement. Should NOT be bumped.
+        const dupVague = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: "2026-04-01",
+          priority: "low",
+          source: { kind: "system" },
+          content: "User has a deploy command for the api service.",
+          tags: ["seeded", "dup"],
+        });
+        // Unrelated decoy: must stay untouched.
+        const cat = await fixture.append({
+          sessionId: "session_other",
+          kind: "reflection",
+          observedDate: "2026-04-30",
+          priority: "high",
+          source: { kind: "system" },
+          content: "User mentioned their cat is named Pixel and is a 3-year-old tabby.",
+          tags: ["seeded"],
+        });
+
+        await rebuildMemoryContextPack({
+          session: fixture.session,
+          cache: fixture.cache,
+          settings,
+          sessionId: "session_eval",
+        });
+
+        const messages: AgentMessage[] = [
+          {
+            role: "user",
+            content: [{ type: "text", text: "How do I deploy the api service?" }],
+            timestamp: Date.now(),
+          },
+          createAssistantMessage({
+            text: "Run `pnpm deploy:prod` from the repo root (VPN required) — the canonical deploy command you confirmed earlier.",
+            timestamp: Date.now() + 1,
+          }),
+        ];
+
+        const seedTime = Date.now() - 24 * 60 * 60 * 1000;
+        const seededIds = [best.id, dupMedium.id, dupVague.id, cat.id];
+        await fixture.session.withDb(async (db) => {
+          await db.query(
+            "UPDATE observations SET created_at = $1, last_used_at = $1 WHERE id = ANY($2::text[])",
+            [seedTime, seededIds],
+          );
+        });
+
+        await updateObservationalMemory({
+          session: fixture.session,
+          memory: fixture.cache,
+          sessionId: "session_eval",
+          effectiveContext: DEFAULT_EFFECTIVE_CONTEXT,
+          actorModel: memoryModel,
+          messages,
+        });
+
+        const rows = await readLastUsed(fixture.session, seededIds);
+
+        // Best one moved.
+        expect(rows[best.id]).toBeGreaterThan(seedTime + 60_000);
+        // Duplicates stayed pinned at the seed time. This is the
+        // contract: do not refresh every memory that overlaps the
+        // same fact — only the single best representative.
+        expect(rows[dupMedium.id]).toBe(seedTime);
+        expect(rows[dupVague.id]).toBe(seedTime);
+        // Unrelated decoy untouched.
+        expect(rows[cat.id]).toBe(seedTime);
+      } finally {
+        await fixture.dispose();
+      }
+    },
+    60_000,
+  );
+});
+
+async function readLastUsed(
+  session: Awaited<ReturnType<typeof createMemoryFixture>>["session"],
+  ids: string[],
+): Promise<Record<string, number>> {
+  const result = await session.withDb(async (db) =>
+    db.query<{ id: string; last_used_at: number }>(
+      "SELECT id, last_used_at FROM observations WHERE id = ANY($1::text[])",
+      [ids],
+    ),
+  );
+  const out: Record<string, number> = {};
+  for (const row of result?.rows ?? []) {
+    out[row.id] = row.last_used_at;
+  }
+  return out;
+}

--- a/src/memory/observational-prompts.ts
+++ b/src/memory/observational-prompts.ts
@@ -177,6 +177,8 @@ export function buildObserverOutputFormat(includeThreadTitle = false): string {
     usedObservationIds:
     The existing observations block above lists prior cross-session memories with explicit \`[memory id: mem_xxx]\` markers. If the assistant's response in this exchange leaned on one or more of those memories — referenced facts, preferences, prior decisions, or context drawn from them — list the matching ids here. Omit or return [] when no prior memory was actually used. Only cite ids that appear verbatim in the markers above; do not invent ids.
 
+    CRITICAL — ONE CITATION PER FACT: When several existing memories describe the SAME underlying fact, decision, preference, or piece of context, cite only the single BEST representative — never every duplicate. The "best" memory is the one that is most specific, highest priority, and most recently observed (in that order). Listing every overlapping id uniformly refreshes stale and vague duplicates and breaks the freshness-decay ranking. If two memories independently informed the response on DIFFERENT facts, cite both. If they say the same thing in different words, cite only the strongest one and let the duplicates decay.
+
     suggestedContinuation:
     Hint for the agent's immediate next message. If the assistant needs to respond to the user, say that it should pause for user reply before continuing other tasks.
     ${threadTitleSection}

--- a/src/memory/observational.ts
+++ b/src/memory/observational.ts
@@ -236,7 +236,7 @@ const observerResultSchema = Type.Object({
   usedObservationIds: Type.Optional(
     Type.Array(Type.String(), {
       description:
-        "Ids of prior memories from the [memory id: mem_...] markers in the existing observations block whose content actually informed the assistant's response in this exchange. Drives the lastUsedAt freshness signal so reused memories keep surfacing. Omit or return [] when no prior memory was leaned on.",
+        "Ids of prior memories from the [memory id: mem_...] markers in the existing observations block whose content actually informed the assistant's response in this exchange. Drives the lastUsedAt freshness signal so reused memories keep surfacing. When multiple existing memories describe the same fact, cite only the single best one (most specific, highest priority, most recent) — never every duplicate, otherwise stale duplicates get uniformly refreshed and decay-ranking breaks. Omit or return [] when no prior memory was leaned on.",
     }),
   ),
   currentTask: Type.Optional(


### PR DESCRIPTION
When the assistant leans on a fact that multiple existing memories describe, the observer was citing every overlapping memory id in `usedObservationIds`. That uniformly refreshes stale and vague duplicates and breaks the `last_used_at` freshness-decay ranking.

## Fix
- Tighten the `usedObservationIds` section of the observer prompt (`src/memory/observational-prompts.ts`) with an explicit "one citation per fact" rule: when several memories describe the same underlying fact, cite only the single best representative (most specific, highest priority, most recent) — never every duplicate.
- Mirror the same rule in the structured-output schema description in `src/memory/observational.ts` so the tool itself nudges the observer.

## Eval (red/green TDD)
New live-model eval `evals/observer-best-of-duplicates.eval.ts`:
- Seeds three overlapping memories about the same deploy command (`pnpm deploy:prod`) at different specificity/priority/age, plus an unrelated decoy.
- Runs a real exchange that uses the fact.
- Asserts only the best memory's `last_used_at` advances; the two duplicates and the decoy stay at the seeded backdate.

Red without the prompt change (observer was citing all three duplicates), green with it.

## Validation
- `bun run check-types` ✅
- Lint ✅