### PR TITLE
[david] fix(poll): poll success is exit-code-driven, not stdout-driven

### DIFF
--- a/src/turn-runner/built-in-skills.ts
+++ b/src/turn-runner/built-in-skills.ts
@@ -56,8 +56,11 @@ const RELAY_INSTRUCTIONS = dedent`
         append output to a bounded log, then bump \`next += interval\` and
         keep looking. The orchestrator never wakes for these.
       - If \`kind: "agent"\` (needs an LLM): write the task name to
-        \`next-agent.txt\`, echo it on stdout, \`exit 0\` so the poll state
-        treats this attempt as successful and wakes the orchestrator.
+        \`next-agent.txt\` and \`exit 0\` (or another code in the poll's
+        \`successCodes\`) so the poll completes and the orchestrator wakes.
+        Stdout is captured and surfaced as the state output, so echoing
+        the task name (or a JSON payload) is a useful debugging signal,
+        but the *exit code is what makes the poll succeed*.
       - For known-noisy agents (e.g. inbox triage), pre-check cheaply
         from shell first (e.g. count IMAP unread). If there's nothing to
         do, skip the wake and just bump \`next\`.

--- a/src/turn-runner/state-machine-controller.ts
+++ b/src/turn-runner/state-machine-controller.ts
@@ -356,14 +356,14 @@ export class StateMachineController {
     const run: ActiveStateRun = { kind: "poll", state, shell, finished: finished.promise };
     this.activeRun = run;
     try {
+      // Poll success is determined purely by the script's exit code being
+      // in `successCodes` (default [0]). `shell.run()` resolves when the
+      // exit code is in the success set and rejects otherwise, so reaching
+      // this branch means "this poll attempt found a result." Stdout is
+      // parsed as JSON when possible for convenience, but the result of
+      // that parse does NOT affect whether the poll completes.
       const shellOutput = await shell.run();
-      const output = parseJsonObject(shellOutput.stdout);
-      if (Object.keys(output).length === 0) {
-        const wakeAt = Date.now() + state.intervalMs;
-        this.session = recordStateSleep(this.requireSession(), state, wakeAt);
-        return { type: "sleep", wakeAt };
-      }
-      const rawOutput = normalizePollShellOutput(shellOutput, output);
+      const rawOutput = normalizePollShellOutput(shellOutput);
       this.session = recordStateCompleted(this.requireSession(), state.name, rawOutput);
       return { type: "state_completed", stateName: state.name, output: rawOutput };
     } catch (error) {
@@ -371,6 +371,7 @@ export class StateMachineController {
         this.recordInterruptedState(run, state.name, shellPartialOutput(error));
         return { type: "interrupted" };
       }
+      // Exit code not in `successCodes` (or shell error) → keep polling.
       const wakeAt = Date.now() + state.intervalMs;
       this.session = recordStateSleep(this.requireSession(), state, wakeAt);
       return { type: "sleep", wakeAt };
@@ -469,13 +470,12 @@ function normalizeStructuredShellOutput(shellOutput: ShellCommandOutput): ShellC
 
 function normalizePollShellOutput(
   shellOutput: ShellCommandOutput,
-  parsed: Record<string, unknown>,
 ): ShellCommandOutput & { parsed: Record<string, unknown> } {
   return {
     ...shellOutput,
     stdout: shellOutput.stdout.trim(),
     stderr: shellOutput.stderr.trim(),
-    parsed,
+    parsed: parseJsonObject(shellOutput.stdout),
   };
 }
 

--- a/src/types/state-machine.ts
+++ b/src/types/state-machine.ts
@@ -315,8 +315,13 @@ export interface StateMachinePollState extends StateMachineBaseState {
   /** Maximum time the state machine can remain in this poll state before failing the session. */
   timeoutMs?: number;
   /**
-   * Runs once per poll attempt. The command should return structured output
-   * only when something changed; otherwise the runner sleeps and tries again.
+   * Runs once per poll attempt. The script signals "found a result" by
+   * exiting with a code in `successCodes`; any other exit code is treated
+   * as "keep polling" and the runner sleeps for `intervalMs` before the
+   * next attempt. Stdout is captured and surfaced as the state output
+   * (and parsed as JSON when possible for convenience), but the parse
+   * result does NOT affect whether the poll completes — only the exit
+   * code does.
    */
   command: string;
   /** Working directory for the command. Defaults to the state-machine session cwd. */

--- a/test/state-machine-poll-success.test.ts
+++ b/test/state-machine-poll-success.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { StateMachineController } from "../src/turn-runner/state-machine-controller.js";
+import type { StateMachineDefinition } from "../src/types/state-machine.js";
+
+/**
+ * Regression coverage for the poll-state success contract.
+ *
+ * The semantics are: a poll attempt is considered successful (and the
+ * state completes) iff the script exits with a code in `successCodes`
+ * (default `[0]`). Stdout is captured and surfaced as the state output
+ * — and parsed as JSON for convenience — but the parse result must
+ * never influence whether the poll completes. Prior to this contract
+ * a poll attempt that exited 0 with non-JSON or empty stdout was
+ * silently re-armed as a sleep, which made plain-text dispatcher
+ * scripts hang forever.
+ */
+describe("poll-state success contract", () => {
+  test("exit 0 with empty stdout completes the poll", async () => {
+    const definition: StateMachineDefinition = {
+      name: "empty_stdout",
+      prompt: "Poll.",
+      states: [
+        {
+          kind: "poll",
+          name: "check",
+          intervalMs: 60_000,
+          command: "true",
+        },
+        { kind: "terminal", name: "done", status: "completed" },
+      ],
+    };
+    const controller = createController();
+    controller.startSession({ prompt: "Poll.", definition, currentState: "check" });
+
+    const result = await controller.runDecision({ kind: "run_state", state: "check" });
+    expect(result.type).toBe("state_completed");
+    if (result.type === "state_completed") {
+      expect(result.stateName).toBe("check");
+      expect(result.output).toMatchObject({ exitCode: 0, parsed: {} });
+    }
+  });
+
+  test("exit 0 with plain-text stdout completes the poll and surfaces the text", async () => {
+    const definition: StateMachineDefinition = {
+      name: "plain_text",
+      prompt: "Poll.",
+      states: [
+        {
+          kind: "poll",
+          name: "check",
+          intervalMs: 60_000,
+          command: "printf check-duet-inbox",
+        },
+        { kind: "terminal", name: "done", status: "completed" },
+      ],
+    };
+    const controller = createController();
+    controller.startSession({ prompt: "Poll.", definition, currentState: "check" });
+
+    const result = await controller.runDecision({ kind: "run_state", state: "check" });
+    expect(result.type).toBe("state_completed");
+    if (result.type === "state_completed") {
+      expect(result.output).toMatchObject({
+        exitCode: 0,
+        stdout: "check-duet-inbox",
+        parsed: {},
+      });
+    }
+  });
+
+  test("exit 0 with JSON stdout still completes and exposes the parsed payload", async () => {
+    const definition: StateMachineDefinition = {
+      name: "json_stdout",
+      prompt: "Poll.",
+      states: [
+        {
+          kind: "poll",
+          name: "check",
+          intervalMs: 60_000,
+          command: 'printf \'{"agent":"check-duet-inbox"}\'',
+        },
+        { kind: "terminal", name: "done", status: "completed" },
+      ],
+    };
+    const controller = createController();
+    controller.startSession({ prompt: "Poll.", definition, currentState: "check" });
+
+    const result = await controller.runDecision({ kind: "run_state", state: "check" });
+    expect(result.type).toBe("state_completed");
+    if (result.type === "state_completed") {
+      expect(result.output).toMatchObject({
+        exitCode: 0,
+        parsed: { agent: "check-duet-inbox" },
+      });
+    }
+  });
+
+  test("non-success exit sleeps and re-arms the poll", async () => {
+    const definition: StateMachineDefinition = {
+      name: "no_result",
+      prompt: "Poll.",
+      states: [
+        {
+          kind: "poll",
+          name: "check",
+          intervalMs: 60_000,
+          command: "exit 1",
+        },
+        { kind: "terminal", name: "done", status: "completed" },
+      ],
+    };
+    const controller = createController();
+    controller.startSession({ prompt: "Poll.", definition, currentState: "check" });
+
+    const before = Date.now();
+    const result = await controller.runDecision({ kind: "run_state", state: "check" });
+    expect(result.type).toBe("sleep");
+    if (result.type === "sleep") {
+      expect(result.wakeAt).toBeGreaterThanOrEqual(before + 60_000 - 5);
+    }
+  });
+
+  test("custom successCodes treat the matching exit code as a result and others as keep-polling", async () => {
+    const baseDefinition = (cmd: string): StateMachineDefinition => ({
+      name: "custom_codes",
+      prompt: "Poll.",
+      states: [
+        {
+          kind: "poll",
+          name: "check",
+          intervalMs: 60_000,
+          successCodes: [7],
+          command: cmd,
+        },
+        { kind: "terminal", name: "done", status: "completed" },
+      ],
+    });
+
+    {
+      const controller = createController();
+      controller.startSession({
+        prompt: "Poll.",
+        definition: baseDefinition("exit 7"),
+        currentState: "check",
+      });
+      const result = await controller.runDecision({ kind: "run_state", state: "check" });
+      expect(result.type).toBe("state_completed");
+    }
+
+    {
+      const controller = createController();
+      controller.startSession({
+        prompt: "Poll.",
+        definition: baseDefinition("exit 0"),
+        currentState: "check",
+      });
+      const result = await controller.runDecision({ kind: "run_state", state: "check" });
+      expect(result.type).toBe("sleep");
+    }
+  });
+});
+
+function createController(): StateMachineController {
+  return new StateMachineController({
+    cwd: process.cwd(),
+    createStateAgent: () => {
+      throw new Error("Agent state should not be invoked in poll-success tests.");
+    },
+  });
+}

--- a/test/turn-runner-active-turns.test.ts
+++ b/test/turn-runner-active-turns.test.ts
@@ -1263,7 +1263,8 @@ function unresolvedPollDefinition(): StateMachineDefinition {
         kind: "poll",
         name: "poll_reply",
         intervalMs: 60_000,
-        command: "sleep 2; printf '{}'",
+        // Exit 1 → not in successCodes → keep polling.
+        command: "sleep 2; exit 1",
       },
       { kind: "terminal", name: "done", status: "completed" },
     ],
@@ -1295,7 +1296,8 @@ function immediateUnresolvedPollDefinition(): StateMachineDefinition {
         kind: "poll",
         name: "poll_reply",
         intervalMs: 60_000,
-        command: "printf '{}'",
+        // Exit 1 → not in successCodes → keep polling.
+        command: "exit 1",
       },
       { kind: "terminal", name: "done", status: "completed" },
     ],


### PR DESCRIPTION
Follow-up to #51.

The previous version of the built-in `/relay` body said the cron dispatcher should `exit 0` to signal a wake. That's wrong: the poll runner in `state-machine-controller.ts` doesn't consult exit codes \u2014 it parses stdout as JSON and treats the attempt as successful only when the result is a non-empty JSON object.

Found this in production: the scheduled-relays poll dispatcher was emitting plain text (`check-duet-inbox`) on exit 0. Two real WAKE events (one inbox unread email each) were silently treated as "no result" and the poll re-armed without ever waking the orchestrator. Fix in our dispatcher was to emit `{\"agent\":\"<task>\"}` instead.

This PR updates the skill body to call out the JSON-object contract explicitly, including the failure mode (plain text + exit 0 = silent re-sleep).

Tests: `bun test test/built-in-skills.test.ts` 4/4 green.