### PR TITLE
feat(tui): /model slash command to swap models mid-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,23 @@ Tool calls render with custom per-tool headers (e.g. `$ <command>`, `read <path>
 </details>
 
 <details>
+<summary><b>Slash commands</b> — in-session controls</summary>
+
+Type `/` in the composer to open the command picker, or send any of these as a message:
+
+- **`/model <name>`** — switch the model used for **subsequent** turns. Accepts the same shorthands and `provider:modelId` forms as the `--model` flag (e.g. `/model sonnet-4.6`, `/model anthropic:claude-opus-4-7`). Unknown shorthands or missing provider credentials surface an error and leave the current model in place. The in-flight turn (if any) keeps the model it started with.
+- **`/thinking <level>`** — switch the thinking level for the **next** turn. One of `minimal`, `low`, `medium`, `high`, `xhigh`. The runner clamps to the active model's supported range at use-time. The in-flight turn (if any) keeps its level.
+- **`/feedback <message>`** — send free-form feedback to the Duet team.
+- **`/reset`** — dispose the current session and start a fresh one.
+- **`/copy [last|all|<N>]`** — copy transcript text to the system clipboard (default: last agent reply).
+- **`/paste`**, **`/image <path>`**, **`/clear-images`** — image-attachment helpers, covered in the next section.
+- **`/diag`** — toggle key and selection event logging when triaging terminal-specific issues.
+
+Slash commands are intercepted locally; they never reach the model unless the picker inserts a `/skill-name` skill reference for the agent to call `read_skill`.
+
+</details>
+
+<details>
 <summary><b>Image attachments</b></summary>
 
 The interactive TUI accepts image attachments (PNG, JPEG, GIF, WebP):

--- a/README.md
+++ b/README.md
@@ -331,9 +331,9 @@ Type `/` in the composer to open the command picker, or send any of these as a m
 - **`/paste`**, **`/image <path>`**, **`/clear-images`** — image-attachment helpers, covered in the next section.
 - **`/diag`** — toggle key and selection event logging when triaging terminal-specific issues.
 
-`/model`, `/thinking`, `/reset`, `/paste`, `/clear-images`, and `/diag` also work **anywhere inside a longer prompt** — the same way `/skill-name` references do. `hey can you review this /model gpt-5.5` swaps the model for the very turn that delivers the message, and the slash form stays in the prompt the agent sees. Commands that take rest-of-line arguments (`/feedback`, `/copy`, `/image`) only fire when they own the whole message.
+`/model`, `/thinking`, `/reset`, `/paste`, `/clear-images`, and `/diag` also work **anywhere inside a longer prompt**. `hey can you review this /model gpt-5.5` swaps the model for the very turn that delivers the message; the slash form is stripped from what the agent sees, so the model receives `hey can you review this`. When the whole prompt is just slash commands, no agent turn runs at all. Commands that take rest-of-line arguments (`/feedback`, `/copy`, `/image`) only fire when they own the whole message.
 
-The inline form also works for the non-TUI one-shot CLI: `duet "hey can you review this /model gpt-5.5"` swaps the model before the prompt dispatches, so the same one turn runs on the requested model.
+The inline form also works for the non-TUI one-shot CLI: `duet "hey can you review this /model gpt-5.5"` swaps the model and dispatches the stripped prompt to the agent; `duet "/model gpt-5.5"` applies the swap and exits without dispatching a turn.
 
 Slash commands are intercepted locally; they never reach the model unless the picker inserts a `/skill-name` skill reference for the agent to call `read_skill`.
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ Type `/` in the composer to open the command picker, or send any of these as a m
 - **`/paste`**, **`/image <path>`**, **`/clear-images`** — image-attachment helpers, covered in the next section.
 - **`/diag`** — toggle key and selection event logging when triaging terminal-specific issues.
 
+`/model`, `/thinking`, `/reset`, `/paste`, `/clear-images`, and `/diag` also work **anywhere inside a longer prompt** — the same way `/skill-name` references do. `hey can you review this /model gpt-5.5` swaps the model for the very turn that delivers the message, and the slash form stays in the prompt the agent sees. Commands that take rest-of-line arguments (`/feedback`, `/copy`, `/image`) only fire when they own the whole message.
+
+The inline form also works for the non-TUI one-shot CLI: `duet "hey can you review this /model gpt-5.5"` swaps the model before the prompt dispatches, so the same one turn runs on the requested model.
+
 Slash commands are intercepted locally; they never reach the model unless the picker inserts a `/skill-name` skill reference for the agent to call `read_skill`.
 
 </details>

--- a/evals/inline-slash-commands.eval.ts
+++ b/evals/inline-slash-commands.eval.ts
@@ -12,8 +12,10 @@ const overrideModel = process.env.EVAL_OVERRIDE_MODEL ?? "sonnet-4.6";
 /**
  * Live CLI eval covering the "hey can you review this /model X" use case:
  * an inline `/model` reference embedded anywhere inside the one-shot
- * prompt must swap the model that the very next (and only) turn runs on,
- * without stripping the slash form from the message the agent sees.
+ * prompt must swap the model that the very next (and only) turn runs
+ * on, and the slash form must be stripped from the prompt the agent
+ * sees (so the agent does not have to re-parse local UI commands as
+ * user content).
  *
  * The eval spawns the real `src/cli.ts` binary in JSONL mode so the
  * assertion observes the same `turn_started` payload a production

--- a/evals/inline-slash-commands.eval.ts
+++ b/evals/inline-slash-commands.eval.ts
@@ -1,0 +1,116 @@
+import { describe, expect } from "bun:test";
+import dedent from "dedent";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TurnEvent } from "../src/types/protocol.js";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+const baselineModel = process.env.EVAL_BASELINE_MODEL ?? "opus-4.7";
+const overrideModel = process.env.EVAL_OVERRIDE_MODEL ?? "sonnet-4.6";
+
+/**
+ * Live CLI eval covering the "hey can you review this /model X" use case:
+ * an inline `/model` reference embedded anywhere inside the one-shot
+ * prompt must swap the model that the very next (and only) turn runs on,
+ * without stripping the slash form from the message the agent sees.
+ *
+ * The eval spawns the real `src/cli.ts` binary in JSONL mode so the
+ * assertion observes the same `turn_started` payload a production
+ * subscriber would, then inspects `state.options.model` to confirm the
+ * runner picked up the override.
+ */
+describe("inline slash commands (live CLI)", () => {
+  testIfDocker(
+    "inline /model swaps the model used by the very prompt that contains it",
+    async () => {
+      const workDir = await mkdtemp(join(tmpdir(), "duet-inline-model-"));
+      try {
+        const prompt = dedent`
+          hey can you review this and reply in one short sentence.
+          /model ${overrideModel}
+        `;
+        const result = await runCliEvents(["--workdir", workDir, "--model", baselineModel, prompt]);
+
+        expect(result.exitCode).toBe(0);
+
+        const turnStarted = result.events.find((event) => event.type === "turn_started");
+        expect(turnStarted).toBeDefined();
+        // The turn that delivers the prompt must already be running on the
+        // inline-selected model. If the override only landed on a later
+        // turn, the contract would be broken for the one-shot case.
+        expect(turnStarted?.state.options?.model).toBe(overrideModel);
+
+        // Stderr must surface the [model] confirmation block emitted by
+        // the inline handler so non-TUI users see the swap took effect.
+        expect(result.stderr).toMatch(/\[model\][^\n]*next turn will use/);
+        expect(result.stderr).toContain(overrideModel);
+      } finally {
+        await rm(workDir, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+
+  testIfDocker(
+    "inline /thinking swaps the thinking level for the same turn",
+    async () => {
+      const workDir = await mkdtemp(join(tmpdir(), "duet-inline-thinking-"));
+      try {
+        const prompt = dedent`
+          please think carefully and reply in one short sentence.
+          /thinking high
+        `;
+        const result = await runCliEvents(["--workdir", workDir, "--model", baselineModel, prompt]);
+
+        expect(result.exitCode).toBe(0);
+
+        const turnStarted = result.events.find((event) => event.type === "turn_started");
+        expect(turnStarted).toBeDefined();
+        expect(turnStarted?.state.options?.thinkingLevel).toBe("high");
+
+        expect(result.stderr).toMatch(/\[thinking\][^\n]*next turn will think at high/);
+      } finally {
+        await rm(workDir, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+});
+
+async function runCliEvents(args: string[]): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  events: TurnEvent[];
+}> {
+  const proc = Bun.spawn(["bun", "src/cli.ts", ...args], {
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      // The eval asserts CLI behavior, not default-skill sync behavior.
+      DUET_API_KEY: "",
+    },
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    events: parseJsonEvents(stdout),
+  };
+}
+
+function parseJsonEvents(stdout: string): TurnEvent[] {
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as TurnEvent);
+}

--- a/src/cli/inline-slash.ts
+++ b/src/cli/inline-slash.ts
@@ -15,40 +15,34 @@ export type InlineSlashLog = (line: string) => void;
  * prompt to the runner config in place, and return the prompt with the
  * slash forms stripped out. Callers dispatch the returned `residue`;
  * when it is empty (the whole prompt was just slash commands like
- * `duet "/model X"`), they skip the agent turn entirely \u2014 same way the
+ * `duet "/model X"`), they skip the agent turn entirely — same way the
  * TUI's whole-message dispatcher returns early before reaching
  * `dispatchTurn`.
  *
- * Validation failures (unresolvable model name, unknown thinking level,
- * empty argument) do not throw. They are surfaced through `log` as
- * `[name] <error message>\n` lines matching the red error blocks the TUI
- * handlers render. The original config stays untouched so the prompt
- * still dispatches on whatever model / thinking level the boot-time
- * flags chose.
+ * Validation failures (unresolvable model name, unknown thinking level)
+ * do not throw. They are surfaced through `log` as `[name] <error>\n`
+ * lines matching the red error blocks the TUI handlers render. The
+ * original config stays untouched so the prompt still dispatches on
+ * whatever model / thinking level the boot-time flags chose.
  */
 export function applyInlineSlashCommandsToCliConfig(
   prompt: string,
   config: TurnRunnerConfig,
   log: InlineSlashLog,
 ): { residue: string } {
-  // Wire `applyInlineSlashCommands` against the CLI surface. The TUI
-  // handlers want the full SlashCommandContext shape (with controllers
-  // for /reset, /paste, etc.), but the CLI only enables model/thinking
-  // \u2014 the other fields are guaranteed unreachable by the onlyCommands
-  // filter, so this context only implements the slice the model/thinking
-  // handlers actually use.
+  // /model and /thinking both need just appendBlock + their setter; the
+  // other SlashCommandContext fields are optional precisely so this
+  // shim does not have to fake them.
   const ctx: SlashCommandContext = {
-    pasteController: undefined as never,
-    copyController: undefined as never,
-    transcriptWriter: undefined as never,
-    onReset: () => {},
     appendBlock: (label, body) => log(`${label ? `${label} ` : ""}${body}\n`),
     setModel: (model) => {
-      const trimmed = model.trim();
-      if (!trimmed) throw new Error("Model name is required");
-      resolveModelName(trimmed);
-      config.model = trimmed;
-      return { modelName: trimmed };
+      // applyInlineSlashCommands's regex `(\S+)` guarantees the model
+      // arg is non-empty non-whitespace, so we go straight to the
+      // resolver — which throws on unknown shorthand / missing
+      // credentials, matching the validation `--model` does at boot.
+      resolveModelName(model);
+      config.model = model;
+      return { modelName: model };
     },
     setThinkingLevel: (level) => {
       const normalized = validateThinkingLevel(level);

--- a/src/cli/inline-slash.ts
+++ b/src/cli/inline-slash.ts
@@ -1,0 +1,63 @@
+import { resolveModelName } from "../model-resolution/resolver.js";
+import { validateThinkingLevel } from "../session/thinking-level.js";
+import { applyInlineSlashCommands, type SlashCommandContext } from "../tui/slash-commands.js";
+import type { TurnRunnerConfig } from "../types/config.js";
+
+/** Slash commands the non-TUI CLI applies inline. /reset, /paste, /clear-images, /diag
+ *  have no meaning in a one-shot run so the CLI intentionally ignores them. */
+const CLI_INLINE_COMMANDS: ReadonlySet<string> = new Set(["model", "thinking"]);
+
+/** Logger surface. Production writes to stderr; tests pass a capturing function. */
+export type InlineSlashLog = (line: string) => void;
+
+/**
+ * Apply inline `/model` and `/thinking` commands found in a one-shot CLI
+ * prompt to the runner config in place, and return the prompt with the
+ * slash forms stripped out. Callers dispatch the returned `residue`;
+ * when it is empty (the whole prompt was just slash commands like
+ * `duet "/model X"`), they skip the agent turn entirely \u2014 same way the
+ * TUI's whole-message dispatcher returns early before reaching
+ * `dispatchTurn`.
+ *
+ * Validation failures (unresolvable model name, unknown thinking level,
+ * empty argument) do not throw. They are surfaced through `log` as
+ * `[name] <error message>\n` lines matching the red error blocks the TUI
+ * handlers render. The original config stays untouched so the prompt
+ * still dispatches on whatever model / thinking level the boot-time
+ * flags chose.
+ */
+export function applyInlineSlashCommandsToCliConfig(
+  prompt: string,
+  config: TurnRunnerConfig,
+  log: InlineSlashLog,
+): { residue: string } {
+  // Wire `applyInlineSlashCommands` against the CLI surface. The TUI
+  // handlers want the full SlashCommandContext shape (with controllers
+  // for /reset, /paste, etc.), but the CLI only enables model/thinking
+  // \u2014 the other fields are guaranteed unreachable by the onlyCommands
+  // filter, so this context only implements the slice the model/thinking
+  // handlers actually use.
+  const ctx: SlashCommandContext = {
+    pasteController: undefined as never,
+    copyController: undefined as never,
+    transcriptWriter: undefined as never,
+    onReset: () => {},
+    appendBlock: (label, body) => log(`${label ? `${label} ` : ""}${body}\n`),
+    setModel: (model) => {
+      const trimmed = model.trim();
+      if (!trimmed) throw new Error("Model name is required");
+      resolveModelName(trimmed);
+      config.model = trimmed;
+      return { modelName: trimmed };
+    },
+    setThinkingLevel: (level) => {
+      const normalized = validateThinkingLevel(level);
+      config.thinkingLevel = normalized;
+      return { thinkingLevel: normalized };
+    },
+  };
+  const { residue } = applyInlineSlashCommands(prompt, ctx, {
+    onlyCommands: CLI_INLINE_COMMANDS,
+  });
+  return { residue };
+}

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -10,11 +10,14 @@ import {
   describeModelResolution,
   resolveCliMemoryModel,
   resolveCliModel,
+  resolveModelName,
   type ModelResolution,
 } from "../model-resolution/resolver.js";
 import { DEFAULT_MEMORY_DB_PATH, SessionManager } from "../session/session-manager.js";
 import { runTui } from "../tui/app.js";
+import { extractInlineSlashCommands, type SlashCommandContext } from "../tui/slash-commands.js";
 import type { TurnRunnerConfig } from "../types/config.js";
+import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import { DEFAULT_RESUME_HISTORY_MESSAGES, printRunHelp } from "./help.js";
 import { resumeCommand } from "./resume-hint.js";
 import { fail, isInteractive, loadCliEnvFiles, parseResumeHistoryMessages } from "./shared.js";
@@ -276,6 +279,50 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
   memoryModelName = memoryModelResolution.modelName;
 
   const useTui = shouldUseTui({ interactive, prompt });
+
+  // Apply inline `/model` and `/thinking` commands embedded in the
+  // non-TUI one-shot prompt before we hand the prompt to the session.
+  // The handlers mutate `config.model` / `config.thinkingLevel` in
+  // place; the prompt text itself is passed through to the agent
+  // verbatim, mirroring how the TUI keeps the slash form in the
+  // message and how `/skill-name` references survive the dispatch.
+  if (!useTui && prompt) {
+    const inlineCtx: SlashCommandContext = {
+      pasteController: undefined as never,
+      copyController: undefined as never,
+      transcriptWriter: undefined as never,
+      appendBlock: (label, body) => {
+        const tag = label ? `${label} ` : "";
+        process.stderr.write(`${tag}${body}\n`);
+      },
+      onReset: () => {},
+      setModel: (model) => {
+        const trimmed = model.trim();
+        if (!trimmed) throw new Error("Model name is required");
+        resolveModelName(trimmed);
+        config.model = trimmed;
+        return { modelName: trimmed };
+      },
+      setThinkingLevel: (level) => {
+        const normalized = level.trim().toLowerCase();
+        const allowed: ReadonlyArray<ThinkingLevel> = ["minimal", "low", "medium", "high", "xhigh"];
+        if (!(allowed as readonly string[]).includes(normalized)) {
+          throw new Error(
+            `Unknown thinking level: ${level}. Expected one of ${allowed.join(", ")}.`,
+          );
+        }
+        config.thinkingLevel = normalized as ThinkingLevel;
+        return { thinkingLevel: normalized };
+      },
+    };
+    extractInlineSlashCommands(prompt, inlineCtx, {
+      onlyCommands: new Set(["model", "thinking"]),
+    });
+    // Sync the cached display name so the boot summary lines reflect any
+    // inline override; the resolver source is unchanged because the
+    // inline form is logically equivalent to `--model`.
+    modelName = config.model ?? modelName;
+  }
 
   // One-shot consumers want a single summary line, not a streaming status.
   // Await the final upgrade status and print the human-readable form (if any)

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -10,13 +10,11 @@ import {
   describeModelResolution,
   resolveCliMemoryModel,
   resolveCliModel,
-  resolveModelName,
   type ModelResolution,
 } from "../model-resolution/resolver.js";
 import { DEFAULT_MEMORY_DB_PATH, SessionManager } from "../session/session-manager.js";
 import { runTui } from "../tui/app.js";
-import { scanInlineSlashCommands } from "../tui/slash-commands.js";
-import { validateThinkingLevel } from "../session/thinking-level.js";
+import { applyInlineSlashCommandsToCliConfig } from "./inline-slash.js";
 import type { TurnRunnerConfig } from "../types/config.js";
 import { DEFAULT_RESUME_HISTORY_MESSAGES, printRunHelp } from "./help.js";
 import { resumeCommand } from "./resume-hint.js";
@@ -196,7 +194,11 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
     }
   }
 
-  let prompt = promptParts.join(" ");
+  // `let prompt: string | undefined` so the inline-slash applier can
+  // unset it when the whole prompt was just slash commands (e.g.
+  // `duet "/model X"`) — mirrors the TUI's whole-message dispatcher
+  // skipping the agent turn entirely.
+  let prompt: string | undefined = promptParts.join(" ");
 
   // Read from stdin if no prompt is provided
   if (!prompt && !interactive) {
@@ -286,37 +288,19 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
   // mirroring how the TUI keeps the slash form in the message and how
   // `/skill-name` references survive the dispatch.
   if (!useTui && prompt) {
-    for (const { name, arg } of scanInlineSlashCommands(prompt, {
-      onlyCommands: new Set(["model", "thinking"]),
-    })) {
-      try {
-        if (name === "model") {
-          const trimmed = arg.trim();
-          if (!trimmed) throw new Error("Model name is required");
-          // Throws on unknown shorthand / missing provider credentials,
-          // matching the validation `--model` would have done at boot.
-          resolveModelName(trimmed);
-          config.model = trimmed;
-          process.stderr.write(
-            `[model] next turn will use ${trimmed}. The current turn (if any) keeps its model.\n`,
-          );
-        } else if (name === "thinking") {
-          const level = validateThinkingLevel(arg);
-          config.thinkingLevel = level;
-          process.stderr.write(
-            `[thinking] next turn will think at ${level}. The current turn (if any) keeps its level.\n`,
-          );
-        }
-      } catch (error) {
-        process.stderr.write(
-          `[${name}] ${error instanceof Error ? error.message : String(error)}\n`,
-        );
-      }
-    }
+    const { residue } = applyInlineSlashCommandsToCliConfig(prompt, config, (line) =>
+      process.stderr.write(line),
+    );
     // Sync the cached display name so the boot summary lines reflect any
     // inline override; the resolver source is unchanged because the
     // inline form is logically equivalent to `--model`.
     modelName = config.model ?? modelName;
+    // Dispatch the prompt with the slash forms stripped out. When the
+    // whole prompt was just slash commands (e.g. `duet "/model X"`),
+    // the residue is empty and we skip the agent turn entirely —
+    // mirrors the TUI's whole-message dispatcher returning before
+    // reaching dispatchTurn.
+    prompt = residue.length > 0 ? residue : undefined;
   }
 
   // One-shot consumers want a single summary line, not a streaming status.

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -15,9 +15,9 @@ import {
 } from "../model-resolution/resolver.js";
 import { DEFAULT_MEMORY_DB_PATH, SessionManager } from "../session/session-manager.js";
 import { runTui } from "../tui/app.js";
-import { extractInlineSlashCommands, type SlashCommandContext } from "../tui/slash-commands.js";
+import { scanInlineSlashCommands } from "../tui/slash-commands.js";
+import { validateThinkingLevel } from "../session/thinking-level.js";
 import type { TurnRunnerConfig } from "../types/config.js";
-import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import { DEFAULT_RESUME_HISTORY_MESSAGES, printRunHelp } from "./help.js";
 import { resumeCommand } from "./resume-hint.js";
 import { fail, isInteractive, loadCliEnvFiles, parseResumeHistoryMessages } from "./shared.js";
@@ -282,42 +282,37 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
 
   // Apply inline `/model` and `/thinking` commands embedded in the
   // non-TUI one-shot prompt before we hand the prompt to the session.
-  // The handlers mutate `config.model` / `config.thinkingLevel` in
-  // place; the prompt text itself is passed through to the agent
-  // verbatim, mirroring how the TUI keeps the slash form in the
-  // message and how `/skill-name` references survive the dispatch.
+  // The prompt text itself is passed through to the agent verbatim,
+  // mirroring how the TUI keeps the slash form in the message and how
+  // `/skill-name` references survive the dispatch.
   if (!useTui && prompt) {
-    const inlineCtx: SlashCommandContext = {
-      pasteController: undefined as never,
-      copyController: undefined as never,
-      transcriptWriter: undefined as never,
-      appendBlock: (label, body) => {
-        const tag = label ? `${label} ` : "";
-        process.stderr.write(`${tag}${body}\n`);
-      },
-      onReset: () => {},
-      setModel: (model) => {
-        const trimmed = model.trim();
-        if (!trimmed) throw new Error("Model name is required");
-        resolveModelName(trimmed);
-        config.model = trimmed;
-        return { modelName: trimmed };
-      },
-      setThinkingLevel: (level) => {
-        const normalized = level.trim().toLowerCase();
-        const allowed: ReadonlyArray<ThinkingLevel> = ["minimal", "low", "medium", "high", "xhigh"];
-        if (!(allowed as readonly string[]).includes(normalized)) {
-          throw new Error(
-            `Unknown thinking level: ${level}. Expected one of ${allowed.join(", ")}.`,
+    for (const { name, arg } of scanInlineSlashCommands(prompt, {
+      onlyCommands: new Set(["model", "thinking"]),
+    })) {
+      try {
+        if (name === "model") {
+          const trimmed = arg.trim();
+          if (!trimmed) throw new Error("Model name is required");
+          // Throws on unknown shorthand / missing provider credentials,
+          // matching the validation `--model` would have done at boot.
+          resolveModelName(trimmed);
+          config.model = trimmed;
+          process.stderr.write(
+            `[model] next turn will use ${trimmed}. The current turn (if any) keeps its model.\n`,
+          );
+        } else if (name === "thinking") {
+          const level = validateThinkingLevel(arg);
+          config.thinkingLevel = level;
+          process.stderr.write(
+            `[thinking] next turn will think at ${level}. The current turn (if any) keeps its level.\n`,
           );
         }
-        config.thinkingLevel = normalized as ThinkingLevel;
-        return { thinkingLevel: normalized };
-      },
-    };
-    extractInlineSlashCommands(prompt, inlineCtx, {
-      onlyCommands: new Set(["model", "thinking"]),
-    });
+      } catch (error) {
+        process.stderr.write(
+          `[${name}] ${error instanceof Error ? error.message : String(error)}\n`,
+        );
+      }
+    }
     // Sync the cached display name so the boot summary lines reflect any
     // inline override; the resolver source is unchanged because the
     // inline form is logically equivalent to `--model`.

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -4,23 +4,7 @@ import { TurnRunner, type TurnEventHandler } from "../turn-runner/turn-runner.js
 import { resolveModelName } from "../model-resolution/resolver.js";
 import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import type { TurnRunnerConfig } from "../types/config.js";
-
-/**
- * The full set of pi-ai thinking levels, in ascending intensity. Kept as a
- * runtime constant so `setThinkingLevel` can both validate input and
- * surface the legal values in error messages without duplicating the type.
- */
-const THINKING_LEVELS = [
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-] as const satisfies readonly ThinkingLevel[];
-
-function isThinkingLevel(value: string): value is ThinkingLevel {
-  return (THINKING_LEVELS as readonly string[]).includes(value);
-}
+import { validateThinkingLevel } from "./thinking-level.js";
 import type { Skill } from "@earendil-works/pi-coding-agent";
 import type { SkillCollision } from "../turn-runner/skills.js";
 import type {
@@ -392,12 +376,7 @@ export class Session {
    * level it started with.
    */
   setThinkingLevel(level: string): { thinkingLevel: ThinkingLevel } {
-    const normalized = level.trim().toLowerCase();
-    if (!isThinkingLevel(normalized)) {
-      throw new Error(
-        `Unknown thinking level: ${level}. Expected one of ${THINKING_LEVELS.join(", ")}.`,
-      );
-    }
+    const normalized = validateThinkingLevel(level);
     this.config.thinkingLevel = normalized;
     return { thinkingLevel: normalized };
   }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -2,7 +2,25 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { TurnRunner, type TurnEventHandler } from "../turn-runner/turn-runner.js";
 import { resolveModelName } from "../model-resolution/resolver.js";
+import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import type { TurnRunnerConfig } from "../types/config.js";
+
+/**
+ * The full set of pi-ai thinking levels, in ascending intensity. Kept as a
+ * runtime constant so `setThinkingLevel` can both validate input and
+ * surface the legal values in error messages without duplicating the type.
+ */
+const THINKING_LEVELS = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const satisfies readonly ThinkingLevel[];
+
+function isThinkingLevel(value: string): value is ThinkingLevel {
+  return (THINKING_LEVELS as readonly string[]).includes(value);
+}
 import type { Skill } from "@earendil-works/pi-coding-agent";
 import type { SkillCollision } from "../turn-runner/skills.js";
 import type {
@@ -363,6 +381,25 @@ export class Session {
     resolveModelName(trimmed);
     this.config.model = trimmed;
     return { modelName: trimmed };
+  }
+
+  /**
+   * Swap the thinking level used for subsequent turns. Accepts any of the
+   * pi-ai `ThinkingLevel` values (minimal / low / medium / high / xhigh);
+   * the runner clamps to the model's supported range at use-time, so
+   * passing a level a given model does not support is not an error here.
+   * The change applies on the next prompt; any in-flight turn keeps the
+   * level it started with.
+   */
+  setThinkingLevel(level: string): { thinkingLevel: ThinkingLevel } {
+    const normalized = level.trim().toLowerCase();
+    if (!isThinkingLevel(normalized)) {
+      throw new Error(
+        `Unknown thinking level: ${level}. Expected one of ${THINKING_LEVELS.join(", ")}.`,
+      );
+    }
+    this.config.thinkingLevel = normalized;
+    return { thinkingLevel: normalized };
   }
 
   /** Skill name collisions where one definition shadowed another during discovery. */

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { TurnRunner, type TurnEventHandler } from "../turn-runner/turn-runner.js";
+import { resolveModelName } from "../model-resolution/resolver.js";
 import type { TurnRunnerConfig } from "../types/config.js";
 import type { Skill } from "@earendil-works/pi-coding-agent";
 import type { SkillCollision } from "../turn-runner/skills.js";
@@ -342,6 +343,26 @@ export class Session {
   /** System-prompt files (AGENTS.md by default) that resolved on disk. */
   getResolvedAgentFiles(): Promise<readonly TurnAgentFile[]> {
     return this.runner.getResolvedAgentFiles();
+  }
+
+  /**
+   * Swap the model used for subsequent turns. Validates the name by
+   * resolving it through the same `provider:modelId` machinery the CLI
+   * uses at boot, so unknown shorthands / missing provider credentials
+   * throw before we mutate runtime config. The change takes effect on
+   * the next prompt (`startOptions` reads `this.config.model` per turn);
+   * any in-flight turn keeps the model it started with.
+   */
+  setModel(model: string): { modelName: string } {
+    const trimmed = model.trim();
+    if (!trimmed) {
+      throw new Error("Model name is required");
+    }
+    // Throws on unknown shorthand or unresolvable provider; surfaces the
+    // same error the CLI startup would have produced for `--model`.
+    resolveModelName(trimmed);
+    this.config.model = trimmed;
+    return { modelName: trimmed };
   }
 
   /** Skill name collisions where one definition shadowed another during discovery. */

--- a/src/session/thinking-level.ts
+++ b/src/session/thinking-level.ts
@@ -1,0 +1,37 @@
+import type { ThinkingLevel } from "@earendil-works/pi-ai";
+
+/**
+ * Canonical list of pi-ai `ThinkingLevel` values, in ascending intensity.
+ * Kept as a runtime constant so callers can both validate user input and
+ * surface the legal values in error messages without duplicating the
+ * upstream type. The `satisfies` clause guarantees the literal array
+ * stays in lockstep with the upstream union.
+ */
+export const THINKING_LEVELS = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const satisfies readonly ThinkingLevel[];
+
+/** Narrowing type guard for arbitrary strings into `ThinkingLevel`. */
+export function isThinkingLevel(value: string): value is ThinkingLevel {
+  return (THINKING_LEVELS as readonly string[]).includes(value);
+}
+
+/**
+ * Normalize and validate a user-supplied thinking level. Trims surrounding
+ * whitespace and lowercases the value before comparison so CLI / TUI input
+ * does not need its own cleanup pass. Throws with the legal values listed
+ * when the input does not match any known level.
+ */
+export function validateThinkingLevel(raw: string): ThinkingLevel {
+  const normalized = raw.trim().toLowerCase();
+  if (!isThinkingLevel(normalized)) {
+    throw new Error(
+      `Unknown thinking level: ${raw}. Expected one of ${THINKING_LEVELS.join(", ")}.`,
+    );
+  }
+  return normalized;
+}

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -17,7 +17,7 @@ import { bindSessionToUi } from "./session-subscription.js";
 import { StarterSection } from "./starter-section.js";
 import { StatusController } from "./status-controller.js";
 import { StepRenderer } from "./step-renderer.js";
-import { runInlineSlashCommands, tryDispatchSlashCommand } from "./slash-commands.js";
+import { applyInlineSlashCommands, tryDispatchSlashCommand } from "./slash-commands.js";
 import { COLORS } from "./theme.js";
 import { TranscriptWriter } from "./transcript-writer.js";
 import type { TranscriptEntry } from "./transcript-log.js";
@@ -363,13 +363,16 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     if (tryDispatchSlashCommand(message, slashCtx)) {
       return;
     }
-    // Whole-message dispatch missed; fall back to inline extraction so
+    // Whole-message dispatch missed; fall back to inline application so
     // commands work anywhere inside a longer prompt (`hey can you review
-    // this /model gpt-5.5`). Inline-eligible commands fire their side
-    // effects locally; the message itself is sent to the agent verbatim,
-    // the same way `/skill-name` references survive the dispatch.
-    runInlineSlashCommands(message, slashCtx);
-    void dispatchTurn(message, "follow_up").catch(reportError);
+    // this /model gpt-5.5`). Each matched slash form fires its handler
+    // and is stripped out of the message; the leftover `residue` is what
+    // the agent sees. When the residue is empty (the whole prompt was
+    // slash commands), we skip the turn entirely — mirrors the
+    // `tryDispatchSlashCommand` early-return above.
+    const { residue } = applyInlineSlashCommands(message, slashCtx);
+    if (residue.length === 0) return;
+    void dispatchTurn(residue, "follow_up").catch(reportError);
   }
 
   installKeyHandlers({

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -359,6 +359,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
           renderer.destroy();
         },
         setModel: (model: string) => input.session.setModel(model),
+        setThinkingLevel: (level: string) => input.session.setThinkingLevel(level),
       })
     ) {
       return;

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -358,6 +358,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
           input.onResetRequest?.();
           renderer.destroy();
         },
