### PR TITLE
fix(tui): reload skills each time the slash picker opens

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -102,7 +102,15 @@ The most valuable test suite is the one most decoupled from the implementation i
 - **Coupled tests are a refactor tax.** When renaming an internal function or moving a module breaks dozens of tests without changing any user-visible behavior, the suite is testing the wrong layer. Rewrite those tests against the outer surface and delete the brittle ones.
 - **Reserve unit tests for genuinely tricky pure logic** — parsers, normalizers, schedulers, state machines with subtle invariants. Everything else earns more value as an integration or end-to-end test.
 
-## 14. Reuse existing types — derive, don't redeclare
+## 14. Gate filesystem-touching tests on `testIfDocker`
+
+- Tests that write real files, spawn subprocesses, mutate `$HOME`, or otherwise reach outside the process must use `testIfDocker` from `test/helpers/docker-only.js`, not bare `test`.
+- `testIfDocker` resolves to `test` when `DUET_TEST_IN_DOCKER=1` (inside the `oven/bun` test image) and `test.skip` everywhere else, so the same suite is safe to run on a contributor's laptop without polluting their host.
+- `os.tmpdir()` + `mkdirSync` / `writeFileSync` counts. So does anything that touches `~/.duet`, the home directory, the global skills root, or any path outside the test's own in-memory state.
+- If you find yourself reaching for `afterEach(rm)` to clean up a real directory, that's the signal — wrap the test in `testIfDocker` and let the container be the sandbox.
+- Pure-logic tests (parsers, reducers, in-memory data structures) stay on bare `test`; the gate is only for tests that escape the process boundary.
+
+## 15. Reuse existing types — derive, don't redeclare
 
 - If a type already exists upstream (SDK, protocol package, schema validator, generated client), use it directly. Don't redeclare its shape inline, even partially.
 - When you need a variant of an existing type — a subset of fields, an optional version, a union member, the args of a function — derive it with TypeScript utilities: `Pick`, `Omit`, `Partial`, `Required`, `Readonly`, `NonNullable`, `Parameters`, `ReturnType`, `Awaited`, indexed access (`T['field']`), `Extract`/`Exclude` on unions, `infer` in conditional types. Convex/Zod have their own equivalents (`Infer<typeof V>`, `FunctionArgs<typeof api.x.y>`, `z.input/z.output`); use them instead of writing a parallel TS type.

--- a/examples/tui-playground.ts
+++ b/examples/tui-playground.ts
@@ -170,6 +170,10 @@ export class FakePlaygroundRunner implements SessionTurnRunner {
     return [];
   }
 
+  async reloadSkills(): Promise<readonly Skill[]> {
+    return [];
+  }
+
   async getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]> {
     return [];
   }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -90,6 +90,7 @@ export interface SessionTurnRunner {
   subscribe(handler: TurnEventHandler): () => void;
   getState(): TurnState | undefined;
   getSkills(): Promise<readonly Skill[]>;
+  reloadSkills(): Promise<readonly Skill[]>;
   getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]>;
   getSkillCollisions(): Promise<readonly SkillCollision[]>;
   dispose(): Promise<void>;
