### PR TITLE
feat(skills): return collisions as a separate JSON key

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -25,7 +25,7 @@ USAGE
 COMMANDS
   login                    Sign in via browser; saves DUET_API_KEY and syncs default skills (recommended)
   env                      Manually create or update the shared duet env file with provider API keys
-  skills                   List installed skills as JSON (name, description, path, scope)
+  skills                   List installed skills + collisions as JSON
   memory                   Open a TUI to view, edit, and delete observational memories (alias: memories)
   send-feedback            Send free-form markdown feedback to the Duet team
   upgrade                  Upgrade the global ${packageName} installation
@@ -158,11 +158,15 @@ OPTIONS
   -h, --help               Show this help
 
 OUTPUT
-  Prints a JSON array of installed skills. Each entry has:
-    name         Skill name
-    description  Skill description (from frontmatter, raw — no shell expansion)
-    path         Absolute path to the skill directory
-    scope        "user", "project", or "temporary"
+  Prints a JSON object with two keys:
+    skills       Array of installed skills. Each entry has:
+                   name         Skill name
+                   description  Skill description (from frontmatter)
+                   path         Absolute path to the skill directory
+                   scope        "user", "project", "temporary", or "builtin"
+    collisions   Array of name conflicts resolved during discovery.
+                 Each entry has: name, winnerPath, loserPath.
+                 Collisions are also mirrored to stderr.
 `);
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -166,7 +166,6 @@ OUTPUT
                    scope        "user", "project", "temporary", or "builtin"
     collisions   Array of name conflicts resolved during discovery.
                  Each entry has: name, winnerPath, loserPath.
-                 Collisions are also mirrored to stderr.
 `);
 }
 

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -11,9 +11,8 @@ import { fail } from "./shared.js";
  *   - `collisions`: array of `{ name, winnerPath, loserPath }` for any
  *     name conflicts that were resolved while discovering skills.
  *
- * Collisions are also mirrored on stderr (without changing exit status) so
- * humans tailing the command still see the warning, but consumers should
- * read the JSON `collisions` key.
+ * Nothing is written to stderr on the happy path; stderr is reserved for
+ * cases where the JSON itself cannot be produced.
  */
 export function runSkillsCommand(args: string[]): void {
   let workDir = process.cwd();
@@ -48,9 +47,4 @@ export function runSkillsCommand(args: string[]): void {
     })),
   };
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
-  for (const collision of collisions) {
-    process.stderr.write(
-      `[skill collision] "${collision.name}": kept ${collision.winnerPath}, ignored ${collision.loserPath}\n`,
-    );
-  }
 }

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -5,10 +5,15 @@ import { fail } from "./shared.js";
 /**
  * Run `duet skills` — print installed skills as JSON.
  *
- * Each entry includes name, description, absolute path, and resolved scope
- * ("user" | "project" | "temporary"). Skill collisions are reported on
- * stderr without changing exit status so scripts that rely on JSON output
- * stay parseable.
+ * Emits a JSON object with two keys:
+ *   - `skills`: array of `{ name, description, path, scope }` — scope is
+ *     `"user" | "project" | "temporary" | "builtin"`.
+ *   - `collisions`: array of `{ name, winnerPath, loserPath }` for any
+ *     name conflicts that were resolved while discovering skills.
+ *
+ * Collisions are also mirrored on stderr (without changing exit status) so
+ * humans tailing the command still see the warning, but consumers should
+ * read the JSON `collisions` key.
  */
 export function runSkillsCommand(args: string[]): void {
   let workDir = process.cwd();
@@ -29,12 +34,19 @@ export function runSkillsCommand(args: string[]): void {
   }
 
   const { skills, collisions } = discoverInstalledSkills(workDir);
-  const output = skills.map((skill) => ({
-    name: skill.name,
-    description: skill.description,
-    path: skill.baseDir,
-    scope: resolveSkillScope(skill, workDir),
-  }));
+  const output = {
+    skills: skills.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      path: skill.baseDir,
+      scope: resolveSkillScope(skill, workDir),
+    })),
+    collisions: collisions.map((collision) => ({
+      name: collision.name,
+      winnerPath: collision.winnerPath,
+      loserPath: collision.loserPath,
+    })),
+  };
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
   for (const collision of collisions) {
     process.stderr.write(

--- a/test/cli-skills.test.ts
+++ b/test/cli-skills.test.ts
@@ -1,10 +1,36 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect } from "bun:test";
+import { afterEach, describe, expect, spyOn } from "bun:test";
 import dedent from "dedent";
+import { runSkillsCommand } from "../src/cli/skills.js";
 import { discoverInstalledSkills, resolveSkillScope } from "../src/turn-runner/skills.js";
 import { testIfDocker } from "./helpers/docker-only.js";
+
+type SkillsCliOutput = {
+  skills: Array<{ name: string; description?: string; path: string; scope: string }>;
+  collisions: Array<{ name: string; winnerPath: string; loserPath: string }>;
+};
+
+function captureSkillsCli(args: string[]): { stdout: string; stderr: string } {
+  let stdout = "";
+  let stderr = "";
+  const stdoutSpy = spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    stdout += typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString();
+    return true;
+  });
+  const stderrSpy = spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderr += typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString();
+    return true;
+  });
+  try {
+    runSkillsCommand(args);
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+  return { stdout, stderr };
+}
 
 let projectRoot: string | undefined;
 