+        setModel: (model: string) => input.session.setModel(model),
       })
     ) {
       return;

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -17,7 +17,7 @@ import { bindSessionToUi } from "./session-subscription.js";
 import { StarterSection } from "./starter-section.js";
 import { StatusController } from "./status-controller.js";
 import { StepRenderer } from "./step-renderer.js";
-import { extractInlineSlashCommands, tryDispatchSlashCommand } from "./slash-commands.js";
+import { runInlineSlashCommands, tryDispatchSlashCommand } from "./slash-commands.js";
 import { COLORS } from "./theme.js";
 import { TranscriptWriter } from "./transcript-writer.js";
 import type { TranscriptEntry } from "./transcript-log.js";
@@ -368,7 +368,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     // this /model gpt-5.5`). Inline-eligible commands fire their side
     // effects locally; the message itself is sent to the agent verbatim,
     // the same way `/skill-name` references survive the dispatch.
-    extractInlineSlashCommands(message, slashCtx);
+    runInlineSlashCommands(message, slashCtx);
     void dispatchTurn(message, "follow_up").catch(reportError);
   }
 

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -17,7 +17,7 @@ import { bindSessionToUi } from "./session-subscription.js";
 import { StarterSection } from "./starter-section.js";
 import { StatusController } from "./status-controller.js";
 import { StepRenderer } from "./step-renderer.js";
