### PR TITLE
refactor(memory): drop suppressed param + narrative comments from #45

### DIFF
--- a/src/memory/observation-groups.ts
+++ b/src/memory/observation-groups.ts
@@ -75,7 +75,6 @@ export function wrapInObservationGroup(
   observations: string,
   range: string,
   id = generateAnchorId(),
-  _sourceGroupIds?: string[],
   kind?: string,
   cwd?: string,
 ): string {
@@ -235,14 +234,7 @@ export function reconcileObservationGroupsFromReflection(
   if (derivedGroups.length > 0) {
     return derivedGroups
       .map((group) =>
-        wrapInObservationGroup(
-          group.content,
-          group.range,
-          group.id,
-          undefined,
-          group.kind,
-          group.cwd,
-        ),
+        wrapInObservationGroup(group.content, group.range, group.id, group.kind, group.cwd),
       )
       .join("\n\n");
   }
@@ -256,7 +248,6 @@ export function reconcileObservationGroupsFromReflection(
     normalizedContent,
     combineObservationGroupRanges(sourceGroups),
     generateAnchorId(),
-    undefined,
     "reflection",
     inheritedCwd,
   );

--- a/src/memory/observational.ts
+++ b/src/memory/observational.ts
@@ -230,10 +230,9 @@ export interface ReflectorReflection {
 
 export interface ReflectorResult {
   /**
-   * Atomic reflection rows produced from the batch. The reflector must
-   * emit one row per durable insight rather than one giant blob; the
-   * global-prune path persists each as its own `Observation` so recall
-   * freshness can bump individual insights.
+   * Atomic reflection rows produced from the batch. The global-prune
+   * path persists each row as its own `Observation` so recall
+   * freshness can rank, decay, and refresh each insight independently.
    */
   reflections: ReflectorReflection[];
   /** Hint for the actor's next response after reflection rewrites memory. */
@@ -822,7 +821,6 @@ async function activateObservations(
       range,
       undefined,
       undefined,
-      undefined,
       args.cwd,
     ),
     tags: ["observational-memory"],
@@ -1248,11 +1246,11 @@ const MIN_REFLECTION_ROW_TOKENS = 120;
 
 /**
  * Run the reflector against one eligible batch and emit one
- * `Observation` per insight the model returned. The retry path used by
- * the single-blob reflector does not apply on the array shape — there
- * is no single "too long" condition that retrying with the same prompt
- * would fix — so this path enforces the budget by trimming each row to
- * a per-row token budget instead.
+ * `Observation` per insight the model returned. The token budget is
+ * enforced by trimming each row to its share of `targetTokens`: rows
+ * are independent insights, so retrying the whole batch when only one
+ * row is over budget would waste a model call without changing the
+ * other rows.
  */
 async function reflectBatch(args: {
   batch: ReflectionBatch;


### PR DESCRIPTION
Review followups on the merged #45.

- **`wrapInObservationGroup`** carried a `_sourceGroupIds?: string[]` parameter, prefixed with underscore to suppress the unused-arg warning. Every one of the three call sites passed `undefined`. Per the 'never suppress a signal — fix the root cause' rule, drop the parameter and update callers.
- Two doc-comments in `src/memory/observational.ts` described what the reflector *used to* produce ("rather than one giant blob", "the retry path used by the single-blob reflector does not apply on the array shape"). The current array shape is the only shape now, so the comments now state the current rule directly without narrating the pivot.

`bun run check-types` and `bun run lint` clean. Tests 636/637 (the one failure is the known pre-existing flaky `MemorySession concurrent fresh open` test, unrelated).