### PR TITLE
fix(tui): drop dino hint row, tease Ctrl-G in placeholder

### DIFF
--- a/src/tui/dino/index.ts
+++ b/src/tui/dino/index.ts
@@ -64,9 +64,9 @@ export interface DinoPanel {
   resume(): void;
   /** Agent flipped to needs-user → freeze the world. */
   freeze(): void;
-  /** Track the agent's busy/idle signal so the collapsed hint row only
-   *  surfaces while the agent is working — at rest the panel takes no
-   *  vertical space and stays out of the way. */
+  /** Track the agent's busy/idle signal so Ctrl-G is only meaningful
+   *  while the agent is working — at rest the panel takes no vertical
+   *  space and the toggle is a no-op. */
   setAgentBusy(busy: boolean): void;
   /** Route a keystroke to the game. Returns true when consumed. */
   handleKey(keyName: string | undefined): boolean;
@@ -94,9 +94,9 @@ export function createDinoPanel(opts: DinoPanelOptions): DinoPanel {
   // input (so resume runs the 3-2-1 + grace gap) vs. a manual collapse
   // (so re-expand resumes instantly per the spec).
   let frozenByAgent = false;
-  // Mirrors the StatusController running signal. The collapsed hint row
-  // ("▶ Ctrl-G to play") only renders while this is true; at idle the
-  // panel is invisible and reserves no rows.
+  // Mirrors the StatusController running signal. Ctrl-G is only
+  // accepted while this is true; at idle the panel is invisible and
+  // reserves no rows.
   let agentBusy = false;
   let ticker: ReturnType<typeof setInterval> | undefined;
   // Last persisted high score, so we only write on improvement. Hydrated
@@ -226,10 +226,9 @@ export function createDinoPanel(opts: DinoPanelOptions): DinoPanel {
     // The game is strictly opt-in: the panel never auto-expands. The
     // Ctrl-G tease lives in the input placeholder, and the user has to
     // press it themselves to bring up the playfield.
-    // When the agent goes idle, snap the panel back to its starting
-    // point (collapsed) so the next busy cycle begins at "hint only"
-    // rather than re-appearing already expanded. The user opts back in
-    // by pressing Ctrl-G again.
+    // When the agent goes idle, snap the panel back to collapsed so
+    // the next busy cycle starts invisible rather than re-appearing
+    // already expanded. The user opts back in by pressing Ctrl-G.
     if (!busy) {
       expanded = false;
       gameFocused = true;

--- a/src/tui/dino/index.ts
+++ b/src/tui/dino/index.ts
@@ -19,7 +19,7 @@ import { SIDEBAR_WIDTH } from "../sidebar.js";
 import { COLORS } from "../theme.js";
 import { actionForKey, applyJump, applyStart } from "./input.js";
 import { loadHighScore, saveHighScore } from "./persistence.js";
-import { EXPANDED_ROWS, renderCollapsedRow, renderExpanded } from "./render.js";
+import { EXPANDED_ROWS, renderExpanded } from "./render.js";
 import { panelVisibleRowCount } from "./visibility.js";
 import {
   beginCountdown,
@@ -98,12 +98,6 @@ export function createDinoPanel(opts: DinoPanelOptions): DinoPanel {
   // ("▶ Ctrl-G to play") only renders while this is true; at idle the
   // panel is invisible and reserves no rows.
   let agentBusy = false;
-  // Auto-expand the panel the first time the agent goes busy in this
-  // session so the game is visible by default. Ctrl-G is otherwise an
-  // easter egg — surfacing the full panel once teaches the user it's
-  // there. Every subsequent busy cycle starts collapsed again so we
-  // don't fight users who chose to dismiss it.
-  let hasAutoExpanded = false;
   let ticker: ReturnType<typeof setInterval> | undefined;
   // Last persisted high score, so we only write on improvement. Hydrated
   // from disk at construction time.
@@ -229,14 +223,9 @@ export function createDinoPanel(opts: DinoPanelOptions): DinoPanel {
   function setAgentBusy(busy: boolean): void {
     if (agentBusy === busy) return;
     agentBusy = busy;
-    if (busy && !hasAutoExpanded) {
-      // First busy cycle of the session: open the panel so the user
-      // discovers the game. After this they own the toggle via Ctrl-G
-      // and we never auto-expand again.
-      hasAutoExpanded = true;
-      expanded = true;
-      gameFocused = true;
-    }
+    // The game is strictly opt-in: the panel never auto-expands. The
+    // Ctrl-G tease lives in the input placeholder, and the user has to
+    // press it themselves to bring up the playfield.
     // When the agent goes idle, snap the panel back to its starting
     // point (collapsed) so the next busy cycle begins at "hint only"
     // rather than re-appearing already expanded. The user opts back in
@@ -322,8 +311,9 @@ export function createDinoPanel(opts: DinoPanelOptions): DinoPanel {
         rows[i].content = frame[i] ?? "";
       }
     } else {
-      rows[0].content = renderCollapsedRow(state.highScore);
-      for (let i = 1; i < rows.length; i++) rows[i].content = "";
+      // Collapsed reserves zero rows; clear any stale content so the
+      // pool stays tidy when the next expand reuses it.
+      for (const row of rows) row.content = "";
     }
   }
 

--- a/src/tui/dino/render.ts
+++ b/src/tui/dino/render.ts
@@ -4,9 +4,11 @@
 import { DINO_X, GROUND_ROW, type GameState } from "./state.js";
 
 /** Total rendered rows of the expanded panel: title + 10 playfield rows +
- *  status row = 12 rows when expanded. Collapsed = 1 row. */
+ *  status row = 12 rows when expanded. Collapsed = 0 rows — the Ctrl-G
+ *  tease lives in the input placeholder instead, so the dino takes no
+ *  vertical space until the user opts in. */
 export const EXPANDED_ROWS = 12;
-export const COLLAPSED_ROWS = 1;
+export const COLLAPSED_ROWS = 0;
 export const PLAYFIELD_ROWS = 10;
 
 /** Width of the dino sprite in cells. Anchored at `DINO_X` (left edge). */
@@ -26,12 +28,6 @@ export const DINO_HEIGHT = 3;
 const DINO_RUN_A: readonly string[] = ["  __", " /_)", " /\\ "];
 const DINO_RUN_B: readonly string[] = ["  __", " /_)", " \\/ "];
 const DINO_JUMP: readonly string[] = ["  __", " /_)", " || "];
-
-/** Single-row "press Ctrl-G  HI 0142" hint shown when the panel is
- *  collapsed but the user has opened it at least once this session. */
-export function renderCollapsedRow(highScore: number): string {
-  return `▶ Ctrl-G to play  ·  HI ${pad4(highScore)}`;
-}
 
 /** Full 12-row expanded panel. The phase determines which overlay (idle
  *  splash, countdown numerals, dim "agent needs you" hint, gameover

--- a/src/tui/dino/visibility.ts
+++ b/src/tui/dino/visibility.ts
@@ -7,7 +7,8 @@
 // Contract:
 //   - agent idle               → 0 rows (panel is invisible, reserves no
 //                                vertical space).
-//   - agent busy + collapsed   → COLLAPSED_ROWS rows (the Ctrl-G hint).
+//   - agent busy + collapsed   → 0 rows. The Ctrl-G tease lives in the
+//                                input placeholder, not in a hint row.
 //   - agent busy + expanded    → EXPANDED_ROWS rows (the full game).
 
 import { COLLAPSED_ROWS, EXPANDED_ROWS } from "./render.js";

--- a/src/tui/layout.ts
+++ b/src/tui/layout.ts
@@ -392,7 +392,10 @@ export function buildLayout(renderer: CliRenderer): LayoutRefs {
   // Textarea (rather than Input) so long messages soft-wrap visually. Enter
   // is intercepted in onKeyDown below to submit instead of inserting a newline.
   const inputField = new TextareaRenderable(renderer, {
-    placeholder: "Type a message and press Enter…",
+    // Doubles as the easter-egg tease for the dino panel: idle composer
+    // hints that Ctrl-G exists, so the game stays opt-in and we don't
+    // need a dedicated hint row stealing a line under the transcript.
+    placeholder: "Type a message… or hit Ctrl-G if you're bored 🦖",
     flexGrow: 1,
     minHeight: 1,
     maxHeight: 10,

--- a/test/tui-dino.test.ts
+++ b/test/tui-dino.test.ts
@@ -5,12 +5,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { actionForKey, applyJump, applyStart } from "../src/tui/dino/input.js";
-import {
-  COLLAPSED_ROWS,
-  renderCollapsedRow,
-  renderExpanded,
-  EXPANDED_ROWS,
-} from "../src/tui/dino/render.js";
+import { COLLAPSED_ROWS, renderExpanded, EXPANDED_ROWS } from "../src/tui/dino/render.js";
 import { panelVisibleRowCount } from "../src/tui/dino/visibility.js";
 import {
   BASE_SPEED,
@@ -141,9 +136,8 @@ describe("dino physics", () => {
 });
 
 describe("dino render", () => {
-  test("collapsed row formats the high score with leading zeros", () => {
-    expect(renderCollapsedRow(7)).toContain("HI 0007");
-    expect(renderCollapsedRow(1234)).toContain("HI 1234");
+  test("collapsed panel reserves zero rows so it never steals a line under the transcript", () => {
+    expect(COLLAPSED_ROWS).toBe(0);
   });
 
   test("expanded frame matches the row budget", () => {
@@ -238,8 +232,12 @@ describe("dino responsive width", () => {
     expect(panelVisibleRowCount(true, false)).toBe(0);
   });
 
-  test("panel surfaces the hint when busy + collapsed and full game when busy + expanded", () => {
+  test("collapsed panel stays invisible even when the agent is busy; expanded shows the full game", () => {
+    // Ctrl-G is now strictly opt-in. The collapsed shape reserves no
+    // rows so the transcript bottom stays aligned with the sidebar's
+    // bottom regardless of agent state.
     expect(panelVisibleRowCount(false, true)).toBe(COLLAPSED_ROWS);
+    expect(panelVisibleRowCount(false, true)).toBe(0);
     expect(panelVisibleRowCount(true, true)).toBe(EXPANDED_ROWS);
   });
 


### PR DESCRIPTION
Fixes the two-line hint stack that misaligned the transcript bottom with the relays sidebar, and makes the dino game strictly opt-in.

**Changes**
- Dino collapsed panel now reserves **0 rows** (was 1). The `▶ Ctrl-G to play · HI 0142` row no longer exists, so the transcript bottom lines up with the bottom of the relays panel again.
- Ctrl-G tease moves into the composer placeholder: `Type a message… or hit Ctrl-G if you're bored 🦖`. Playful and discoverable without a permanent hint row.
- `setAgentBusy` no longer auto-expands on the first busy cycle. The game stays an opt-in easter egg via Ctrl-G; never enabled by default.
- Removed `renderCollapsedRow` and `hasAutoExpanded` plumbing; updated `COLLAPSED_ROWS` to 0 and the visibility contract docs.

**Validation**
- `bun run check-types` clean
- `bun run lint` clean
- `bun test` — 435 pass / 0 fail (24 in `test/tui-dino.test.ts` updated for the new contract)