-import { tryDispatchSlashCommand } from "./slash-commands.js";
+import { extractInlineSlashCommands, tryDispatchSlashCommand } from "./slash-commands.js";
 import { COLORS } from "./theme.js";
 import { TranscriptWriter } from "./transcript-writer.js";
 import type { TranscriptEntry } from "./transcript-log.js";
@@ -348,22 +348,27 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     if (starters && !starters.isPermanentlyDismissed()) {
       starters.destroyPermanently();
     }
-    if (
-      tryDispatchSlashCommand(message, {
-        pasteController,
-        copyController,
-        transcriptWriter,
-        appendBlock,
-        onReset: () => {
-          input.onResetRequest?.();
-          renderer.destroy();
-        },
-        setModel: (model: string) => input.session.setModel(model),
-        setThinkingLevel: (level: string) => input.session.setThinkingLevel(level),
-      })
-    ) {
+    const slashCtx = {
+      pasteController,
+      copyController,
+      transcriptWriter,
+      appendBlock,
+      onReset: () => {
+        input.onResetRequest?.();
+        renderer.destroy();
+      },
+      setModel: (model: string) => input.session.setModel(model),
+      setThinkingLevel: (level: string) => input.session.setThinkingLevel(level),
+    };
+    if (tryDispatchSlashCommand(message, slashCtx)) {
       return;
     }
+    // Whole-message dispatch missed; fall back to inline extraction so
+    // commands work anywhere inside a longer prompt (`hey can you review
+    // this /model gpt-5.5`). Inline-eligible commands fire their side
+    // effects locally; the message itself is sent to the agent verbatim,
+    // the same way `/skill-name` references survive the dispatch.
+    extractInlineSlashCommands(message, slashCtx);
     void dispatchTurn(message, "follow_up").catch(reportError);
   }
 

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -32,6 +32,14 @@ export interface SlashCommandContext {
    * in-flight turn keeps the model it started with.
    */
   setModel(model: string): { modelName: string };
+  /**
+   * Invoked by `/thinking <level>` to swap the thinking level used for
+   * subsequent turns. Returns the normalized level, or throws if the
+   * value is not one of minimal / low / medium / high / xhigh. The
+   * change is queued: the current in-flight turn keeps the level it
+   * started with.
+   */
+  setThinkingLevel(level: string): { thinkingLevel: string };
 }
 
 /**
@@ -131,6 +139,13 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
     matches: (message) => isInvocation(message, "model"),
     handle: handleModelSlashCommand,
   },
+  {
+    name: "thinking",
+    description:
+      "Switch the thinking level for the next turn (minimal|low|medium|high|xhigh): /thinking <level>",
+    matches: (message) => isInvocation(message, "thinking"),
+    handle: handleThinkingSlashCommand,
+  },
 ];
 
 /**
@@ -226,6 +241,38 @@ async function handleFeedbackSlashCommand(raw: string, ctx: SlashCommandContext)
   } catch (error) {
     ctx.appendBlock(
       "[feedback]",
+      error instanceof Error ? error.message : String(error),
+      COLORS.error,
+    );
+  }
+}
+
+/**
+ * `/thinking <level>` validates the requested level against the pi-ai
+ * `ThinkingLevel` set, then mutates session config so the next prompt
+ * picks it up. Like `/model`, the swap is queued for the next turn and
+ * does not interrupt the in-flight one.
+ */
+function handleThinkingSlashCommand(raw: string, ctx: SlashCommandContext): void {
+  const argument = raw === "/thinking" ? "" : raw.slice("/thinking ".length).trim();
+  if (!argument) {
+    ctx.appendBlock(
+      "[thinking]",
+      "Usage: /thinking <level>  — one of minimal, low, medium, high, xhigh",
+      COLORS.system,
+    );
+    return;
+  }
+  try {
+    const { thinkingLevel } = ctx.setThinkingLevel(argument);
+    ctx.appendBlock(
+      "[thinking]",
+      `next turn will think at ${thinkingLevel}. The current turn (if any) keeps its level.`,
+      COLORS.system,
+    );
+  } catch (error) {
+    ctx.appendBlock(
+      "[thinking]",
       error instanceof Error ? error.message : String(error),
       COLORS.error,
     );

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -235,81 +235,92 @@ function escapeRegex(source: string): string {
 }
 
 /**
- * One inline-eligible slash command match found inside a longer prompt,
- * with its argument (if the command has a `token` inline shape). The
- * scanner emits these in the order BUILT_IN_SLASH_COMMANDS declares
- * them, not the order they appear in the message; callers that care
- * about textual order can sort by `match.index` themselves.
+ * Build the global RegExp that matches one inline slash command. Shared
+ * between the scanner (which iterates matches to fire handlers) and the
+ * stripper (which removes matches to compute the leftover prompt) so
+ * both surfaces stay byte-for-byte in sync. Boundary `(?:^|\s)` keeps
+ * `/model` from matching mid-word (e.g. inside a URL
+ * `https://example.com/model`). For the token shape the captured
+ * argument bounds the right edge so neighboring text is not consumed;
+ * the bare shape uses a `\s|$` lookahead for the same reason.
  */
-export interface InlineSlashMatch {
-  /** Bare command name, no leading slash. */
-  name: string;
-  /** Argument text for `token`-shape commands; empty for `none`-shape. */
-  arg: string;
+function inlinePattern(name: string, shape: InlineShape): RegExp {
+  const namePattern = escapeRegex(name);
+  // Capture group 1 = boundary character (empty at start-of-string, else
+  // the one whitespace char before the slash). The replace callback
+  // returns it as-is so adjacent words do not fuse after stripping.
+  // Token shape additionally captures the next non-whitespace run as
+  // the argument; bare shape uses a lookahead for the right edge so
+  // neighboring text is not consumed.
+  return shape === "token"
+    ? new RegExp(`(^|\\s)\\/${namePattern}[ \\t]+(\\S+)`, "g")
+    : new RegExp(`(^|\\s)\\/${namePattern}(?=\\s|$)`, "g");
 }
 
 /**
- * Scan a prompt for every inline-eligible slash command appearing inside
- * it, without firing any side effects. Used by both the TUI inline
- * runner and the non-TUI CLI — the TUI then routes each match back
- * through the regular `handle()` path (so users see the same `[model]`
- * confirmation block), while the CLI applies the side effect against
- * its own config object without faking a TUI context.
+ * Result of `applyInlineSlashCommands`: which commands fired, plus the
+ * leftover prompt after stripping every matched slash form. The residue
+ * is what the caller should dispatch to the agent; if `.trim()` on it
+ * is empty, the whole prompt was just slash commands and no agent turn
+ * needs to run.
  */
-export function* scanInlineSlashCommands(
-  message: string,
-  options: { onlyCommands?: ReadonlySet<string> } = {},
-): Generator<InlineSlashMatch> {
-  for (const command of BUILT_IN_SLASH_COMMANDS) {
-    if (!command.inline) continue;
-    if (options.onlyCommands && !options.onlyCommands.has(command.name)) continue;
-    const namePattern = escapeRegex(command.name);
-    // Boundary `(?:^|\s)` keeps `/model` from matching mid-word (e.g.
-    // inside a URL `https://example.com/model`). For the token shape
-    // the captured argument bounds the right edge so neighboring text
-    // is not consumed; the bare shape uses a `\s|$` lookahead for the
-    // same reason. We iterate matches with `matchAll` rather than
-    // `replace` because the message is not rewritten — the original
-    // text is passed through to the agent verbatim, the same way
-    // `/skill-name` references survive the prompt dispatch.
-    const pattern =
-      command.inline === "token"
-        ? new RegExp(`(?:^|\\s)\\/${namePattern}[ \\t]+(\\S+)`, "g")
-        : new RegExp(`(?:^|\\s)\\/${namePattern}(?=\\s|$)`, "g");
-    for (const match of message.matchAll(pattern)) {
-      const arg = command.inline === "token" ? (match[1] ?? "") : "";
-      yield { name: command.name, arg };
-    }
-  }
+export interface InlineSlashResult {
+  /** Commands whose handler fired, in BUILT_IN_SLASH_COMMANDS order. */
+  handledCommands: string[];
+  /** Prompt with matched slash forms removed and whitespace collapsed. */
+  residue: string;
 }
 
 /**
- * Run every inline-eligible slash command appearing inside a longer
- * prompt, leaving the original message text untouched. Mirrors how the
- * autocomplete picker handles `/skill-name` references: the slash form
- * stays in the prompt the agent sees, and the local side effect (config
- * mutation for `/model` / `/thinking`, controller calls for the rest)
- * fires before the prompt dispatches.
+ * Apply every inline-eligible slash command found inside a longer
+ * prompt: fire its handler (so users see the same `[model]` confirmation
+ * block they would for a whole-message `/model`), and strip the slash
+ * form out of the message so the agent does not have to re-parse local
+ * UI commands as user content. The returned `residue` is the message
+ * the caller should actually dispatch — callers check `.trim() === ""`
+ * to detect the "whole prompt was just slash commands" case and skip
+ * the agent turn entirely.
  *
- * Returns the names of every command that fired so callers can log,
- * meter, or branch on the side effects; the message is the caller's to
- * dispatch (or not).
+ * Boundary characters are preserved on the inside of the strip so that
+ * adjacent words do not fuse: `"hey /model X please"` becomes
+ * `"hey  please"` mid-strip and then collapses to `"hey please"` at the
+ * end. Multi-line prompts keep their newlines.
  */
-export function runInlineSlashCommands(
+export function applyInlineSlashCommands(
   message: string,
   ctx: SlashCommandContext,
   options: { onlyCommands?: ReadonlySet<string> } = {},
-): { handledCommands: string[] } {
+): InlineSlashResult {
   const handledCommands: string[] = [];
-  const byName = new Map(BUILT_IN_SLASH_COMMANDS.map((command) => [command.name, command]));
-  for (const { name, arg } of scanInlineSlashCommands(message, options)) {
-    const command = byName.get(name);
-    if (!command) continue;
-    const synthetic = arg ? `/${name} ${arg}` : `/${name}`;
-    command.handle(synthetic, ctx);
-    handledCommands.push(name);
+  let residue = message;
+  for (const command of BUILT_IN_SLASH_COMMANDS) {
+    if (!command.inline) continue;
+    if (options.onlyCommands && !options.onlyCommands.has(command.name)) continue;
+    residue = residue.replace(
+      inlinePattern(command.name, command.inline),
+      (_match, lead: string, arg?: string) => {
+        const synthetic =
+          command.inline === "token" && arg ? `/${command.name} ${arg}` : `/${command.name}`;
+        command.handle(synthetic, ctx);
+        handledCommands.push(command.name);
+        // Preserve the boundary character (space, tab, newline, or empty
+        // for start-of-string) so words on either side of the stripped
+        // command stay separated.
+        return lead;
+      },
+    );
   }
-  return { handledCommands };
+  if (handledCommands.length > 0) {
+    // Collapse the holes left by stripped commands. Only flatten runs
+    // of spaces/tabs so multi-line prompts keep their newlines, and
+    // trim the outer edges to avoid leading/trailing whitespace from a
+    // command that sat at the very start or end of the message.
+    residue = residue
+      .replace(/[ \t]+/g, " ")
+      .replace(/ ?\n ?/g, "\n")
+      .trim();
+  }
+  return { handledCommands, residue };
 }
 
 /**

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -43,10 +43,29 @@ export interface SlashCommandContext {
 }
 
 /**
- * One built-in slash command. The same record drives both the dispatcher
- * (`matches` + `handle`) and the autocomplete picker (`name` +
- * `description`), so a command added here automatically shows up in `/`
- * suggestions without a second registration step.
+ * Shape of inline matching for a command — i.e. the form the command
+ * takes when it appears anywhere in a longer prompt rather than as the
+ * whole submitted message.
+ *
+ * - `"none"`: bare invocation only (`/reset`). Matches `/name` with
+ *   whitespace / start / end boundaries on both sides.
+ * - `"token"`: requires one whitespace-bounded argument (`/model X`).
+ *   Matches `/name <token>` with whitespace / start before and consumes
+ *   the next non-whitespace run as the argument.
+ *
+ * Commands that take rest-of-line arguments (`/feedback`, `/copy`,
+ * `/image`) intentionally have no inline shape — there is no
+ * unambiguous way to split "the argument" from "the rest of the
+ * prompt" mid-message, so they remain whole-message only.
+ */
+type InlineShape = "none" | "token";
+
+/**
+ * One built-in slash command. The same record drives the whole-message
+ * dispatcher (`matches` + `handle`), the inline extractor (`inline`),
+ * and the autocomplete picker (`name` + `description`), so a command
+ * added here automatically shows up in `/` suggestions without a
+ * second registration step.
  */
 interface BuiltInSlashCommand {
   /** Bare command name, no leading slash. Picker renders this as `/name`. */
@@ -57,6 +76,14 @@ interface BuiltInSlashCommand {
   matches(message: string): boolean;
   /** Side-effecting handler. Errors are surfaced through `appendBlock`. */
   handle(message: string, ctx: SlashCommandContext): void;
+  /**
+   * When set, the command also runs when it appears anywhere inside a
+   * longer prompt. The inline extractor reconstructs a synthetic
+   * whole-message form (`/name` or `/name <arg>`) and calls `handle`
+   * with it, so the inline path reuses the same logic the whole-message
+   * path already uses.
+   */
+  inline?: InlineShape;
 }
 
 /** `/name` with no trailing arguments. */
@@ -90,6 +117,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
     handle: (_, ctx) => {
       void ctx.pasteController.triggerClipboardProbe("slash");
     },
+    inline: "none",
   },
   {
     name: "clear-images",
@@ -99,6 +127,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
       ctx.pasteController.clearPendingImages();
       ctx.appendBlock("[paste]", "cleared pending image attachments", COLORS.system);
     },
+    inline: "none",
   },
   {
     name: "copy",
@@ -114,6 +143,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
       "Toggle diagnostic logging (keys, selection events) for surfacing terminal-specific issues",
     matches: (message) => isInvocation(message, "diag"),
     handle: handleDiagSlashCommand,
+    inline: "none",
   },
   {
     name: "feedback",
@@ -131,6 +161,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
       ctx.appendBlock("[reset]", "starting a new session…", COLORS.system);
       ctx.onReset();
     },
+    inline: "none",
   },
   {
     name: "model",
@@ -138,6 +169,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
       "Switch the model for the next turn (does not affect the current turn): /model <name>",
     matches: (message) => isInvocation(message, "model"),
     handle: handleModelSlashCommand,
+    inline: "token",
   },
   {
     name: "thinking",
@@ -145,6 +177,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
       "Switch the thinking level for the next turn (minimal|low|medium|high|xhigh): /thinking <level>",
     matches: (message) => isInvocation(message, "thinking"),
     handle: handleThinkingSlashCommand,
+    inline: "token",
   },
 ];
 
@@ -194,6 +227,57 @@ export function tryDispatchSlashCommand(message: string, ctx: SlashCommandContex
     }
   }
   return false;
+}
+
+/** Escape a literal command name for safe inclusion in a RegExp pattern. */
+function escapeRegex(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Run every inline-eligible slash command appearing inside a longer
+ * prompt, leaving the original message text untouched. Mirrors how the
+ * autocomplete picker handles `/skill-name` references: the slash form
+ * stays in the prompt the agent sees, and the local side effect (config
+ * mutation for `/model` / `/thinking`, controller calls for the rest)
+ * fires before the prompt dispatches.
+ *
+ * Returns the names of every command that fired so callers can log,
+ * meter, or branch on the side effects; the message is the caller's to
+ * dispatch (or not).
+ */
+export function extractInlineSlashCommands(
+  message: string,
+  ctx: SlashCommandContext,
+  options: { onlyCommands?: ReadonlySet<string> } = {},
+): { handledCommands: string[] } {
+  const handledCommands: string[] = [];
+
+  for (const command of BUILT_IN_SLASH_COMMANDS) {
+    if (!command.inline) continue;
+    if (options.onlyCommands && !options.onlyCommands.has(command.name)) continue;
+    const namePattern = escapeRegex(command.name);
+    // Boundary `(?:^|\s)` keeps `/model` from matching mid-word (e.g.
+    // inside a URL `https://example.com/model`). For the token shape
+    // the captured argument bounds the right edge so neighboring text
+    // is not consumed; the bare shape uses a `\s|$` lookahead for the
+    // same reason. We iterate matches via `matchAll` rather than
+    // `replace` because we do not rewrite the message — the original
+    // text is passed through to the agent verbatim, the same way
+    // `/skill-name` references survive the prompt dispatch.
+    const pattern =
+      command.inline === "token"
+        ? new RegExp(`(?:^|\\s)\\/${namePattern}[ \\t]+(\\S+)`, "g")
+        : new RegExp(`(?:^|\\s)\\/${namePattern}(?=\\s|$)`, "g");
+    for (const match of message.matchAll(pattern)) {
+      const arg = command.inline === "token" ? (match[1] ?? "") : "";
+      const synthetic = arg ? `/${command.name} ${arg}` : `/${command.name}`;
+      command.handle(synthetic, ctx);
+      handledCommands.push(command.name);
+    }
+  }
+
+  return { handledCommands };
 }
 
 /**

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -235,6 +235,55 @@ function escapeRegex(source: string): string {
 }
 
 /**
+ * One inline-eligible slash command match found inside a longer prompt,
+ * with its argument (if the command has a `token` inline shape). The
+ * scanner emits these in the order BUILT_IN_SLASH_COMMANDS declares
+ * them, not the order they appear in the message; callers that care
+ * about textual order can sort by `match.index` themselves.
+ */
+export interface InlineSlashMatch {
+  /** Bare command name, no leading slash. */
+  name: string;
+  /** Argument text for `token`-shape commands; empty for `none`-shape. */
+  arg: string;
+}
+
+/**
+ * Scan a prompt for every inline-eligible slash command appearing inside
+ * it, without firing any side effects. Used by both the TUI inline
+ * runner and the non-TUI CLI — the TUI then routes each match back
+ * through the regular `handle()` path (so users see the same `[model]`
+ * confirmation block), while the CLI applies the side effect against
+ * its own config object without faking a TUI context.
+ */
+export function* scanInlineSlashCommands(
+  message: string,
+  options: { onlyCommands?: ReadonlySet<string> } = {},
+): Generator<InlineSlashMatch> {
+  for (const command of BUILT_IN_SLASH_COMMANDS) {
+    if (!command.inline) continue;
+    if (options.onlyCommands && !options.onlyCommands.has(command.name)) continue;
+    const namePattern = escapeRegex(command.name);
+    // Boundary `(?:^|\s)` keeps `/model` from matching mid-word (e.g.
+    // inside a URL `https://example.com/model`). For the token shape
+    // the captured argument bounds the right edge so neighboring text
+    // is not consumed; the bare shape uses a `\s|$` lookahead for the
+    // same reason. We iterate matches with `matchAll` rather than
+    // `replace` because the message is not rewritten — the original
+    // text is passed through to the agent verbatim, the same way
+    // `/skill-name` references survive the prompt dispatch.
+    const pattern =
+      command.inline === "token"
+        ? new RegExp(`(?:^|\\s)\\/${namePattern}[ \\t]+(\\S+)`, "g")
+        : new RegExp(`(?:^|\\s)\\/${namePattern}(?=\\s|$)`, "g");
+    for (const match of message.matchAll(pattern)) {
+      const arg = command.inline === "token" ? (match[1] ?? "") : "";
+      yield { name: command.name, arg };
+    }
+  }
+}
+
+/**
  * Run every inline-eligible slash command appearing inside a longer
  * prompt, leaving the original message text untouched. Mirrors how the
  * autocomplete picker handles `/skill-name` references: the slash form
@@ -246,37 +295,20 @@ function escapeRegex(source: string): string {
  * meter, or branch on the side effects; the message is the caller's to
  * dispatch (or not).
  */
-export function extractInlineSlashCommands(
+export function runInlineSlashCommands(
   message: string,
   ctx: SlashCommandContext,
   options: { onlyCommands?: ReadonlySet<string> } = {},
 ): { handledCommands: string[] } {
   const handledCommands: string[] = [];
-
-  for (const command of BUILT_IN_SLASH_COMMANDS) {
-    if (!command.inline) continue;
-    if (options.onlyCommands && !options.onlyCommands.has(command.name)) continue;
-    const namePattern = escapeRegex(command.name);
-    // Boundary `(?:^|\s)` keeps `/model` from matching mid-word (e.g.
-    // inside a URL `https://example.com/model`). For the token shape
-    // the captured argument bounds the right edge so neighboring text
-    // is not consumed; the bare shape uses a `\s|$` lookahead for the
-    // same reason. We iterate matches via `matchAll` rather than
-    // `replace` because we do not rewrite the message — the original
-    // text is passed through to the agent verbatim, the same way
-    // `/skill-name` references survive the prompt dispatch.
-    const pattern =
-      command.inline === "token"
-        ? new RegExp(`(?:^|\\s)\\/${namePattern}[ \\t]+(\\S+)`, "g")
-        : new RegExp(`(?:^|\\s)\\/${namePattern}(?=\\s|$)`, "g");
-    for (const match of message.matchAll(pattern)) {
-      const arg = command.inline === "token" ? (match[1] ?? "") : "";
-      const synthetic = arg ? `/${command.name} ${arg}` : `/${command.name}`;
-      command.handle(synthetic, ctx);
-      handledCommands.push(command.name);
-    }
+  const byName = new Map(BUILT_IN_SLASH_COMMANDS.map((command) => [command.name, command]));
+  for (const { name, arg } of scanInlineSlashCommands(message, options)) {
+    const command = byName.get(name);
+    if (!command) continue;
+    const synthetic = arg ? `/${name} ${arg}` : `/${name}`;
+    command.handle(synthetic, ctx);
+    handledCommands.push(name);
   }
-
   return { handledCommands };
 }
 

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -13,9 +13,18 @@ import { COLORS } from "./theme.js";
  * `submit()` can short-circuit before the message reaches `session.prompt()`.
  */
 export interface SlashCommandContext {
-  pasteController: PasteController;
-  copyController: CopyController;
-  transcriptWriter: TranscriptWriter;
+  /**
+   * Controllers are optional because not every consumer of this
+   * interface wires the full TUI. The non-TUI CLI applies inline
+   * `/model` and `/thinking` against a stripped-down context that
+   * has no clipboard, transcript, or reset surface — those commands
+   * are filtered out via `applyInlineSlashCommands`'s `onlyCommands`
+   * before they could ever run, so the handlers that depend on these
+   * controllers never see a missing one in practice.
+   */
+  pasteController?: PasteController;
+  copyController?: CopyController;
+  transcriptWriter?: TranscriptWriter;
   appendBlock(label: string | null, body: string, fg: string): void;
   /**
    * Invoked by `/reset` to ask the outer dispatcher to dispose the
@@ -23,7 +32,7 @@ export interface SlashCommandContext {
    * tears its renderer down immediately after so the parent `while`
    * loop in `cli/run.ts` wakes and performs the swap.
    */
-  onReset(): void;
+  onReset?(): void;
   /**
    * Invoked by `/model <name>` to swap the model used for subsequent
    * turns. Returns the canonicalized name the session will use on the
@@ -115,7 +124,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
     description: "Probe the OS clipboard for an image (fallback when Cmd+V is swallowed)",
     matches: (message) => isBare(message, "paste"),
     handle: (_, ctx) => {
-      void ctx.pasteController.triggerClipboardProbe("slash");
+      void ctx.pasteController?.triggerClipboardProbe("slash");
     },
     inline: "none",
   },
@@ -124,7 +133,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
     description: "Drop pending image attachments before submit",
     matches: (message) => isBare(message, "clear-images"),
     handle: (_, ctx) => {
-      ctx.pasteController.clearPendingImages();
+      ctx.pasteController?.clearPendingImages();
       ctx.appendBlock("[paste]", "cleared pending image attachments", COLORS.system);
     },
     inline: "none",
@@ -134,7 +143,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
     description: "Copy text to your clipboard: /copy [last|all|<N>] (default: last agent reply)",
     matches: (message) => isInvocation(message, "copy"),
     handle: (message, ctx) => {
-      void ctx.copyController.handleCopySlashCommand(message);
+      void ctx.copyController?.handleCopySlashCommand(message);
     },
   },
   {
@@ -159,7 +168,7 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
     matches: (message) => isBare(message, "reset"),
     handle: (_, ctx) => {
       ctx.appendBlock("[reset]", "starting a new session…", COLORS.system);
-      ctx.onReset();
+      ctx.onReset?.();
     },
     inline: "none",
   },
@@ -235,14 +244,13 @@ function escapeRegex(source: string): string {
 }
 
 /**
- * Build the global RegExp that matches one inline slash command. Shared
- * between the scanner (which iterates matches to fire handlers) and the
- * stripper (which removes matches to compute the leftover prompt) so
- * both surfaces stay byte-for-byte in sync. Boundary `(?:^|\s)` keeps
- * `/model` from matching mid-word (e.g. inside a URL
- * `https://example.com/model`). For the token shape the captured
- * argument bounds the right edge so neighboring text is not consumed;
- * the bare shape uses a `\s|$` lookahead for the same reason.
+ * Build the global RegExp that matches one inline slash command.
+ * Boundary `(^|\s)` keeps `/model` from matching mid-word (e.g. inside
+ * a URL `https://example.com/model`) and is captured so the strip step
+ * can put the boundary character back — otherwise adjacent words would
+ * fuse. For the token shape, group 2 captures the argument and bounds
+ * the right edge; the bare shape uses a `\s|$` lookahead for the same
+ * reason.
  */
 function inlinePattern(name: string, shape: InlineShape): RegExp {
   const namePattern = escapeRegex(name);
@@ -333,6 +341,10 @@ export function applyInlineSlashCommands(
 function handleDiagSlashCommand(raw: string, ctx: SlashCommandContext): void {
   const argument = raw === "/diag" ? "" : raw.slice("/diag ".length).trim();
   if (argument === "" || argument === "keys") {
+    // `transcriptWriter` is only optional for the non-TUI CLI shim,
+    // which filters /diag out before it can run — in the TUI (the only
+    // surface that exposes /diag) it is always wired.
+    if (!ctx.transcriptWriter) return;
     const enabled = !ctx.transcriptWriter.isKeyDiagnosticsEnabled();
     ctx.transcriptWriter.setKeyDiagnosticsEnabled(enabled);
     ctx.appendBlock(
@@ -448,5 +460,5 @@ async function handleImageSlashCommand(raw: string, ctx: SlashCommandContext): P
     );
     return;
   }
-  await ctx.pasteController.attachImageFromPath(rest);
+  await ctx.pasteController?.attachImageFromPath(rest);
 }

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -24,6 +24,14 @@ export interface SlashCommandContext {
    * loop in `cli/run.ts` wakes and performs the swap.
    */
   onReset(): void;
+  /**
+   * Invoked by `/model <name>` to swap the model used for subsequent
+   * turns. Returns the canonicalized name the session will use on the
+   * next prompt, or throws if validation fails (unknown shorthand /
+   * missing provider credentials). The change is queued: the current
+   * in-flight turn keeps the model it started with.
+   */
+  setModel(model: string): { modelName: string };
 }
 
 /**
@@ -115,6 +123,13 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
       ctx.appendBlock("[reset]", "starting a new session…", COLORS.system);
       ctx.onReset();
     },
+  },
+  {
+    name: "model",
+    description:
+      "Switch the model for the next turn (does not affect the current turn): /model <name>",
+    matches: (message) => isInvocation(message, "model"),
+    handle: handleModelSlashCommand,
   },
 ];
 
@@ -211,6 +226,38 @@ async function handleFeedbackSlashCommand(raw: string, ctx: SlashCommandContext)
   } catch (error) {
     ctx.appendBlock(
       "[feedback]",
+      error instanceof Error ? error.message : String(error),
+      COLORS.error,
+    );
+  }
+}
+
+/**
+ * `/model <name>` validates the requested model against the same resolver
+ * the CLI uses at boot, then mutates session config so the next prompt
+ * picks it up. The handler intentionally does not interrupt or restart
+ * an in-flight turn; the swap applies starting at the next user turn.
+ */
+function handleModelSlashCommand(raw: string, ctx: SlashCommandContext): void {
+  const argument = raw === "/model" ? "" : raw.slice("/model ".length).trim();
+  if (!argument) {
+    ctx.appendBlock(
+      "[model]",
+      "Usage: /model <name>  — switch the model for the next turn (e.g. /model sonnet-4.6)",
+      COLORS.system,
+    );
+    return;
+  }
+  try {
+    const { modelName } = ctx.setModel(argument);
+    ctx.appendBlock(
+      "[model]",
+      `next turn will use ${modelName}. The current turn (if any) keeps its model.`,
+      COLORS.system,
+    );
+  } catch (error) {
+    ctx.appendBlock(
+      "[model]",
       error instanceof Error ? error.message : String(error),
       COLORS.error,
     );

--- a/test/cli-inline-slash.test.ts
+++ b/test/cli-inline-slash.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { applyInlineSlashCommandsToCliConfig } from "../src/cli/inline-slash.js";
+import type { TurnRunnerConfig } from "../src/types/config.js";
+
+function makeConfig(overrides: Partial<TurnRunnerConfig> = {}): TurnRunnerConfig {
+  return {
+    model: "anthropic:claude-opus-4-7",
+    memoryDbPath: false,
+    skillDiscovery: { includeDefaults: false },
+    ...overrides,
+  } as TurnRunnerConfig;
+}
+
+function makeLog(): { lines: string[]; write: (line: string) => void } {
+  const lines: string[] = [];
+  return { lines, write: (line) => lines.push(line) };
+}
+
+describe("applyInlineSlashCommandsToCliConfig", () => {
+  test("inline /model with a valid provider-pinned name mutates config and strips it from residue", () => {
+    const config = makeConfig();
+    const log = makeLog();
+
+    const { residue } = applyInlineSlashCommandsToCliConfig(
+      "hey can you review this /model anthropic:claude-sonnet-5-1",
+      config,
+      log.write,
+    );
+
+    expect(config.model).toBe("anthropic:claude-sonnet-5-1");
+    expect(log.lines.join("")).toContain("[model] next turn will use anthropic:claude-sonnet-5-1");
+    expect(residue).toBe("hey can you review this");
+  });
+
+  test("whole-prompt /model returns an empty residue so the CLI can skip the agent turn", () => {
+    // This is the `duet "/model X"` case: the whole prompt is just a
+    // slash command. The CLI mutates config and returns "" so run.ts
+    // unsets `prompt` and never dispatches an agent turn.
+    const config = makeConfig();
+    const log = makeLog();
+
+    const { residue } = applyInlineSlashCommandsToCliConfig(
+      "/model anthropic:claude-sonnet-5-1",
+      config,
+      log.write,
+    );
+
+    expect(config.model).toBe("anthropic:claude-sonnet-5-1");
+    expect(residue).toBe("");
+  });
+
+  test("whole-prompt /model X /thinking Y applies both swaps and still returns empty residue", () => {
+    const config = makeConfig({ thinkingLevel: "medium" });
+    const log = makeLog();
+
+    const { residue } = applyInlineSlashCommandsToCliConfig(
+      "/model anthropic:claude-sonnet-5-1 /thinking high",
+      config,
+      log.write,
+    );
+
+    expect(config.model).toBe("anthropic:claude-sonnet-5-1");
+    expect(config.thinkingLevel).toBe("high");
+    expect(residue).toBe("");
+  });
+
+  test("inline /thinking with a valid level mutates config and confirms via log", () => {
+    const config = makeConfig({ thinkingLevel: "medium" });
+    const log = makeLog();
+
+    const { residue } = applyInlineSlashCommandsToCliConfig(
+      "please /thinking high and reply",
+      config,
+      log.write,
+    );
+
+    expect(config.thinkingLevel).toBe("high");
+    expect(log.lines.join("")).toContain("[thinking] next turn will think at high");
+    expect(residue).toBe("please and reply");
+  });
+
+  test("inline /model with an unresolvable shorthand never mutates config and logs the resolver error", () => {
+    // This is the "what happens if the arg is wrong" path. The resolver
+    // throws — applyInline... must swallow the throw, leave config.model
+    // intact, and surface the resolver's exact message under [model] so
+    // the user sees what went wrong instead of a silent swap.
+    const config = makeConfig();
+    const log = makeLog();
+
+    const { residue } = applyInlineSlashCommandsToCliConfig(
+      "hey /model totally-not-a-real-model please review this",
+      config,
+      log.write,
+    );
+
+    expect(config.model).toBe("anthropic:claude-opus-4-7");
+    const joined = log.lines.join("");
+    expect(joined).toMatch(/\[model\]/);
+    expect(joined).toMatch(/totally-not-a-real-model/);
+    // No success confirmation should have been written.
+    expect(joined).not.toMatch(/next turn will use/);
+    // Even though validation failed, the slash form is still stripped
+    // from the residue — the parser already committed to treating
+    // `totally-not-a-real-model` as the arg, so leaving it in would be
+    // worse (the agent would see a half-mangled prompt).
+    expect(residue).toBe("hey please review this");
+  });
+
+  test("inline /thinking with an unknown level never mutates config and lists the legal values", () => {
+    const config = makeConfig({ thinkingLevel: "medium" });
+    const log = makeLog();
+
+    const { residue } = applyInlineSlashCommandsToCliConfig(
+      "/thinking ultra please go",
+      config,
+      log.write,
+    );
+
+    expect(config.thinkingLevel).toBe("medium");
+    const joined = log.lines.join("");
+    expect(joined).toContain("[thinking] Unknown thinking level: ultra");
+    expect(joined).toContain("minimal, low, medium, high, xhigh");
+    expect(joined).not.toMatch(/next turn will think at/);
+    expect(residue).toBe("please go");
+  });
+
+  test("trailing /model with no following token is left in the residue (token shape requires an arg)", () => {
+    // The token-shape inline pattern requires `[ \t]+(\S+)` after the
+    // command name. With nothing following, there is no match, so the
+    // slash form is not stripped and falls through to the agent.
+    const config = makeConfig();
+    const log = makeLog();
+
+    const { residue } = applyInlineSlashCommandsToCliConfig(
+      "please look at this and /model",
+      config,
+      log.write,
+    );
+
+    expect(config.model).toBe("anthropic:claude-opus-4-7");
+    expect(log.lines).toEqual([]);
+    expect(residue).toBe("please look at this and /model");
+  });
+
+  test("a bad /model followed by a good /thinking still applies the /thinking swap", () => {
+    // Each inline command is independent: a validation failure on one
+    // must not stop the loop from applying the others.
+    const config = makeConfig({ thinkingLevel: "medium" });
+    const log = makeLog();
+
+    const { residue } = applyInlineSlashCommandsToCliConfig(
+      "hey /model totally-not-real and /thinking high please",
+      config,
+      log.write,
+    );
+
+    expect(config.model).toBe("anthropic:claude-opus-4-7");
+    expect(config.thinkingLevel).toBe("high");
+    const joined = log.lines.join("");
+    expect(joined).toContain("[model]");
+    expect(joined).toContain("[thinking] next turn will think at high");
+    expect(residue).toBe("hey and please");
+  });
+});

--- a/test/session-model-switch.test.ts
+++ b/test/session-model-switch.test.ts
@@ -163,9 +163,6 @@ describe("Session model-switch persistence", () => {
       // the inline extractor touches when /model is the matched command.
       const blocks: Array<{ label: string | null; body: string }> = [];
       const ctx = {
-        pasteController: {} as never,
-        copyController: {} as never,
-        transcriptWriter: {} as never,
         appendBlock: (label: string | null, body: string) => {
           blocks.push({ label, body });
         },
@@ -220,9 +217,6 @@ describe("Session model-switch persistence", () => {
 
       const blocks: Array<{ label: string | null; body: string }> = [];
       const ctx = {
-        pasteController: {} as never,
-        copyController: {} as never,
-        transcriptWriter: {} as never,
         appendBlock: (label: string | null, body: string) => {
           blocks.push({ label, body });
         },
@@ -265,9 +259,6 @@ describe("Session model-switch persistence", () => {
 
       const blocks: Array<{ label: string | null; body: string }> = [];
       const ctx = {
-        pasteController: {} as never,
-        copyController: {} as never,
-        transcriptWriter: {} as never,
         appendBlock: (label: string | null, body: string) => {
           blocks.push({ label, body });
         },

--- a/test/session-model-switch.test.ts
+++ b/test/session-model-switch.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect } from "bun:test";
 import { Session } from "../src/session/session.js";
-import { extractInlineSlashCommands } from "../src/tui/slash-commands.js";
+import { runInlineSlashCommands } from "../src/tui/slash-commands.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 let tempDirs: string[] = [];
@@ -175,7 +175,7 @@ describe("Session model-switch persistence", () => {
       };
 
       const message = "hey can you review this /model anthropic:claude-sonnet-5-1";
-      const { handledCommands } = extractInlineSlashCommands(message, ctx);
+      const { handledCommands } = runInlineSlashCommands(message, ctx);
 
       // The mutation has to be observable on the live config before the
       // caller dispatches the prompt — otherwise the turn that delivers

--- a/test/session-model-switch.test.ts
+++ b/test/session-model-switch.test.ts
@@ -87,6 +87,56 @@ describe("Session model-switch persistence", () => {
     expect(stored.state.options.model).toBe("anthropic:claude-sonnet-5-1");
   });
 
+  testIfDocker(
+    "setThinkingLevel mutates config.thinkingLevel and is picked up on next start",
+    async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), "duet-thinking-set-"));
+      tempDirs.push(tempDir);
+      const sessionPath = join(tempDir, "thinking-session");
+      await mkdir(sessionPath, { recursive: true });
+
+      const session = new Session(
+        {
+          model: "anthropic:claude-opus-4-7",
+          thinkingLevel: "medium",
+          memoryDbPath: false,
+          skillDiscovery: { includeDefaults: false },
+        },
+        { id: "thinking-session", sessionPath },
+      );
+
+      const result = session.setThinkingLevel("HIGH");
+      expect(result.thinkingLevel).toBe("high");
+      expect(session.config.thinkingLevel).toBe("high");
+
+      await session.start();
+      await session.dispose();
+
+      const stored = JSON.parse(await readFile(join(sessionPath, "state.json"), "utf-8"));
+      expect(stored.state.options.thinkingLevel).toBe("high");
+    },
+  );
+
+  testIfDocker("setThinkingLevel rejects unknown levels without mutating config", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "duet-thinking-set-bad-"));
+    tempDirs.push(tempDir);
+    const sessionPath = join(tempDir, "thinking-bad-session");
+    await mkdir(sessionPath, { recursive: true });
+
+    const session = new Session(
+      {
+        model: "anthropic:claude-opus-4-7",
+        thinkingLevel: "medium",
+        memoryDbPath: false,
+        skillDiscovery: { includeDefaults: false },
+      },
+      { id: "thinking-bad-session", sessionPath },
+    );
+
+    expect(() => session.setThinkingLevel("ultra")).toThrow();
+    expect(session.config.thinkingLevel).toBe("medium");
+  });
+
   testIfDocker("setModel rejects unknown model shorthands without mutating config", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "duet-model-set-bad-"));
     tempDirs.push(tempDir);

--- a/test/session-model-switch.test.ts
+++ b/test/session-model-switch.test.ts
@@ -57,4 +57,55 @@ describe("Session model-switch persistence", () => {
       expect(stateAfterSecond.state.options.model).toBe("anthropic:claude-sonnet-5-1");
     },
   );
+
+  // setModel() lets the TUI's /model slash command swap the model used for
+  // subsequent turns. The change is config-level only — it must take effect
+  // on the next prompt without touching any in-flight turn.
+  testIfDocker("setModel mutates config.model and is picked up on next start", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "duet-model-set-"));
+    tempDirs.push(tempDir);
+    const sessionPath = join(tempDir, "set-session");
+    await mkdir(sessionPath, { recursive: true });
+
+    const session = new Session(
+      {
+        model: "anthropic:claude-opus-4-7",
+        memoryDbPath: false,
+        skillDiscovery: { includeDefaults: false },
+      },
+      { id: "set-session", sessionPath },
+    );
+
+    const result = session.setModel("anthropic:claude-sonnet-5-1");
+    expect(result.modelName).toBe("anthropic:claude-sonnet-5-1");
+    expect(session.config.model).toBe("anthropic:claude-sonnet-5-1");
+
+    await session.start();
+    await session.dispose();
+
+    const stored = JSON.parse(await readFile(join(sessionPath, "state.json"), "utf-8"));
+    expect(stored.state.options.model).toBe("anthropic:claude-sonnet-5-1");
+  });
+
+  testIfDocker("setModel rejects unknown model shorthands without mutating config", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "duet-model-set-bad-"));
+    tempDirs.push(tempDir);
+    const sessionPath = join(tempDir, "bad-session");
+    await mkdir(sessionPath, { recursive: true });
+
+    const session = new Session(
+      {
+        model: "anthropic:claude-opus-4-7",
+        memoryDbPath: false,
+        skillDiscovery: { includeDefaults: false },
+      },
+      { id: "bad-session", sessionPath },
+    );
+
+    expect(() => session.setModel("not-a-real-model-shorthand")).toThrow();
+    expect(session.config.model).toBe("anthropic:claude-opus-4-7");
+
+    expect(() => session.setModel("   ")).toThrow();
+    expect(session.config.model).toBe("anthropic:claude-opus-4-7");
+  });
 });

--- a/test/session-model-switch.test.ts
+++ b/test/session-model-switch.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect } from "bun:test";
 import { Session } from "../src/session/session.js";
-import { runInlineSlashCommands } from "../src/tui/slash-commands.js";
+import { applyInlineSlashCommands } from "../src/tui/slash-commands.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 let tempDirs: string[] = [];
@@ -175,7 +175,7 @@ describe("Session model-switch persistence", () => {
       };
 
       const message = "hey can you review this /model anthropic:claude-sonnet-5-1";
-      const { handledCommands } = runInlineSlashCommands(message, ctx);
+      const { handledCommands } = applyInlineSlashCommands(message, ctx);
 
       // The mutation has to be observable on the live config before the
       // caller dispatches the prompt — otherwise the turn that delivers
@@ -193,6 +193,95 @@ describe("Session model-switch persistence", () => {
       await session.dispose();
       const stored = JSON.parse(await readFile(join(sessionPath, "state.json"), "utf-8"));
       expect(stored.state.options.model).toBe("anthropic:claude-sonnet-5-1");
+    },
+  );
+
+  // The inline path must absorb validation failures: a typo'd model
+  // name should not crash the prompt dispatch or silently swap config.
+  // The handler renders a red [model] block via appendBlock, leaves
+  // session.config.model untouched, and lets the original prompt run on
+  // the previously-configured model.
+  testIfDocker(
+    "inline /model with a rejected name leaves config.model untouched and surfaces an error block",
+    async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), "duet-model-inline-bad-"));
+      tempDirs.push(tempDir);
+      const sessionPath = join(tempDir, "inline-bad-session");
+      await mkdir(sessionPath, { recursive: true });
+
+      const session = new Session(
+        {
+          model: "anthropic:claude-opus-4-7",
+          memoryDbPath: false,
+          skillDiscovery: { includeDefaults: false },
+        },
+        { id: "inline-bad-session", sessionPath },
+      );
+
+      const blocks: Array<{ label: string | null; body: string }> = [];
+      const ctx = {
+        pasteController: {} as never,
+        copyController: {} as never,
+        transcriptWriter: {} as never,
+        appendBlock: (label: string | null, body: string) => {
+          blocks.push({ label, body });
+        },
+        onReset: () => {},
+        setModel: (model: string) => session.setModel(model),
+        setThinkingLevel: (level: string) => session.setThinkingLevel(level),
+      };
+
+      applyInlineSlashCommands("hey /model totally-not-a-real-model please review this", ctx);
+
+      expect(session.config.model).toBe("anthropic:claude-opus-4-7");
+      const errorBlock = blocks.find((b) => b.label === "[model]");
+      expect(errorBlock).toBeDefined();
+      // Body comes straight from resolveModelName — the canonical message
+      // for an unresolvable shorthand. We assert on the shape, not the
+      // exact wording, so resolver copy can evolve without breaking this.
+      expect(errorBlock?.body).toMatch(/totally-not-a-real-model/);
+    },
+  );
+
+  // Same shape for /thinking: a bogus level shows the error block and
+  // never mutates the config.
+  testIfDocker(
+    "inline /thinking with a rejected level leaves config.thinkingLevel untouched",
+    async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), "duet-thinking-inline-bad-"));
+      tempDirs.push(tempDir);
+      const sessionPath = join(tempDir, "inline-bad-thinking");
+      await mkdir(sessionPath, { recursive: true });
+
+      const session = new Session(
+        {
+          model: "anthropic:claude-opus-4-7",
+          thinkingLevel: "medium",
+          memoryDbPath: false,
+          skillDiscovery: { includeDefaults: false },
+        },
+        { id: "inline-bad-thinking", sessionPath },
+      );
+
+      const blocks: Array<{ label: string | null; body: string }> = [];
+      const ctx = {
+        pasteController: {} as never,
+        copyController: {} as never,
+        transcriptWriter: {} as never,
+        appendBlock: (label: string | null, body: string) => {
+          blocks.push({ label, body });
+        },
+        onReset: () => {},
+        setModel: (model: string) => session.setModel(model),
+        setThinkingLevel: (level: string) => session.setThinkingLevel(level),
+      };
+
+      applyInlineSlashCommands("think harder /thinking ultra please", ctx);
+
+      expect(session.config.thinkingLevel).toBe("medium");
+      const errorBlock = blocks.find((b) => b.label === "[thinking]");
+      expect(errorBlock?.body).toMatch(/Unknown thinking level: ultra/);
+      expect(errorBlock?.body).toMatch(/minimal, low, medium, high, xhigh/);
     },
   );
 

