### PR TITLE
feat(prompt): advertise session state.json path to the agent

### DIFF
--- a/evals/session-state-file-prompt.eval.ts
+++ b/evals/session-state-file-prompt.eval.ts
@@ -1,0 +1,119 @@
+import { describe, expect } from "bun:test";
+import dedent from "dedent";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TurnEvent } from "../src/types/protocol.js";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+const model = process.env.EVAL_MODEL ?? "sonnet-4.6";
+
+/**
+ * The base system prompt grows a `<session_state_file>` layer right after
+ * `<cwd>` that hands the agent the absolute path to its own `state.json`.
+ * This eval drives the production CLI in non-TTY JSONL mode (the same path
+ * `duet "<prompt>" | jq` exercises) and verifies the agent can read the
+ * path back verbatim from its system prompt. We also assert the file
+ * actually exists on disk so a future regression that leaks a stale or
+ * synthesized path would fail loudly.
+ */
+describe("session state file system prompt layer", () => {
+  testIfDocker(
+    "advertises the session state.json path via the CLI JSON event stream",
+    async () => {
+      const homeDir = await mkdtemp(join(tmpdir(), "duet-session-state-home-"));
+      const workDir = await mkdtemp(join(tmpdir(), "duet-session-state-work-"));
+      try {
+        const result = await runCliEvents(
+          [
+            "--workdir",
+            workDir,
+            "--incognito",
+            "--no-skill-sync",
+            "--model",
+            model,
+            dedent`
+              Look at the <session_state_file> block in your system prompt.
+              Reply with exactly one line of the form:
+
+              STATE_FILE=<absolute path>
+
+              where <absolute path> is the value of the "Session state file:"
+              path verbatim. Do not add punctuation, markdown, quoting, or any
+              other words.
+            `,
+          ],
+          { HOME: homeDir },
+        );
+
+        expect(result.exitCode, `CLI exited ${result.exitCode}. stderr=\n${result.stderr}`).toBe(0);
+        const terminal = findLastTerminal(result.events);
+        expect(terminal?.type, `Expected complete terminal. stderr=\n${result.stderr}`).toBe(
+          "complete",
+        );
+        const reply =
+          terminal?.type === "complete" && terminal.result ? terminal.result.trim() : "";
+        const match = reply.match(/STATE_FILE=(.+\/state\.json)\s*$/m);
+        expect(match, `Expected STATE_FILE=<path>/state.json, got: ${reply}`).toBeTruthy();
+        const path = match![1]!;
+        // The advertised path must live under the temp HOME's session
+        // storage and must actually exist on disk after the run.
+        expect(path.startsWith(join(homeDir, ".duet", "sessions"))).toBe(true);
+        expect(path.endsWith("/state.json")).toBe(true);
+        await access(path);
+      } finally {
+        await rm(homeDir, { recursive: true, force: true });
+        await rm(workDir, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+});
+
+async function runCliEvents(
+  args: string[],
+  envOverrides: Record<string, string> = {},
+): Promise<{ exitCode: number; stdout: string; stderr: string; events: TurnEvent[] }> {
+  const proc = Bun.spawn(["bun", "src/cli.ts", ...args], {
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      // Suppress the on-load default-skill sync so the eval only exercises
+      // the base system prompt, not the skills layer.
+      ...envOverrides,
+    },
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr, events: parseJsonEvents(stdout) };
+}
+
+function parseJsonEvents(stdout: string): TurnEvent[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as TurnEvent);
+}
+
+function findLastTerminal(
+  events: TurnEvent[],
+): Extract<TurnEvent, { type: "complete" | "ask" | "interrupted" | "sleep" }> | undefined {
+  for (let index = events.length - 1; index >= 0; index--) {
+    const event = events[index];
+    if (
+      event?.type === "complete" ||
+      event?.type === "ask" ||
+      event?.type === "interrupted" ||
+      event?.type === "sleep"
+    ) {
+      return event;
+    }
+  }
+  return undefined;
+}

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -172,7 +172,10 @@ export class Session {
       new TurnRunner({
         ...config,
         sessionId: options.id,
-        sessionStatePath: join(this.sessionPath, "state.json"),
+        // Prompt-layer hint only. Session owns the file; the runner just
+        // advertises this path to the agent so it can read its own raw
+        // chat history when needed.
+        advertisedSessionStatePath: join(this.sessionPath, "state.json"),
       });
     this.unsubscribeRunner = this.runner.subscribe((event) => void this.handleTurnEvent(event));
   }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -166,8 +166,14 @@ export class Session {
     // observer/reflector write are tagged with this session. The memory
     // loader uses session id to separate local memory (this session) from
     // global memory (every other session, ranked into a budget).
-    this.runner = options.runner ?? new TurnRunner({ ...config, sessionId: options.id });
     this.sessionPath = options.sessionPath;
+    this.runner =
+      options.runner ??
+      new TurnRunner({
+        ...config,
+        sessionId: options.id,
+        sessionStatePath: join(this.sessionPath, "state.json"),
+      });
     this.unsubscribeRunner = this.runner.subscribe((event) => void this.handleTurnEvent(event));
   }
 

--- a/src/turn-runner/prompts.ts
+++ b/src/turn-runner/prompts.ts
@@ -14,10 +14,10 @@ function cwdSystemPrompt(cwd: string): string {
   `;
 }
 
-function sessionStateSystemPrompt(sessionStatePath: string): string {
+function sessionStateSystemPrompt(advertisedSessionStatePath: string): string {
   return dedent`
     <session_state_file>
-    Session state file: ${sessionStatePath}.
+    Session state file: ${advertisedSessionStatePath}.
     This JSON file contains your session's raw, untruncated chat history (every turn, tool call, and tool result the runner has persisted). If you ever need to inspect what was actually said earlier in this session — beyond the summarized context already in your prompt — read this file directly (e.g. \`read\` or \`jq\` it). Do not write to it.
     </session_state_file>
   `;
@@ -56,8 +56,8 @@ export function createSystemPromptWithAppendedLayers(input: {
     ...input.systemPromptFiles,
     TOOL_EXECUTION_SYSTEM_PROMPT,
     cwdSystemPrompt(input.config.cwd ?? process.cwd()),
-    input.config.sessionStatePath
-      ? sessionStateSystemPrompt(input.config.sessionStatePath)
+    input.config.advertisedSessionStatePath
+      ? sessionStateSystemPrompt(input.config.advertisedSessionStatePath)
       : undefined,
     createSkillsSystemPrompt(input.skills),
     ...input.append,

--- a/src/turn-runner/prompts.ts
+++ b/src/turn-runner/prompts.ts
@@ -14,6 +14,15 @@ function cwdSystemPrompt(cwd: string): string {
   `;
 }
 
+function sessionStateSystemPrompt(sessionStatePath: string): string {
+  return dedent`
+    <session_state_file>
+    Session state file: ${sessionStatePath}.
+    This JSON file contains your session's raw, untruncated chat history (every turn, tool call, and tool result the runner has persisted). If you ever need to inspect what was actually said earlier in this session — beyond the summarized context already in your prompt — read this file directly (e.g. \`read\` or \`jq\` it). Do not write to it.
+    </session_state_file>
+  `;
+}
+
 function currentDateSystemPrompt(): string {
   // Day-level resolution keeps the prompt stable for the whole UTC day so prompt
   // caching is not invalidated on every turn. Agents that need finer-grained
@@ -47,6 +56,9 @@ export function createSystemPromptWithAppendedLayers(input: {
     ...input.systemPromptFiles,
     TOOL_EXECUTION_SYSTEM_PROMPT,
     cwdSystemPrompt(input.config.cwd ?? process.cwd()),
+    input.config.sessionStatePath
+      ? sessionStateSystemPrompt(input.config.sessionStatePath)
+      : undefined,
     createSkillsSystemPrompt(input.skills),
     ...input.append,
     currentDateSystemPrompt(),

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -42,13 +42,17 @@ export interface TurnRunnerConfig extends TurnOptions {
   memoryDbPath?: string | false;
   cwd?: string;
   /**
-   * Absolute path to this session's persisted `state.json` on disk. The runner
-   * advertises it in the system prompt so the agent can read its own raw
-   * chat history if it needs to. Set by `Session` from its owned
-   * `sessionPath`; unset for direct TurnRunner construction (tests, one-shot
-   * tools) that has no persisted session file.
+   * Advertised in the system prompt as the path the agent can read to
+   * inspect its own raw chat history. The TurnRunner does NOT read, write,
+   * or otherwise manage this file — it only echoes the value into the
+   * `<session_state_file>` prompt layer. The file itself is owned and
+   * persisted by `Session` (which writes `state.json` inside its
+   * `sessionPath`), so this config is purely an out-of-band hint pointing
+   * the agent at that path. Unset for direct TurnRunner construction
+   * (tests, one-shot tools, `duet --rpc`) where no persisted session file
+   * exists; the prompt layer is omitted in that case.
    */
-  sessionStatePath?: string;
+  advertisedSessionStatePath?: string;
   /** Default mode for TurnRunner.turn. "auto" lets the runner classify each prompt. */
   mode?: TurnMode;
   guardrails?: GuardrailConfig[];

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -41,6 +41,14 @@ export interface TurnRunnerConfig extends TurnOptions {
    */
   memoryDbPath?: string | false;
   cwd?: string;
+  /**
+   * Absolute path to this session's persisted `state.json` on disk. The runner
+   * advertises it in the system prompt so the agent can read its own raw
+   * chat history if it needs to. Set by `Session` from its owned
+   * `sessionPath`; unset for direct TurnRunner construction (tests, one-shot
+   * tools) that has no persisted session file.
+   */
+  sessionStatePath?: string;
   /** Default mode for TurnRunner.turn. "auto" lets the runner classify each prompt. */
   mode?: TurnMode;
   guardrails?: GuardrailConfig[];


### PR DESCRIPTION
## What

Adds a new `<session_state_file>` layer to the base system prompt, placed immediately after `<cwd>`, that hands the agent the absolute path to its own `state.json`. The instruction tells the agent it can read that file directly (e.g. `read` / `jq` it) to inspect its raw, untruncated chat history if it ever needs to look beyond the summarized context in the prompt.

## How

- **`TurnRunnerConfig.sessionStatePath`** — new optional field.
- **`Session`** — passes `<sessionPath>/state.json` into the owned `TurnRunner`.
- **`prompts.ts`** — emits the new layer only when `sessionStatePath` is set, so direct `TurnRunner` callers without a persisted session (tests, `duet --rpc` mode) cleanly omit the layer.

## Tests

New eval `evals/session-state-file-prompt.eval.ts` drives the production CLI in non-TTY JSONL mode (`bun src/cli.ts --workdir <tmp> --incognito --model <m> "..."`), parses the `complete` event off stdout, asserts the agent echoes `STATE_FILE=<path>` verbatim from its system prompt, and confirms the file actually exists on disk under the temp HOME's session storage.

```
bun test ./evals/session-state-file-prompt.eval.ts
(pass) advertises the session state.json path via the CLI JSON event stream [4650.86ms]
1 pass · 0 fail
```

Also clean: `tsc --noEmit`, `oxlint`, `bun test test/` (561 pass / 262 skip).