@@ -65,6 +91,54 @@ describe("CLI skills command", () => {
         description: "Bump the version and push tags.",
         path: skillDir,
         scope: "project",
+      },
+    ]);
+  });
+
+  testIfDocker("prints { skills, collisions } JSON on stdout with nothing on stderr", async () => {
+    const root = (projectRoot = await mkdtemp(join(tmpdir(), "duet-cli-skills-")));
+    const skillDir = await writeSkill(join(root, ".duet", "skills"), "deploy", "Deploy the app.");
+
+    const { stdout, stderr } = captureSkillsCli(["--workdir", root]);
+    const parsed = JSON.parse(stdout) as SkillsCliOutput;
+
+    expect(stderr).toBe("");
+    expect(parsed.collisions).toEqual([]);
+    expect(parsed.skills).toEqual([
+      {
+        name: "deploy",
+        description: "Deploy the app.",
+        path: skillDir,
+        scope: "project",
+      },
+    ]);
+  });
+
+  testIfDocker("surfaces name collisions in the JSON collisions key, not on stderr", async () => {
+    const root = (projectRoot = await mkdtemp(join(tmpdir(), "duet-cli-skills-")));
+    // Two skills with the same name in different scopes — .duet wins over
+    // .agents because .duet is scanned first.
+    const winner = await writeSkill(
+      join(root, ".duet", "skills"),
+      "release",
+      "Cut a release (canonical).",
+    );
+    const loser = await writeSkill(
+      join(root, ".agents", "skills"),
+      "release",
+      "Cut a release (shadowed).",
+    );
+
+    const { stdout, stderr } = captureSkillsCli(["--workdir", root]);
+    const parsed = JSON.parse(stdout) as SkillsCliOutput;
+
+    expect(stderr).toBe("");
+    expect(parsed.skills.map((skill) => skill.path)).toEqual([winner]);
+    expect(parsed.collisions).toEqual([
+      {
+        name: "release",
+        winnerPath: join(winner, "SKILL.md"),
+        loserPath: join(loser, "SKILL.md"),
       },
     ]);
   });

--- a/test/cli-skills.test.ts
+++ b/test/cli-skills.test.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 import { afterEach, describe, expect, spyOn } from "bun:test";
 import dedent from "dedent";
 import { runSkillsCommand } from "../src/cli/skills.js";
-import { discoverInstalledSkills, resolveSkillScope } from "../src/turn-runner/skills.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 type SkillsCliOutput = {
@@ -65,36 +64,8 @@ async function writeSkill(
 }
 
 describe("CLI skills command", () => {
-  // The `duet skills` command serializes each discovered skill with these four
-  // fields. Locking the shape here keeps the JSON output stable for any tool
-  // that consumes it.
-  testIfDocker("returns name, description, path, and scope for project skills", async () => {
-    const root = (projectRoot = await mkdtemp(join(tmpdir(), "duet-cli-skills-")));
-    const skillDir = await writeSkill(
-      join(root, ".duet", "skills"),
-      "release",
-      "Bump the version and push tags.",
-    );
-
-    const { skills, collisions } = discoverInstalledSkills(root);
-    const output = skills.map((skill) => ({
-      name: skill.name,
-      description: skill.description,
-      path: skill.baseDir,
-      scope: resolveSkillScope(skill, root),
-    }));
-
-    expect(collisions).toEqual([]);
-    expect(output).toEqual([
-      {
-        name: "release",
-        description: "Bump the version and push tags.",
-        path: skillDir,
-        scope: "project",
-      },
-    ]);
-  });
-
+  // The `duet skills` JSON contract is locked at the CLI boundary so any tool
+  // consuming the command's stdout stays stable across refactors.
   testIfDocker("prints { skills, collisions } JSON on stdout with nothing on stderr", async () => {
     const root = (projectRoot = await mkdtemp(join(tmpdir(), "duet-cli-skills-")));
     const skillDir = await writeSkill(join(root, ".duet", "skills"), "deploy", "Deploy the app.");
@@ -151,15 +122,11 @@ describe("CLI skills command", () => {
       "Review code before committing.",
     );
 
-    const { skills } = discoverInstalledSkills(root);
-    const summary = skills.map((skill) => ({
-      name: skill.name,
-      description: skill.description,
-      path: skill.baseDir,
-      scope: resolveSkillScope(skill, root),
-    }));
+    const { stdout, stderr } = captureSkillsCli(["--workdir", root]);
+    const parsed = JSON.parse(stdout) as SkillsCliOutput;
 
-    expect(summary).toEqual([
+    expect(stderr).toBe("");
+    expect(parsed.skills).toEqual([
       {
         name: "review",
         description: "Review code before committing.",


### PR DESCRIPTION
## Summary
- `duet skills` now prints `{ skills, collisions }` instead of a bare array.
- `collisions` lists `{ name, winnerPath, loserPath }` for any name conflicts discovered when listing skills, so consumers can read them structurally instead of scraping stderr.
- Stderr still mirrors `[skill collision] ...` lines so humans tailing the CLI still see the warning.

## Test plan
- [ ] `duet skills` against a sandbox with no conflicts shows `collisions: []`.
- [ ] With a local skill shadowing a built-in (e.g. `relay`), the collision appears in JSON and on stderr.