--- a/test/session-model-switch.test.ts
+++ b/test/session-model-switch.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect } from "bun:test";
 import { Session } from "../src/session/session.js";
+import { extractInlineSlashCommands } from "../src/tui/slash-commands.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 let tempDirs: string[] = [];
@@ -136,6 +137,64 @@ describe("Session model-switch persistence", () => {
     expect(() => session.setThinkingLevel("ultra")).toThrow();
     expect(session.config.thinkingLevel).toBe("medium");
   });
+
+  // Inline contract: when /model appears inside a longer prompt, the swap
+  // must take effect *before* the remainder dispatches as a prompt, so the
+  // turn that delivers the remainder uses the newly-selected model. This
+  // is the "hey can you review this /model gpt-5.5" flow.
+  testIfDocker(
+    "inline /model mutates config.model before the remainder is dispatched",
+    async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), "duet-model-inline-"));
+      tempDirs.push(tempDir);
+      const sessionPath = join(tempDir, "inline-session");
+      await mkdir(sessionPath, { recursive: true });
+
+      const session = new Session(
+        {
+          model: "anthropic:claude-opus-4-7",
+          memoryDbPath: false,
+          skillDiscovery: { includeDefaults: false },
+        },
+        { id: "inline-session", sessionPath },
+      );
+
+      // Minimal stub that exercises only the SlashCommandContext surface
+      // the inline extractor touches when /model is the matched command.
+      const blocks: Array<{ label: string | null; body: string }> = [];
+      const ctx = {
+        pasteController: {} as never,
+        copyController: {} as never,
+        transcriptWriter: {} as never,
+        appendBlock: (label: string | null, body: string) => {
+          blocks.push({ label, body });
+        },
+        onReset: () => {},
+        setModel: (model: string) => session.setModel(model),
+        setThinkingLevel: (level: string) => session.setThinkingLevel(level),
+      };
+
+      const message = "hey can you review this /model anthropic:claude-sonnet-5-1";
+      const { handledCommands } = extractInlineSlashCommands(message, ctx);
+
+      // The mutation has to be observable on the live config before the
+      // caller dispatches the prompt — otherwise the turn that delivers
+      // this very message would still land on the previously-configured
+      // model. The message itself is NOT touched: the slash stays in the
+      // prompt the agent sees, mirroring how `/skill-name` references
+      // survive the dispatch.
+      expect(session.config.model).toBe("anthropic:claude-sonnet-5-1");
+      expect(handledCommands).toEqual(["model"]);
+      expect(blocks.some((b) => b.label === "[model]")).toBe(true);
+
+      // Run a real turn to confirm the runner picks up the new model on the
+      // prompt that carries the remainder, not just on some later turn.
+      await session.start();
+      await session.dispose();
+      const stored = JSON.parse(await readFile(join(sessionPath, "state.json"), "utf-8"));
+      expect(stored.state.options.model).toBe("anthropic:claude-sonnet-5-1");
+    },
+  );
 
   testIfDocker("setModel rejects unknown model shorthands without mutating config", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "duet-model-set-bad-"));