@@ -328,6 +329,14 @@ export class Session {
    */
   getSkills(): Promise<readonly Skill[]> {
     return this.runner.getSkills();
+  }
+
+  /**
+   * Re-discover skills from disk so newly installed ones show up in the
+   * autocomplete catalog without restarting the session.
+   */
+  reloadSkills(): Promise<readonly Skill[]> {
+    return this.runner.reloadSkills();
   }
 
   /** System-prompt files (AGENTS.md by default) that resolved on disk. */

--- a/src/tui/autocomplete-controller.ts
+++ b/src/tui/autocomplete-controller.ts
@@ -53,6 +53,13 @@ export interface AutocompleteControllerOptions {
    * escape that closed the picker stops there.
    */
   onEscapeClose: () => void;
+  /**
+   * Fires the moment the slash picker opens (token went from absent to
+   * present). Used to re-discover installed skills so additions made
+   * during the session show up; the cached catalog is shown first and
+   * the callback updates it asynchronously.
+   */
+  onSkillTokenOpened?: () => void;
 }
 
 /**
@@ -223,6 +230,12 @@ export class AutocompleteController {
       this.skillSelectedIndex = 0;
     }
     this.renderSkill();
+    // Fire after rendering the cached catalog so the picker paints
+    // immediately; the reload runs in the background and a follow-up
+    // setSkillItems()+refresh() updates the open picker in place.
+    if (!previousToken) {
+      this.opts.onSkillTokenOpened?.();
+    }
   }
 
   private refreshFile(): void {

--- a/src/tui/boot-screen.ts
+++ b/src/tui/boot-screen.ts
@@ -8,7 +8,7 @@ import {
 import type { Session } from "../session/session.js";
 import type { TurnAgentFile } from "../types/protocol.js";
 import type { AutocompleteController } from "./autocomplete-controller.js";
-import { BUILT_IN_SLASH_COMMAND_ITEMS } from "./slash-commands.js";
+import { buildSkillAutocompleteCatalog } from "./slash-commands.js";
 import { refreshSidebarFromSession } from "./session-subscription.js";
 import type { Sidebar } from "./sidebar.js";
 import type { StarterSection } from "./starter-section.js";
@@ -160,15 +160,7 @@ export async function renderBootScreen(deps: {
     deps.session.getSkills(),
     deps.session.getResolvedAgentFiles(),
   ]);
-  deps.autocomplete.setSkillItems([
-    ...BUILT_IN_SLASH_COMMAND_ITEMS,
-    ...skills.map((skill) => ({
-      name: skill.name,
-      description: skill.description,
-      path: skill.baseDir,
-      group: "skills" as const,
-    })),
-  ]);
+  deps.autocomplete.setSkillItems(buildSkillAutocompleteCatalog(skills));
   deps.autocomplete.refresh();
   renderSetupIntro(
     {

--- a/src/tui/controllers.ts
+++ b/src/tui/controllers.ts
@@ -1,5 +1,6 @@
 import type { CliRenderer } from "@opentui/core";
 import { AutocompleteController } from "./autocomplete-controller.js";
+import { BUILT_IN_SLASH_COMMAND_ITEMS } from "./slash-commands.js";
 import { CopyController } from "./copy-controller.js";
 import type { LayoutRefs } from "./layout.js";
 import { PasteController } from "./paste-controller.js";
@@ -40,7 +41,11 @@ export interface TuiControllerDeps {
  * makes the controller surface easy to mock in isolation.
  */
 export function createTuiControllers(deps: TuiControllerDeps): TuiControllers {
-  const autocomplete = new AutocompleteController({
+  // Track an in-flight reload so rapid `/` openings collapse into a
+  // single discovery pass. Stays scoped to this controller bundle so the
+  // closure resets when the session is torn down and recreated.
+  let pendingSkillReload: Promise<void> | undefined;
+  const autocomplete: AutocompleteController = new AutocompleteController({
     inputField: deps.ui.inputField,
     skillAutocompletePanel: deps.ui.skillAutocompletePanel,
     commandRows: deps.ui.commandRows,
@@ -51,6 +56,30 @@ export function createTuiControllers(deps: TuiControllerDeps): TuiControllers {
     fileAutocompleteRows: deps.ui.fileAutocompleteRows,
     workDir: deps.workDir,
     onEscapeClose: deps.onPickerEscapeClose,
+    onSkillTokenOpened: () => {
+      if (pendingSkillReload) return;
+      pendingSkillReload = (async () => {
+        try {
+          const skills = await deps.session.reloadSkills();
+          autocomplete.setSkillItems([
+            ...BUILT_IN_SLASH_COMMAND_ITEMS,
+            ...skills.map((skill) => ({
+              name: skill.name,
+              description: skill.description,
+              path: skill.baseDir,
+              group: "skills" as const,
+            })),
+          ]);
+          // Re-evaluate against the current token so the open picker
+          // picks up the freshly discovered entries.
+          autocomplete.refresh();
+        } catch (error) {
+          deps.reportError(error);
+        } finally {
+          pendingSkillReload = undefined;
+        }
+      })();
+    },
   });
 
   const questionPicker = new QuestionPicker({

--- a/src/tui/controllers.ts
+++ b/src/tui/controllers.ts
@@ -1,6 +1,6 @@
 import type { CliRenderer } from "@opentui/core";
 import { AutocompleteController } from "./autocomplete-controller.js";
-import { BUILT_IN_SLASH_COMMAND_ITEMS } from "./slash-commands.js";
+import { buildSkillAutocompleteCatalog } from "./slash-commands.js";
 import { CopyController } from "./copy-controller.js";
 import type { LayoutRefs } from "./layout.js";
 import { PasteController } from "./paste-controller.js";
@@ -61,15 +61,7 @@ export function createTuiControllers(deps: TuiControllerDeps): TuiControllers {
       pendingSkillReload = (async () => {
         try {
           const skills = await deps.session.reloadSkills();
-          autocomplete.setSkillItems([
-            ...BUILT_IN_SLASH_COMMAND_ITEMS,
-            ...skills.map((skill) => ({
-              name: skill.name,
-              description: skill.description,
-              path: skill.baseDir,
-              group: "skills" as const,
-            })),
-          ]);
+          autocomplete.setSkillItems(buildSkillAutocompleteCatalog(skills));
           // Re-evaluate against the current token so the open picker
           // picks up the freshly discovered entries.
           autocomplete.refresh();

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -1,3 +1,4 @@
+import type { Skill } from "@earendil-works/pi-coding-agent";
 import type { SkillAutocompleteItem } from "./autocomplete.js";
 import type { CopyController } from "./copy-controller.js";
 import type { PasteController } from "./paste-controller.js";
@@ -128,6 +129,26 @@ export const BUILT_IN_SLASH_COMMAND_ITEMS: readonly SkillAutocompleteItem[] =
     description: command.description,
     group: "commands" as const,
   }));
+
+/**
+ * Build the slash-picker catalog from a list of discovered skills. Built-in
+ * commands lead, discovered skills follow under the `skills` group. Shared
+ * between the initial boot seed and the per-open background reload so both
+ * surfaces stay in lockstep.
+ */
+export function buildSkillAutocompleteCatalog(
+  skills: readonly Skill[],
+): readonly SkillAutocompleteItem[] {
+  return [
+    ...BUILT_IN_SLASH_COMMAND_ITEMS,
+    ...skills.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      path: skill.baseDir,
+      group: "skills" as const,
+    })),
+  ];
+}
 
 /**
  * Routes the message to a local handler when it matches a built-in command.

--- a/src/turn-runner/skill-context.ts
+++ b/src/turn-runner/skill-context.ts
@@ -35,6 +35,22 @@ export class SkillContext {
     this.collisions = discovered.collisions;
   }
 
+  /**
+   * Re-run skill discovery so newly installed skills show up without
+   * restarting the session. The initial explicit skill list from
+   * `config.skills` is preserved; on-disk discovery is re-read.
+   */
+  async reload(): Promise<void> {
+    const baseline = this.config.skills ? prepareExplicitSkills(this.config.skills) : [];
+    const discovered = loadDiscoveredSkills(
+      this.config.skillDiscovery,
+      this.config.cwd ?? process.cwd(),
+    );
+    this.skills = mergeSkillsByName(baseline, discovered.skills);
+    this.collisions = discovered.collisions;
+    this.loaded = true;
+  }
+
   getSkills(): readonly Skill[] {
     return [...this.skills];
   }

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -1632,6 +1632,17 @@ export class TurnRunner {
     return this.skillContext.getSkills();
   }
 
+  /**
+   * Re-discover installed skills from disk. Surfaces newly added skills
+   * (e.g. installed in this session) without restarting the runner.
+   * Callers typically pair this with `getSkills()` to refresh their
+   * autocomplete catalog.
+   */
+  async reloadSkills(): Promise<readonly Skill[]> {
+    await this.skillContext.reload();
+    return this.skillContext.getSkills();
+  }
+
   /** System-prompt files (AGENTS.md by default) that resolved on disk for this session. */
   async getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]> {
     await this.ensureSkillsLoaded();

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -119,6 +119,10 @@ class FakeTurnRunner implements SessionTurnRunner {
     return this.skills;
   }
 
+  async reloadSkills(): Promise<readonly Skill[]> {
+    return this.skills;
+  }
+
   async getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]> {
     return [];
   }

--- a/test/skill-context-reload.test.ts
+++ b/test/skill-context-reload.test.ts
@@ -2,8 +2,9 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect } from "bun:test";
 import { SkillContext } from "../src/turn-runner/skill-context.js";
+import { testIfDocker } from "./helpers/docker-only.js";
 
 let tempDir: string;
 let skillsDir: string;
@@ -29,7 +30,7 @@ function installSkill(name: string, description: string): void {
 }
 
 describe("SkillContext.reload", () => {
-  test("picks up skills added after ensureLoaded()", async () => {
+  testIfDocker("picks up skills added after ensureLoaded()", async () => {
     installSkill("alpha", "first skill");
     const ctx = new SkillContext({
       skillDiscovery: { includeDefaults: false, cwd: tempDir, skillPaths: [skillsDir] },

--- a/test/skill-context-reload.test.ts
+++ b/test/skill-context-reload.test.ts
@@ -1,0 +1,51 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { SkillContext } from "../src/turn-runner/skill-context.js";
+
+let tempDir: string;
+let skillsDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "skill-context-reload-"));
+  skillsDir = join(tempDir, ".duet", "skills");
+  mkdirSync(skillsDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function installSkill(name: string, description: string): void {
+  const dir = join(skillsDir, name);
+  mkdirSync(dir, { recursive: true });
+  // Skill loader requires frontmatter with name + description.
+  writeFileSync(
+    join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
+  );
+}
+
+describe("SkillContext.reload", () => {
+  test("picks up skills added after ensureLoaded()", async () => {
+    installSkill("alpha", "first skill");
+    const ctx = new SkillContext({
+      skillDiscovery: { includeDefaults: false, cwd: tempDir, skillPaths: [skillsDir] },
+    });
+    await ctx.ensureLoaded();
+    expect(ctx.getSkills().some((s) => s.name === "alpha")).toBe(true);
+    expect(ctx.getSkills().some((s) => s.name === "beta")).toBe(false);
+
+    installSkill("beta", "second skill");
+    // ensureLoaded is a no-op after first run — only reload re-discovers.
+    await ctx.ensureLoaded();
+    expect(ctx.getSkills().some((s) => s.name === "beta")).toBe(false);
+
+    await ctx.reload();
+    const names = ctx.getSkills().map((s) => s.name);
+    expect(names).toContain("alpha");
+    expect(names).toContain("beta");
+  });
+});


### PR DESCRIPTION
## Problem

The TUI slash picker seeded its skill catalog once at boot via `session.getSkills()`. Skills installed during the session (e.g. via `bunx skills add ...`) never appeared in autocomplete until `duet` was restarted.

## Fix

Cached catalog still paints immediately on `/`, but a background reload now re-runs skill discovery on every absent→present transition of the slash token and updates the open picker in place.

- `SkillContext.reload()` re-runs disk discovery while preserving the explicit skills from `config.skills`.
- `TurnRunner` / `Session` expose `reloadSkills()` so non-runner hosts get the same hook (FakePlaygroundRunner + the session.test fake are updated to match).
- `AutocompleteController` fires a new `onSkillTokenOpened` callback on the absent→present transition of the slash token.
- `createTuiControllers` wires that callback to `session.reloadSkills()` with single-flight dedupe so rapid reopens collapse into one discovery pass.

## Tests

- New `test/skill-context-reload.test.ts` covers the cache-then-refresh behavior end-to-end (skill added on disk after `ensureLoaded()` is invisible until `reload()`).
- `bun run check-types`, `bun run lint`, `bun run format` all clean.