### PR TITLE
tighten create_state_machine_definition description + repro eval

### DIFF
--- a/evals/state-machine-tool-call-shape.eval.ts
+++ b/evals/state-machine-tool-call-shape.eval.ts
@@ -1,0 +1,130 @@
+import { describe, expect } from "bun:test";
+import dedent from "dedent";
+import { TurnRunner } from "../src/turn-runner/turn-runner.js";
+import type { TurnEvent } from "../src/types/protocol.js";
+import { startTurn } from "../test/helpers/turn-runner-protocol.js";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+const model = process.env.EVAL_MODEL ?? "sonnet-4.6";
+
+/**
+ * Regression eval for the malformed-first-call bug.
+ *
+ * Observed in a real Duet session (channel j97crd89eb3gq08jm73fsbnehs7s5vv0,
+ * 2026-05-18): the model invoked `create_state_machine_definition` with
+ * `input: {}` on the first try, got a validation error
+ * (`definition: must have required properties definition`), then immediately
+ * retried with the correct nested payload. The retry succeeded but the wasted
+ * round-trip surfaces every time the model picks the state-machine tool.
+ *
+ * Hypothesis: the tool description is an outlier in length (~1.5K words) with
+ * zero call-shape example. The wrapper (`{ definition: {...}, firstState? }`)
+ * is non-obvious — most other tools put meaningful fields at the top level —
+ * so the model occasionally serializes the call before the body is ready, or
+ * "flattens" the wrapper and emits an empty object.
+ *
+ * This eval reproduces the exact triggering shape (short user prompt that
+ * lands a real fix into a dev worktree → naturally routes through the state
+ * machine) and asserts the FIRST `create_state_machine_definition` call
+ * carries a populated `definition`, every trial.
+ */
+// Mirror the real session: short message with only the regression context
+// the parent channel surfaced. Keeping it terse is on purpose — the original
+// trigger was literally "pls fix" with screenshot context, and longer
+// prompts may pre-warm the model away from the streaming malforms.
+const TRIGGER_PROMPT = dedent`
+  Recent context: PR #1356 just bumped the compose-bar input min-height and
+  vertical padding in apps/web/components/chat/compose-bar/primitives/input/compose-bar-input.tsx.
+  Now the textarea is too tall and looks even worse with image attachments.
+
+  pls fix — revert that file to the pre-#1356 values, validate, and open a
+  PR against staging.
+`;
+
+const EVAL_INSTRUCTIONS = dedent`
+  You are in a planning-only eval. Do not read, edit, or run anything in
+  the real codebase. Use exactly one planning tool to register a plan that
+  matches the user's request. If you create a state machine, define a
+  terminal state named "eval_done" with status "completed" and pass
+  firstState "eval_done" so no real work runs. After the planning tool
+  call, respond with exactly: PLAN_REGISTERED
+`;
+
+interface CapturedCall {
+  toolCallId: string;
+  status: "running" | "completed" | "error";
+  input?: unknown;
+}
+
+async function runOnce(): Promise<CapturedCall[]> {
+  const runner = new TurnRunner({
+    model,
+    mode: "auto",
+    skillDiscovery: { includeDefaults: false },
+    systemInstructions: EVAL_INSTRUCTIONS,
+  });
+
+  const calls: CapturedCall[] = [];
+  runner.subscribe((event: TurnEvent) => {
+    if (event.type !== "step") return;
+    const step = event.step;
+    if (step.type !== "tool_call") return;
+    if (step.toolName !== "create_state_machine_definition") return;
+    calls.push({
+      toolCallId: step.toolCallId,
+      status: step.status as CapturedCall["status"],
+      input: (step as { input?: unknown }).input,
+    });
+  });
+
+  const { turn } = await startTurn(runner, { mode: "auto", prompt: TRIGGER_PROMPT });
+  await turn;
+  return calls;
+}
+
+function firstAttemptShape(calls: CapturedCall[]): {
+  attempted: boolean;
+  empty: boolean;
+  hasDefinition: boolean;
+} {
+  const firstRunning = calls.find((c) => c.status === "running");
+  if (!firstRunning) return { attempted: false, empty: false, hasDefinition: false };
+  const input = firstRunning.input as Record<string, unknown> | undefined;
+  const empty = !input || Object.keys(input).length === 0;
+  const hasDefinition =
+    !!input && typeof input === "object" && "definition" in input && !!input.definition;
+  return { attempted: true, empty, hasDefinition };
+}
+
+describe("create_state_machine_definition call shape", () => {
+  // Trials per condition. Stochastic streaming bug — we want enough samples
+  // to catch ~10–30% repro rates without burning the eval budget. Each trial
+  // is ~$0.05–0.20 on sonnet-4.6 in planning-only mode.
+  const TRIALS = Number(process.env.EVAL_CALL_SHAPE_TRIALS ?? 3);
+
+  testIfDocker(
+    "first call carries a populated definition every trial",
+    async () => {
+      const failures: Array<{ trial: number; shape: ReturnType<typeof firstAttemptShape> }> = [];
+      let attemptedAny = false;
+
+      for (let trial = 1; trial <= TRIALS; trial++) {
+        const calls = await runOnce();
+        const shape = firstAttemptShape(calls);
+        if (shape.attempted) attemptedAny = true;
+        if (!shape.hasDefinition && shape.attempted) {
+          failures.push({ trial, shape });
+        }
+      }
+
+      // Make sure the eval is actually exercising the path we care about — if
+      // the model never reaches for the state-machine tool, the routing
+      // prompt has drifted and this eval is meaningless.
+      expect(attemptedAny).toBe(true);
+
+      // Every attempt's first call must carry a real definition wrapper.
+      expect(failures).toEqual([]);
+    },
+    600_000,
+  );
+});

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -357,41 +357,15 @@ const stateMachineDefinitionSchema = Type.Object(
   },
 );
 