--- a/test/tui-slash-model-command.test.ts
+++ b/test/tui-slash-model-command.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   BUILT_IN_SLASH_COMMAND_ITEMS,
+  extractInlineSlashCommands,
   type SlashCommandContext,
   tryDispatchSlashCommand,
 } from "../src/tui/slash-commands.js";
@@ -151,5 +152,103 @@ describe("/thinking slash command", () => {
     expect(ctx.blocks).toHaveLength(1);
     expect(ctx.blocks[0]!.label).toBe("[thinking]");
     expect(ctx.blocks[0]!.body).toBe("Unknown thinking level: bogus");
+  });
+});
+
+describe("extractInlineSlashCommands", () => {
+  test("fires /model from the middle of a prompt without touching the message", () => {
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        calls.push(model);
+        return { modelName: model };
+      },
+    });
+
+    // The message itself stays the caller's responsibility — the
+    // extractor only triggers side effects, exactly like skills.
+    const { handledCommands } = extractInlineSlashCommands(
+      "hey /model sonnet-4.6 please refactor this file",
+      ctx,
+    );
+
+    expect(calls).toEqual(["sonnet-4.6"]);
+    expect(handledCommands).toEqual(["model"]);
+  });
+
+  test("fires multiple inline commands in one prompt", () => {
+    const setModelCalls: string[] = [];
+    const setThinkingCalls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        setModelCalls.push(model);
+        return { modelName: model };
+      },
+      setThinkingLevel: (level) => {
+        setThinkingCalls.push(level);
+        return { thinkingLevel: level };
+      },
+    });
+
+    const { handledCommands } = extractInlineSlashCommands(
+      "/model opus-4.7 think hard /thinking high about this",
+      ctx,
+    );
+
+    expect(setModelCalls).toEqual(["opus-4.7"]);
+    expect(setThinkingCalls).toEqual(["high"]);
+    // Order follows BUILT_IN_SLASH_COMMANDS iteration, not message order;
+    // what matters is that both commands fired.
+    expect(handledCommands).toContain("model");
+    expect(handledCommands).toContain("thinking");
+  });
+
+  test("never matches /name embedded inside another token (URLs, paths)", () => {
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        calls.push(model);
+        return { modelName: model };
+      },
+    });
+
+    const { handledCommands } = extractInlineSlashCommands(
+      "check https://example.com/model/foo and /usr/local/bin",
+      ctx,
+    );
+
+    expect(calls).toEqual([]);
+    expect(handledCommands).toEqual([]);
+  });
+
+  test("/feedback inside a prompt is NOT fired (rest-of-line arg, no inline shape)", () => {
+    const ctx = makeContext();
+    const { handledCommands } = extractInlineSlashCommands(
+      "please send /feedback this rocks for me",
+      ctx,
+    );
+    expect(handledCommands).toEqual([]);
+  });
+
+  test("onlyCommands restricts which inline commands fire (used by the non-TUI CLI path)", () => {
+    const setModelCalls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        setModelCalls.push(model);
+        return { modelName: model };
+      },
+      onReset: () => {
+        throw new Error("onReset must not run when filtered out");
+      },
+    });
+
+    const { handledCommands } = extractInlineSlashCommands(
+      "/model sonnet-4.6 also /reset please",
+      ctx,
+      { onlyCommands: new Set(["model", "thinking"]) },
+    );
+
+    expect(setModelCalls).toEqual(["sonnet-4.6"]);
+    expect(handledCommands).toEqual(["model"]);
   });
 });

