### PR TITLE
fix(test): filter built-in relay skill in skill-discovery tests

### DIFF
--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -487,7 +487,7 @@ describe("TurnRunner skills", () => {
       body: "# Code Review\n\nPrefer direct imports and avoid thin wrappers.",
     });
 
-    const skills = await app.runner.getSkills();
+    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
 
     expect(skills).toHaveLength(1);
     expect(skills[0]).toMatchObject({
@@ -506,7 +506,7 @@ describe("TurnRunner skills", () => {
       body: "# Standard Review\n\nUse the standard project skill.",
     });
 
-    const skills = await app.runner.getSkills();
+    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
 
     expect(skills.map((skill) => skill.name)).toEqual(["standard-review"]);
     expect(skills[0]).toMatchObject({
@@ -528,7 +528,7 @@ describe("TurnRunner skills", () => {
       body: "# Agent Review\n\nUse the standard project skill.",
     });
 
-    const skills = await app.runner.getSkills();
+    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
 
     expect(skills.map((skill) => skill.name)).toEqual(["duet-docs", "agent-review"]);
     expect(skills).toContainEqual(
@@ -555,7 +555,7 @@ describe("TurnRunner skills", () => {
       body: "# Release Notes\n\nSummarize user-visible changes.",
     });
 
-    const skills = await app.runner.getSkills();
+    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
     expect(skills.map((skill) => skill.name)).toEqual(["release-notes"]);
     expect(skills[0]).toMatchObject({
       description: "Draft concise release notes from completed work.",
@@ -571,7 +571,7 @@ describe("TurnRunner skills", () => {
       body: "# Standard Release Notes\n\nSummarize user-visible changes.",
     });
 
-    const skills = await app.runner.getSkills();
+    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
 
     expect(skills.map((skill) => skill.name)).toEqual(["standard-release-notes"]);
     expect(skills[0]).toMatchObject({
@@ -588,7 +588,7 @@ describe("TurnRunner skills", () => {
       body: "# Browser QA\n\nSession quick browser checks.",
     });
 
-    const skills = await app.runner.getSkills();
+    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
 
     expect(skills.map((skill) => skill.description)).toEqual([
       "Fast headless browser for QA testing.\nUse when checking UI flows.\n",

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import type { Skill } from "@earendil-works/pi-coding-agent";
 import dedent from "dedent";
+import { isBuiltInSkill } from "../src/turn-runner/built-in-skills.js";
 import { TurnRunner } from "../src/turn-runner/turn-runner.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 import { createTurnRunner, startTurn } from "./helpers/turn-runner-protocol.js";
@@ -487,7 +488,7 @@ describe("TurnRunner skills", () => {
       body: "# Code Review\n\nPrefer direct imports and avoid thin wrappers.",
     });
 
-    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
+    const skills = (await app.runner.getSkills()).filter((s) => !isBuiltInSkill(s));
 
     expect(skills).toHaveLength(1);
     expect(skills[0]).toMatchObject({
@@ -506,7 +507,7 @@ describe("TurnRunner skills", () => {
       body: "# Standard Review\n\nUse the standard project skill.",
     });
 
-    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
+    const skills = (await app.runner.getSkills()).filter((s) => !isBuiltInSkill(s));
 
     expect(skills.map((skill) => skill.name)).toEqual(["standard-review"]);
     expect(skills[0]).toMatchObject({
@@ -528,7 +529,7 @@ describe("TurnRunner skills", () => {
       body: "# Agent Review\n\nUse the standard project skill.",
     });
 
-    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
+    const skills = (await app.runner.getSkills()).filter((s) => !isBuiltInSkill(s));
 
     expect(skills.map((skill) => skill.name)).toEqual(["duet-docs", "agent-review"]);
     expect(skills).toContainEqual(
@@ -555,7 +556,7 @@ describe("TurnRunner skills", () => {
       body: "# Release Notes\n\nSummarize user-visible changes.",
     });
 
-    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
+    const skills = (await app.runner.getSkills()).filter((s) => !isBuiltInSkill(s));
     expect(skills.map((skill) => skill.name)).toEqual(["release-notes"]);
     expect(skills[0]).toMatchObject({
       description: "Draft concise release notes from completed work.",
@@ -571,7 +572,7 @@ describe("TurnRunner skills", () => {
       body: "# Standard Release Notes\n\nSummarize user-visible changes.",
     });
 
-    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
+    const skills = (await app.runner.getSkills()).filter((s) => !isBuiltInSkill(s));
 
     expect(skills.map((skill) => skill.name)).toEqual(["standard-release-notes"]);
     expect(skills[0]).toMatchObject({
@@ -588,7 +589,7 @@ describe("TurnRunner skills", () => {
       body: "# Browser QA\n\nSession quick browser checks.",
     });
 
-    const skills = (await app.runner.getSkills()).filter((s) => s.name !== "relay");
+    const skills = (await app.runner.getSkills()).filter((s) => !isBuiltInSkill(s));
 
     expect(skills.map((skill) => skill.description)).toEqual([
       "Fast headless browser for QA testing.\nUse when checking UI flows.\n",


### PR DESCRIPTION
CI on main started failing after the built-in `/relay` skill landed (#35). `runner.getSkills()` now includes the built-in alongside discovered ones, so the 6 skill-discovery tests that asserted exact length/array equality broke.

Fix: filter `relay` out of `getSkills()` results in those assertions. All 16 skills tests pass under the docker runner.