-// `definition` is technically required, but we declare it as Optional in the
-// schema so the upstream tool validator (pi-ai) does not reject empty/malformed
-// calls with a generic "must have required properties definition" message.
-// Instead, our `execute()` runs, detects the missing wrapper, and throws a
-// retry-hint that includes the expected call shape — so the model's next
-// attempt is grounded rather than guessing. The CALL_SHAPE_HINT below is the
-// exact text returned as the tool result on that failure path.
 const createDefinitionSchema = Type.Object({
-  definition: Type.Optional(stateMachineDefinitionSchema),
+  definition: stateMachineDefinitionSchema,
   firstState: Type.Optional(
     Type.String({ description: "Optional state name to run first after creating the definition." }),
   ),
 });
 
 type CreateDefinitionParams = Static<typeof createDefinitionSchema>;
-type ToolStateMachineDefinition = NonNullable<CreateDefinitionParams["definition"]>;
-
-const CREATE_DEFINITION_CALL_SHAPE_HINT = [
-  "create_state_machine_definition requires a top-level `definition` wrapper. Top-level keys are `definition` and `firstState` ONLY — every state goes inside `definition.states`, never at the top level.",
-  "",
-  "Expected call shape:",
-  "{",
-  '  "definition": {',
-  '    "name": "<human-readable state-machine name>",',
-  '    "prompt": "<routing guidance for when this state machine applies>",',
-  '    "states": [',
-  '      { "name": "step-1", "kind": "agent", "prompt": "..." },',
-  '      { "name": "done", "kind": "terminal", "status": "completed" }',
-  "    ]",
-  "  },",
-  '  "firstState": "step-1"',
-  "}",
-  "",
-  "Retry with a populated `definition`.",
-].join("\n");
+type ToolStateMachineDefinition = CreateDefinitionParams["definition"];
 
 const selectStateSchema = Type.Object({
   decision: Type.Object(
@@ -941,14 +915,6 @@ function createStateMachineDefinitionTool(): AgentTool<typeof createDefinitionSc
     `,
     parameters: createDefinitionSchema,
     async execute(_toolCallId, params) {
-      // Retry-hint path: model sometimes serializes this tool call with an
-      // empty/malformed body (observed in production on long-context sessions).
-      // The TypeBox schema is intentionally permissive on `definition` so we
-      // can return a structured retry-hint here instead of the generic
-      // upstream validator message.
-      if (!params.definition) {
-        throw new Error(CREATE_DEFINITION_CALL_SHAPE_HINT);
-      }
       assertValidDefinition(params.definition);
       const result: TurnRunnerControlResult = {
         type: "create_state_machine_definition",

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -891,31 +891,27 @@ function createStateMachineDefinitionTool(): AgentTool<typeof createDefinitionSc
     name: "create_state_machine_definition",
     label: "Create state machine definition",
     description: dedent`
-      Create a state-machine definition for durable business-process work, or for any multi-step task whose steps are well-scoped enough that a sub-agent or script can complete each one on its own.
+      Create a new state-machine definition for durable, multi-step, or recurring work. See the system prompt for full routing rules (when to choose this over todo_write, how states resume, terminal acknowledgment, etc.). This description only covers the call shape.
 
-      Always create a state machine when the user asks for a recurring or unbounded task — anything shaped like "monitor X and do Y", "watch for X", "keep checking X until Y", "every N minutes/hours do X", or any work with no natural finish line in a single turn. Use a poll state for repeating checks (intervalMs) and a timer state for a single future wake (wakeAt). Once the parent turn ends, only state-machine work keeps running in the background; trying to handle these inline or with todo_write will simply stop when you reply.
+      Call shape (top-level keys are \`definition\` and \`firstState\` ONLY — every state goes inside \`definition.states\`, never at the top level):
+      {
+        "definition": {
+          "name": "<human-readable state-machine name>",
+          "prompt": "<routing guidance for when this state machine applies>",
+          "states": [
+            { "name": "step-1", "kind": "agent", "prompt": "..." },
+            { "name": "step-2", "kind": "script", "command": "..." },
+            { "name": "done", "kind": "terminal", "status": "completed" }
+          ]
+        },
+        "firstState": "step-1"
+      }
 
-      Also always create a state machine when the work is large enough that it would otherwise span multiple sessions. Concrete heuristic: if your plan has roughly seven or more items, or any single item is itself a multi-step job (an entire refactor phase, an entire module extraction, an entire test file to author, an entire batch of files to migrate), make one agent state per item instead of one todo per item. Agent and script states have no minimum duration — only poll intervalMs and timer wakeAt require 15 minutes — so a pure-agent state machine is the right shape for a large in-conversation refactor too, not just lifecycle work. If you are about to tell the user to "continue this in a fresh session" or "land the remaining phases later," you should have created a state machine of agent states up front; the work survives the session boundary on its own and you stay the orchestrator across it.
+      State \`kind\` is one of \`agent\`, \`script\`, \`poll\`, \`timer\`, \`terminal\`. Poll \`intervalMs\` and timer \`wakeAt\` must be ≥ 15 minutes; agent/script states have no minimum duration. Every definition needs at least one \`terminal\` state with status "completed"; "failed" and "cancelled" terminals are auto-injected if omitted.
 
-      Reach for this tool — not todo_write — whenever a step can be described as "do X with these inputs and return the result." Each agent state runs in a fresh sub-agent context, and each script/poll/timer state runs without an agent at all. Only a compact result returns to you, so the sub-agent's tool calls, file reads, and script output never pollute this transcript. That makes a state machine the primary way to keep the parent context clean on multi-step work. The definition, current state, and progress are also rendered to the user in real time, so it doubles as a visible plan — they can see which state is running, what came before, and what is waiting.
+      State prompts and script commands may use \`{{ input.foo }}\` templates — declare \`inputSchema\` on those states and pass matching \`input\` when selecting them via select_state_machine_state. Agent states may set \`allowedSkills\` to restrict the skill set for that sub-agent.
 
-      You stay the orchestrator: when each state finishes, the runner wakes you with its result so you can inspect the output and decide the next transition (select the next state, finalize with a terminal state, or hand back to the user). Sub-agents and scripts only do the per-state work; they do not pick what comes next.
-
-      State-machine work also keeps the user unblocked. While states execute in the background the user can keep sending messages and you (the parent) will respond without waiting for the state machine to finish. State-machine progress continues regardless of what you do in that side reply — by default just answer the user. Only call select_state_machine_state if the user actually wants to redirect or change the running work; questions, status checks, and side conversations should be answered with plain replies. A "steer" message arrives immediately as an interruption (right shape for redirects or anything time-sensitive); a "follow_up" message is queued and delivered when your current turn settles (right shape for context that does not need to interrupt). Doing the same multi-step work via todo_write would block the user behind your own tool calls instead.
-
-      Use todo_write instead only when you need to do the steps yourself in this conversation because you will keep reasoning over the intermediate output.
-
-      State prompts and script commands may use template strings such as {{ input.email }}; define inputSchema on those states and pass matching input when selecting them. Agent states may set allowedSkills to restrict which skills are injected into that sub-agent.
-
-      Poll states always run script attempts on a recurring intervalMs and fail the state machine when timeoutMs is exceeded. Timer states are separate: set kind "timer" with wakeAt as an absolute Unix epoch millisecond timestamp, and the state completes at that time so the parent can choose the next state.
-
-      Poll intervalMs must be at least 15 minutes (900000 ms), and timer wakeAt must be at least 15 minutes in the future. State machines are for long-running lifecycle work that benefits from sleep/wake/background execution. Anything shorter-term should run directly in your turn rather than through a state machine — the orchestration overhead is not worth it for sub-15-minute waits.
-
-      Every definition must include at least one terminal state with status "completed" representing the happy-path exit (success). The runner automatically adds terminal states named "failed" (status "failed") and "cancelled" (status "cancelled") if you do not define them, so you always have escape hatches for unrecoverable failure and user cancellation without specifying boilerplate terminals. You may still define your own "failed" or "cancelled" states (with reasons or different names) to override or supplement the auto-injected ones.
-
-      Every terminal — both the ones you select via select_state_machine_state and the ones the runner records when a state fails at runtime — wakes you one more time with the terminal details so you can summarize the outcome to the user and optionally start follow-up work via another create_state_machine_definition call. Plan terminal states with that in mind: name them meaningfully and use the \`reason\` field, because both flow into the acknowledgment prompt the parent sees.
-
-      Use this only when no state machine is active or the previous state machine has reached a terminal state; otherwise use select_state_machine_state.
+      Only use this when no state machine is active or the previous one has reached a terminal state; otherwise call select_state_machine_state.
     `,
     parameters: createDefinitionSchema,
     async execute(_toolCallId, params) {

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -357,15 +357,41 @@ const stateMachineDefinitionSchema = Type.Object(
   },
 );
 
+// `definition` is technically required, but we declare it as Optional in the
+// schema so the upstream tool validator (pi-ai) does not reject empty/malformed
+// calls with a generic "must have required properties definition" message.
+// Instead, our `execute()` runs, detects the missing wrapper, and throws a
+// retry-hint that includes the expected call shape — so the model's next
+// attempt is grounded rather than guessing. The CALL_SHAPE_HINT below is the
+// exact text returned as the tool result on that failure path.
 const createDefinitionSchema = Type.Object({
-  definition: stateMachineDefinitionSchema,
+  definition: Type.Optional(stateMachineDefinitionSchema),
   firstState: Type.Optional(
     Type.String({ description: "Optional state name to run first after creating the definition." }),
   ),
 });
 
 type CreateDefinitionParams = Static<typeof createDefinitionSchema>;
-type ToolStateMachineDefinition = CreateDefinitionParams["definition"];
+type ToolStateMachineDefinition = NonNullable<CreateDefinitionParams["definition"]>;
+
+const CREATE_DEFINITION_CALL_SHAPE_HINT = [
+  "create_state_machine_definition requires a top-level `definition` wrapper. Top-level keys are `definition` and `firstState` ONLY — every state goes inside `definition.states`, never at the top level.",
+  "",
+  "Expected call shape:",
+  "{",
+  '  "definition": {',
+  '    "name": "<human-readable state-machine name>",',
+  '    "prompt": "<routing guidance for when this state machine applies>",',
+  '    "states": [',
+  '      { "name": "step-1", "kind": "agent", "prompt": "..." },',
+  '      { "name": "done", "kind": "terminal", "status": "completed" }',
+  "    ]",
+  "  },",
+  '  "firstState": "step-1"',
+  "}",
+  "",
+  "Retry with a populated `definition`.",
+].join("\n");
 
 const selectStateSchema = Type.Object({
   decision: Type.Object(
@@ -915,6 +941,14 @@ function createStateMachineDefinitionTool(): AgentTool<typeof createDefinitionSc
     `,
     parameters: createDefinitionSchema,
     async execute(_toolCallId, params) {
+      // Retry-hint path: model sometimes serializes this tool call with an
+      // empty/malformed body (observed in production on long-context sessions).
+      // The TypeBox schema is intentionally permissive on `definition` so we
+      // can return a structured retry-hint here instead of the generic
+      // upstream validator message.
+      if (!params.definition) {
+        throw new Error(CREATE_DEFINITION_CALL_SHAPE_HINT);
+      }
       assertValidDefinition(params.definition);
       const result: TurnRunnerControlResult = {
         type: "create_state_machine_definition",

--- a/test/turn-runner-tools.test.ts
+++ b/test/turn-runner-tools.test.ts
@@ -146,33 +146,6 @@ describe("TurnRunner tools", () => {
     expect(result.content).toEqual([{ type: "text", text: JSON.stringify(details, null, 2) }]);
   });
 
-  test("empty-input call returns a retry-hint with the expected call shape", async () => {
-    const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "auto" });
-    const createDefinitionTool = tools.find(
-      (tool) => tool.name === "create_state_machine_definition",
-    );
-    expect(createDefinitionTool).toBeDefined();
-    if (!createDefinitionTool) throw new Error("create_state_machine_definition tool missing");
-
-    // Simulates the observed production bug where the model emits the tool
-    // call with an empty body. The schema is intentionally permissive on
-    // `definition` so the upstream validator passes the call through to our
-    // execute(), which then throws a structured hint the model can act on.
-    let caught: unknown;
-    try {
-      await createDefinitionTool.execute("tool-empty", {} as never);
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(Error);
-    const message = (caught as Error).message;
-    expect(message).toContain("requires a top-level `definition` wrapper");
-    expect(message).toContain("Expected call shape:");
-    expect(message).toContain('"firstState": "step-1"');
-    expect(message).toContain('"kind": "terminal"');
-    expect(message).toContain("Retry with a populated `definition`.");
-  });
-
   test("returns control decisions in tool details and model-visible content", async () => {
     const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "auto" });
     const createDefinitionTool = tools.find(

--- a/test/turn-runner-tools.test.ts
+++ b/test/turn-runner-tools.test.ts
@@ -996,9 +996,14 @@ describe("TurnRunner tools", () => {
     expect(selectStateTool).toBeDefined();
     if (!createDefinitionTool || !selectStateTool) throw new Error("Expected state-machine tools");
 
-    expect(createDefinitionTool.description).toContain("{{ input.email }}");
-    expect(createDefinitionTool.description).toContain('kind "timer"');
-    expect(createDefinitionTool.description).toContain("timeoutMs is exceeded");
+    // Smoke test: the trimmed description still surfaces the essentials
+    // (call-shape example with the `definition` wrapper, the template syntax,
+    // and the timer kind enum). Routing/policy guidance lives in the system
+    // prompt, not this description.
+    expect(createDefinitionTool.description).toContain("{{ input.foo }}");
+    expect(createDefinitionTool.description).toContain('"kind": "agent"');
+    expect(createDefinitionTool.description).toContain('"firstState"');
+    expect(createDefinitionTool.description).toContain("`timer`");
     expect(selectStateTool.description).toContain("input object");
     expect(selectStateTool.description).toContain("timer overrides");
     expect(propertyDescription(createDefinitionTool.parameters, "definition")).toContain(

--- a/test/turn-runner-tools.test.ts
+++ b/test/turn-runner-tools.test.ts
@@ -146,6 +146,33 @@ describe("TurnRunner tools", () => {
     expect(result.content).toEqual([{ type: "text", text: JSON.stringify(details, null, 2) }]);
   });
 
+  test("empty-input call returns a retry-hint with the expected call shape", async () => {
+    const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "auto" });
+    const createDefinitionTool = tools.find(
+      (tool) => tool.name === "create_state_machine_definition",
+    );
+    expect(createDefinitionTool).toBeDefined();
+    if (!createDefinitionTool) throw new Error("create_state_machine_definition tool missing");
+
+    // Simulates the observed production bug where the model emits the tool
+    // call with an empty body. The schema is intentionally permissive on
+    // `definition` so the upstream validator passes the call through to our
+    // execute(), which then throws a structured hint the model can act on.
+    let caught: unknown;
+    try {
+      await createDefinitionTool.execute("tool-empty", {} as never);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain("requires a top-level `definition` wrapper");
+    expect(message).toContain("Expected call shape:");
+    expect(message).toContain('"firstState": "step-1"');
+    expect(message).toContain('"kind": "terminal"');
+    expect(message).toContain("Retry with a populated `definition`.");
+  });
+
   test("returns control decisions in tool details and model-visible content", async () => {
     const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "auto" });
     const createDefinitionTool = tools.find(


### PR DESCRIPTION
## Summary

The `create_state_machine_definition` tool description was an outlier
(~1.5K words, ~10x neighbors) duplicating the state-machine routing
policy that already lives in the system prompt, and it never showed the
actual call shape. Observed bug: on a real session
([thread](https://duet.so/app/org/js7285zxk4ve021ak84zwh79yx7s58zg/chats/j97crd89eb3gq08jm73fsbnehs7s5vv0/thread/j971r9mqgp73t8z7z2k62as83h86yg4x))
the model invoked the tool with `input: {}`, got back
`definition: must have required properties definition`, and immediately
retried with the correct nested payload — wasted round-trip every time.

## What changed

- **`src/turn-runner/tools.ts`** — rewrote the tool description as a
  small "what to send" reference:
  - Concrete call-shape example showing the `{ definition, firstState }`
    wrapper and a multi-kind `states` array.
  - Explicit note that top-level keys are `definition` and `firstState`
    only (the wrapper is the part the model was flattening).
  - Kept only the hard constraints that aren't routing policy: state
    `kind` enum, ≥15-min floor on poll/timer, completed terminal
    required, template syntax with `inputSchema`.
  - Pushed all the "when to use this vs todo_write / how states resume /
    terminal acknowledgment" prose out — it's already in
    `src/turn-runner/prompts.ts` and the `relay` built-in skill.
- **`evals/state-machine-tool-call-shape.eval.ts`** (new) — mirrors the
  real short-prompt trigger ("pls fix" + brief regression context) and
  asserts the FIRST `create_state_machine_definition` call carries a
  populated `definition` every trial. Configurable via
  `EVAL_CALL_SHAPE_TRIALS` (default 3).
- **`test/turn-runner-tools.test.ts`** — updated the description
  smoke-test substrings to match the trimmed shape.

## Repro status

In 10 sonnet-4.6 trials against the old description I could not
reproduce the empty-input regression (the bug appears rare / depends on
the very long real-session system prompt). The fix is still applied
because:
1. The diagnosis is sound — long description + non-obvious wrapper +
   zero call-shape example is a clear bug surface.
2. The new description is shorter, more useful, and dedupes the system
   prompt.
3. The new eval guards against future regressions in either direction.

## Validation

- `bun test test/` — 411 pass, 0 fail
- `bun test ./evals/state-machine-routing.eval.ts` — 2 pass (routing
  decisions unchanged: still picks state machine for session-spanning
  work, still picks todo_write for tiny tasks)
- `bun test ./evals/state-machine-tool-call-shape.eval.ts` with
  `EVAL_CALL_SHAPE_TRIALS=10` — 10/10 first calls valid
- `bunx tsc --noEmit -p .` clean
- `bunx oxlint src/turn-runner/tools.ts` clean
- `bun format` clean