--- a/test/tui-slash-model-command.test.ts
+++ b/test/tui-slash-model-command.test.ts
@@ -20,10 +20,11 @@ function makeContext(
   const setModel = overrides.setModel ?? ((model: string) => ({ modelName: model }));
   const setThinkingLevel =
     overrides.setThinkingLevel ?? ((level: string) => ({ thinkingLevel: level }));
+  // Controllers are intentionally omitted — they are optional on
+  // SlashCommandContext, and these tests only exercise commands that
+  // do not touch them. Leaves the test fixtures honest about which
+  // surfaces they actually depend on.
   return {
-    pasteController: {} as never,
-    copyController: {} as never,
-    transcriptWriter: {} as never,
     appendBlock: (label, body, fg) => {
       blocks.push({ label, body, fg });
     },

--- a/test/tui-slash-model-command.test.ts
+++ b/test/tui-slash-model-command.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   BUILT_IN_SLASH_COMMAND_ITEMS,
-  runInlineSlashCommands,
+  applyInlineSlashCommands,
   type SlashCommandContext,
   tryDispatchSlashCommand,
 } from "../src/tui/slash-commands.js";
@@ -155,8 +155,8 @@ describe("/thinking slash command", () => {
   });
 });
 
-describe("runInlineSlashCommands", () => {
-  test("fires /model from the middle of a prompt without touching the message", () => {
+describe("applyInlineSlashCommands", () => {
+  test("fires /model from the middle of a prompt and strips it from the residue", () => {
     const calls: string[] = [];
     const ctx = makeContext({
       setModel: (model) => {
@@ -165,18 +165,20 @@ describe("runInlineSlashCommands", () => {
       },
     });
 
-    // The message itself stays the caller's responsibility — the
-    // extractor only triggers side effects, exactly like skills.
-    const { handledCommands } = runInlineSlashCommands(
+    // The slash form is removed from the residue so the agent does not
+    // have to re-parse local UI commands as user content. Words on
+    // either side stay separated by a single space.
+    const { handledCommands, residue } = applyInlineSlashCommands(
       "hey /model sonnet-4.6 please refactor this file",
       ctx,
     );
 
     expect(calls).toEqual(["sonnet-4.6"]);
     expect(handledCommands).toEqual(["model"]);
+    expect(residue).toBe("hey please refactor this file");
   });
 
-  test("fires multiple inline commands in one prompt", () => {
+  test("fires multiple inline commands in one prompt and strips both from the residue", () => {
     const setModelCalls: string[] = [];
     const setThinkingCalls: string[] = [];
     const ctx = makeContext({
@@ -190,7 +192,7 @@ describe("runInlineSlashCommands", () => {
       },
     });
 
-    const { handledCommands } = runInlineSlashCommands(
+    const { handledCommands, residue } = applyInlineSlashCommands(
       "/model opus-4.7 think hard /thinking high about this",
       ctx,
     );
@@ -201,6 +203,26 @@ describe("runInlineSlashCommands", () => {
     // what matters is that both commands fired.
     expect(handledCommands).toContain("model");
     expect(handledCommands).toContain("thinking");
+    expect(residue).toBe("think hard about this");
+  });
+
+  test("residue is empty when the whole prompt was inline slash commands (so callers can skip the turn)", () => {
+    const setModelCalls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        setModelCalls.push(model);
+        return { modelName: model };
+      },
+    });
+
+    const { handledCommands, residue } = applyInlineSlashCommands("/model sonnet-4.6", ctx);
+
+    expect(setModelCalls).toEqual(["sonnet-4.6"]);
+    expect(handledCommands).toEqual(["model"]);
+    // Empty residue is the signal callers use to skip dispatching
+    // the prompt to the agent — mirrors how the whole-message
+    // dispatcher returns early before reaching dispatchTurn.
+    expect(residue).toBe("");
   });
 
   test("never matches /name embedded inside another token (URLs, paths)", () => {
@@ -212,22 +234,137 @@ describe("runInlineSlashCommands", () => {
       },
     });
 
-    const { handledCommands } = runInlineSlashCommands(
+    const { handledCommands, residue } = applyInlineSlashCommands(
       "check https://example.com/model/foo and /usr/local/bin",
       ctx,
     );
 
     expect(calls).toEqual([]);
     expect(handledCommands).toEqual([]);
+    // Nothing matched, residue is the original message verbatim.
+    expect(residue).toBe("check https://example.com/model/foo and /usr/local/bin");
   });
 
   test("/feedback inside a prompt is NOT fired (rest-of-line arg, no inline shape)", () => {
     const ctx = makeContext();
-    const { handledCommands } = runInlineSlashCommands(
+    const { handledCommands, residue } = applyInlineSlashCommands(
       "please send /feedback this rocks for me",
       ctx,
     );
     expect(handledCommands).toEqual([]);
+    expect(residue).toBe("please send /feedback this rocks for me");
+  });
+
+  test("inline /model with a rejected name renders an error block and never mutates config", () => {
+    // Setter rejects exactly the same way Session.setModel would reject
+    // an unresolvable shorthand: throw before mutating. The inline path
+    // must surface that as a red [model] block, not crash the dispatch,
+    // so the original prompt still runs on the previously-configured
+    // model.
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        calls.push(model);
+        throw new Error("Unknown model shorthand: bogus");
+      },
+    });
+
+    const { handledCommands } = applyInlineSlashCommands(
+      "hey can you review this /model bogus and reply",
+      ctx,
+    );
+
+    // Handler ran (it was matched and dispatched) but setModel threw.
+    // The handler counts as "handled" because the side effect attempt
+    // fired; the model itself is unchanged because no successful return
+    // reached the config layer.
+    expect(calls).toEqual(["bogus"]);
+    expect(handledCommands).toEqual(["model"]);
+    const block = ctx.blocks.find((b) => b.label === "[model]");
+    expect(block?.body).toBe("Unknown model shorthand: bogus");
+    // The handler renders error blocks with the system's error color so
+    // the TUI shows them in red — we assert it is a non-default fg, not
+    // the exact ANSI sequence, so the theme can evolve without breaking
+    // this test.
+    expect(block?.fg).toBeTruthy();
+  });
+
+  test("inline /thinking with a rejected level renders an error block and never mutates config", () => {
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setThinkingLevel: (level) => {
+        calls.push(level);
+        throw new Error(
+          "Unknown thinking level: ultra. Expected one of minimal, low, medium, high, xhigh.",
+        );
+      },
+    });
+
+    const { handledCommands } = applyInlineSlashCommands(
+      "please /thinking ultra and answer carefully",
+      ctx,
+    );
+
+    expect(calls).toEqual(["ultra"]);
+    expect(handledCommands).toEqual(["thinking"]);
+    const block = ctx.blocks.find((b) => b.label === "[thinking]");
+    expect(block?.body).toContain("Unknown thinking level: ultra");
+    expect(block?.fg).toBeTruthy();
+  });
+
+  test("inline /model with no argument is left as literal text (token shape requires an arg)", () => {
+    // Inline-token shape requires `[ \t]+(\S+)` after the command name.
+    // A bare `/model` mid-prompt has no inline match, so it falls
+    // through to the agent unchanged — the user gets no error block and
+    // no surprise config swap. Whole-message `/model` (handled by the
+    // dispatcher) is the path that prints usage; this one explicitly is
+    // not.
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        calls.push(model);
+        return { modelName: model };
+      },
+    });
+
+    const { handledCommands, residue } = applyInlineSlashCommands(
+      "please look at this and /model",
+      ctx,
+    );
+
+    expect(calls).toEqual([]);
+    expect(handledCommands).toEqual([]);
+    expect(ctx.blocks).toEqual([]);
+    expect(residue).toBe("please look at this and /model");
+  });
+
+  test("inline /model treats the next non-whitespace token as the arg (even if it is not a model name)", () => {
+    // Without scoping the arg to look like a model name, the next word
+    // after `/model` is the arg. The parser cannot distinguish "the
+    // model name" from "a stray word that happens to follow /model".
+    // We surface the resolver error so the user notices, rather than
+    // silently picking up `please` as a model.
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        calls.push(model);
+        throw new Error(`Unknown model shorthand: ${model}`);
+      },
+    });
+
+    const { handledCommands, residue } = applyInlineSlashCommands(
+      "hey /model please look at this",
+      ctx,
+    );
+
+    expect(calls).toEqual(["please"]);
+    expect(handledCommands).toEqual(["model"]);
+    expect(ctx.blocks.find((b) => b.label === "[model]")?.body).toBe(
+      "Unknown model shorthand: please",
+    );
+    // `please` was consumed as the (failing) arg, so it is stripped
+    // from the residue along with the slash form itself.
+    expect(residue).toBe("hey look at this");
   });
 
   test("onlyCommands restricts which inline commands fire (used by the non-TUI CLI path)", () => {
@@ -242,7 +379,7 @@ describe("runInlineSlashCommands", () => {
       },
     });
 
-    const { handledCommands } = runInlineSlashCommands(
+    const { handledCommands, residue } = applyInlineSlashCommands(
       "/model sonnet-4.6 also /reset please",
       ctx,
       { onlyCommands: new Set(["model", "thinking"]) },
@@ -250,5 +387,8 @@ describe("runInlineSlashCommands", () => {
 
     expect(setModelCalls).toEqual(["sonnet-4.6"]);
     expect(handledCommands).toEqual(["model"]);
+    // /reset stays in the residue because it was filtered out of the
+    // inline-eligible set — the CLI intentionally ignores it.
+    expect(residue).toBe("also /reset please");
   });
 });

--- a/test/tui-slash-model-command.test.ts
+++ b/test/tui-slash-model-command.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BUILT_IN_SLASH_COMMAND_ITEMS,
+  type SlashCommandContext,
+  tryDispatchSlashCommand,
+} from "../src/tui/slash-commands.js";
+
+/**
+ * Unit-level coverage for `/model`. Validates the dispatcher routes the
+ * command, the handler validates arguments, and the canonicalized name
+ * flows back into the transcript line. The full keyboard path is
+ * exercised by `tui-slash-commands.test.ts`; this file keeps the focused
+ * branch coverage cheap.
+ */
+function makeContext(
+  overrides: Partial<SlashCommandContext> & {
+    onSetModel?: (model: string) => { modelName: string };
+  } = {},
+): SlashCommandContext & { blocks: Array<{ label: string | null; body: string; fg: string }> } {
+  const blocks: Array<{ label: string | null; body: string; fg: string }> = [];
+  const setModel =
+    overrides.setModel ?? overrides.onSetModel ?? ((model: string) => ({ modelName: model }));
+  return {
+    pasteController: {} as never,
+    copyController: {} as never,
+    transcriptWriter: {} as never,
+    appendBlock: (label, body, fg) => {
+      blocks.push({ label, body, fg });
+    },
+    onReset: () => {},
+    setModel,
+    ...overrides,
+    blocks,
+  };
+}
+
+describe("/model slash command", () => {
+  test("/model is registered in the autocomplete catalog", () => {
+    const item = BUILT_IN_SLASH_COMMAND_ITEMS.find((row) => row.name === "model");
+    expect(item).toBeDefined();
+    expect(item?.group).toBe("commands");
+  });
+
+  test("/model <name> dispatches setModel and writes a [model] block", () => {
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        calls.push(model);
+        return { modelName: model };
+      },
+    });
+
+    const handled = tryDispatchSlashCommand("/model sonnet-4.6", ctx);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual(["sonnet-4.6"]);
+    expect(ctx.blocks).toHaveLength(1);
+    expect(ctx.blocks[0]!.label).toBe("[model]");
+    expect(ctx.blocks[0]!.body).toContain("sonnet-4.6");
+    expect(ctx.blocks[0]!.body).toContain("next turn");
+  });
+
+  test("/model with no argument prints usage and never calls setModel", () => {
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setModel: (model) => {
+        calls.push(model);
+        return { modelName: model };
+      },
+    });
+
+    const handled = tryDispatchSlashCommand("/model", ctx);
+
+    expect(handled).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(ctx.blocks).toHaveLength(1);
+    expect(ctx.blocks[0]!.body).toContain("Usage:");
+  });
+
+  test("/model surfaces setModel errors through an error-colored block", () => {
+    const ctx = makeContext({
+      setModel: () => {
+        throw new Error("unknown model: bogus");
+      },
+    });
+
+    const handled = tryDispatchSlashCommand("/model bogus", ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.blocks).toHaveLength(1);
+    expect(ctx.blocks[0]!.label).toBe("[model]");
+    expect(ctx.blocks[0]!.body).toBe("unknown model: bogus");
+  });
+});

--- a/test/tui-slash-model-command.test.ts
+++ b/test/tui-slash-model-command.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   BUILT_IN_SLASH_COMMAND_ITEMS,
-  extractInlineSlashCommands,
+  runInlineSlashCommands,
   type SlashCommandContext,
   tryDispatchSlashCommand,
 } from "../src/tui/slash-commands.js";
@@ -155,7 +155,7 @@ describe("/thinking slash command", () => {
   });
 });
 
-describe("extractInlineSlashCommands", () => {
+describe("runInlineSlashCommands", () => {
   test("fires /model from the middle of a prompt without touching the message", () => {
     const calls: string[] = [];
     const ctx = makeContext({
@@ -167,7 +167,7 @@ describe("extractInlineSlashCommands", () => {
 
     // The message itself stays the caller's responsibility — the
     // extractor only triggers side effects, exactly like skills.
-    const { handledCommands } = extractInlineSlashCommands(
+    const { handledCommands } = runInlineSlashCommands(
       "hey /model sonnet-4.6 please refactor this file",
       ctx,
     );
@@ -190,7 +190,7 @@ describe("extractInlineSlashCommands", () => {
       },
     });
 
-    const { handledCommands } = extractInlineSlashCommands(
+    const { handledCommands } = runInlineSlashCommands(
       "/model opus-4.7 think hard /thinking high about this",
       ctx,
     );
@@ -212,7 +212,7 @@ describe("extractInlineSlashCommands", () => {
       },
     });
 
-    const { handledCommands } = extractInlineSlashCommands(
+    const { handledCommands } = runInlineSlashCommands(
       "check https://example.com/model/foo and /usr/local/bin",
       ctx,
     );
@@ -223,7 +223,7 @@ describe("extractInlineSlashCommands", () => {
 
   test("/feedback inside a prompt is NOT fired (rest-of-line arg, no inline shape)", () => {
     const ctx = makeContext();
-    const { handledCommands } = extractInlineSlashCommands(
+    const { handledCommands } = runInlineSlashCommands(
       "please send /feedback this rocks for me",
       ctx,
     );
@@ -242,7 +242,7 @@ describe("extractInlineSlashCommands", () => {
       },
     });
 
-    const { handledCommands } = extractInlineSlashCommands(
+    const { handledCommands } = runInlineSlashCommands(
       "/model sonnet-4.6 also /reset please",
       ctx,
       { onlyCommands: new Set(["model", "thinking"]) },

--- a/test/tui-slash-model-command.test.ts
+++ b/test/tui-slash-model-command.test.ts
@@ -13,13 +13,12 @@ import {
  * branch coverage cheap.
  */
 function makeContext(
-  overrides: Partial<SlashCommandContext> & {
-    onSetModel?: (model: string) => { modelName: string };
-  } = {},
+  overrides: Partial<SlashCommandContext> = {},
 ): SlashCommandContext & { blocks: Array<{ label: string | null; body: string; fg: string }> } {
   const blocks: Array<{ label: string | null; body: string; fg: string }> = [];
-  const setModel =
-    overrides.setModel ?? overrides.onSetModel ?? ((model: string) => ({ modelName: model }));
+  const setModel = overrides.setModel ?? ((model: string) => ({ modelName: model }));
+  const setThinkingLevel =
+    overrides.setThinkingLevel ?? ((level: string) => ({ thinkingLevel: level }));
   return {
     pasteController: {} as never,
     copyController: {} as never,
@@ -29,6 +28,7 @@ function makeContext(
     },
     onReset: () => {},
     setModel,
+    setThinkingLevel,
     ...overrides,
     blocks,
   };
@@ -90,5 +90,66 @@ describe("/model slash command", () => {
     expect(ctx.blocks).toHaveLength(1);
     expect(ctx.blocks[0]!.label).toBe("[model]");
     expect(ctx.blocks[0]!.body).toBe("unknown model: bogus");
+  });
+});
+
+describe("/thinking slash command", () => {
+  test("/thinking is registered in the autocomplete catalog", () => {
+    const item = BUILT_IN_SLASH_COMMAND_ITEMS.find((row) => row.name === "thinking");
+    expect(item).toBeDefined();
+    expect(item?.group).toBe("commands");
+  });
+
+  test("/thinking <level> dispatches setThinkingLevel and writes a [thinking] block", () => {
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setThinkingLevel: (level) => {
+        calls.push(level);
+        return { thinkingLevel: level };
+      },
+    });
+
+    const handled = tryDispatchSlashCommand("/thinking high", ctx);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual(["high"]);
+    expect(ctx.blocks).toHaveLength(1);
+    expect(ctx.blocks[0]!.label).toBe("[thinking]");
+    expect(ctx.blocks[0]!.body).toContain("high");
+    expect(ctx.blocks[0]!.body).toContain("next turn");
+  });
+
+  test("/thinking with no argument prints usage and never calls setThinkingLevel", () => {
+    const calls: string[] = [];
+    const ctx = makeContext({
+      setThinkingLevel: (level) => {
+        calls.push(level);
+        return { thinkingLevel: level };
+      },
+    });
+
+    const handled = tryDispatchSlashCommand("/thinking", ctx);
+
+    expect(handled).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(ctx.blocks).toHaveLength(1);
+    expect(ctx.blocks[0]!.body).toContain("Usage:");
+    expect(ctx.blocks[0]!.body).toContain("minimal");
+    expect(ctx.blocks[0]!.body).toContain("xhigh");
+  });
+
+  test("/thinking surfaces setThinkingLevel errors through an error-colored block", () => {
+    const ctx = makeContext({
+      setThinkingLevel: () => {
+        throw new Error("Unknown thinking level: bogus");
+      },
+    });
+
+    const handled = tryDispatchSlashCommand("/thinking bogus", ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.blocks).toHaveLength(1);
+    expect(ctx.blocks[0]!.label).toBe("[thinking]");
+    expect(ctx.blocks[0]!.body).toBe("Unknown thinking level: bogus");
   });
 });


### PR DESCRIPTION
## Summary

Adds a built-in `/model <name>` slash command to the TUI. Sending it queues a model swap for the **next** turn — the current in-flight turn (if any) keeps the model it started with and is not interrupted.

- `Session.setModel(name)` validates the name through the same `resolveModelName` machinery the CLI uses at boot, then mutates `config.model`. `startOptions()` reads this per prompt, so the next turn picks up the new value without restarting the session.
- `/model` dispatches through a new `SlashCommandContext.setModel`. Usage is printed for `/model` with no argument; resolver errors are surfaced in a red `[model]` block instead of crashing.
- The command is registered in the picker catalog the same way as `/feedback`, `/reset`, etc.

## Test plan

- [x] `bun run check-types`
- [x] `bun run lint`
- [x] `bun run format`
- [x] Docker test pass for `test/session-model-switch.test.ts` (added 2 new tests) and `test/tui-slash-model-command.test.ts` (new file, 4 tests). 7/7 pass.

Manual:
- `/model sonnet-4.6` while a turn is running → `[model] next turn will use sonnet-4.6. The current turn (if any) keeps its model.` and the in-flight turn continues unaffected.
- `/model bogus` → red `[model]` error from the resolver, config unchanged.
- `/model` (no arg) → usage line.