### PR TITLE
[David] feat: recognize chat-app compose-bar <Skill .../> tag in slash resolver

### DIFF
--- a/src/turn-runner/skill-context.ts
+++ b/src/turn-runner/skill-context.ts
@@ -150,17 +150,34 @@ export class SkillContext {
   }
 }
 
+// Matches the self-closing `<Skill name="..." path="..." />` tag that the
+// chat-app compose-bar `/` skill picker emits on both web and mobile when a
+// user selects a skill (see
+// apps/web/components/chat/compose-bar/primitives/input/features/mention/mention-markdown-codec.ts
+// and apps/mobile/src/lib/markdown.ts). We honor the tag as an alias for the
+// bare `/<name>` slash command so picker-driven activations get the same
+// SKILL.md injection as keyboard-typed ones. The tag spelling is fixed by
+// the chat-app codec, so capitalization is exact and the regex stays loose
+// only around the `name="..."` attribute position so other attributes (like
+// `path="..."`) can sit on either side.
+const SKILL_TAG_PATTERN = /<Skill\b[^>]*\bname="([A-Za-z0-9_.-]+)"[^>]*\/>/g;
+
 function parseSlashCommands(prompt: string): {
   commands: string[];
 } {
-  const tokens = prompt.trim().split(/\s+/);
   const commands: string[] = [];
 
+  const tokens = prompt.trim().split(/\s+/);
   for (const token of tokens) {
     const match = token.match(/^\/([A-Za-z0-9_.-]+)$/);
     if (match) {
       commands.push(match[1]!);
     }
+  }
+
+  for (const match of prompt.matchAll(SKILL_TAG_PATTERN)) {
+    const name = match[1];
+    if (name) commands.push(name);
   }
 
   return { commands };

--- a/test/skill-context-resolve.test.ts
+++ b/test/skill-context-resolve.test.ts
@@ -120,4 +120,103 @@ describe("SkillContext.resolveSlashSkillPrompt", () => {
     const resolved = ctx.resolveSlashSkillPrompt("look at /review:summary please");
     expect(resolved).toBe("look at /review:summary please");
   });
+
+  // Regression: a real Duet user message starting with `/review` followed by
+  // newlines and free-form prompt text. Locks in that the resolver wraps
+  // the SKILL.md body in the expected XML envelope:
+  //   <skill name="review">
+  //     <instructions>...SKILL.md body...</instructions>
+  //   </skill>
+  // and appends it after the user's original prompt verbatim.
+  testIfDocker(
+    "wraps the SKILL.md body in <skill><instructions> XML for a real `/review` user message",
+    async () => {
+      const skillBody = "Audit changed code for naming, dead refs, and stale comments.";
+      const skill = await writeSkill("review", skillBody);
+
+      const ctx = new SkillContext({
+        skills: [skill],
+        skillDiscovery: { includeDefaults: false },
+      });
+      await ctx.ensureLoaded();
+
+      const userPrompt =
+        "/review\n\nplus also review the changes - does it resolve with the xml tags?";
+      const resolved = ctx.resolveSlashSkillPrompt(userPrompt);
+
+      // Original user prompt preserved verbatim at the head.
+      expect(resolved.startsWith(userPrompt)).toBe(true);
+
+      // Full XML envelope present, with the SKILL.md body inside <instructions>.
+      expect(resolved).toContain('<skill name="review">');
+      expect(resolved).toContain("<instructions>");
+      expect(resolved).toContain(skillBody);
+      expect(resolved).toContain("</instructions>");
+      expect(resolved).toContain("</skill>");
+
+      // Tag ordering: opening <skill> before <instructions> before body
+      // before </instructions> before </skill>.
+      const skillOpen = resolved.indexOf('<skill name="review">');
+      const instrOpen = resolved.indexOf("<instructions>", skillOpen);
+      const bodyAt = resolved.indexOf(skillBody, instrOpen);
+      const instrClose = resolved.indexOf("</instructions>", bodyAt);
+      const skillClose = resolved.indexOf("</skill>", instrClose);
+      expect(skillOpen).toBeGreaterThan(-1);
+      expect(instrOpen).toBeGreaterThan(skillOpen);
+      expect(bodyAt).toBeGreaterThan(instrOpen);
+      expect(instrClose).toBeGreaterThan(bodyAt);
+      expect(skillClose).toBeGreaterThan(instrClose);
+
+      // Exactly one skill block — no accidental duplicate injection.
+      const skillOpenings = resolved.match(/<skill name="/g) ?? [];
+      expect(skillOpenings.length).toBe(1);
+    },
+  );
+
+  // Regression: chat-app's compose-bar `/` skill picker does NOT emit a bare
+  // `/review` slash token. It emits a literal self-closing XML tag of the
+  // shape `<Skill name="review" path="..." />` into the message markdown,
+  // verbatim, with no backend-side expansion (see
+  // apps/web/components/chat/compose-bar/primitives/input/features/mention/mention-markdown-codec.ts
+  // and apps/mobile/src/lib/markdown.ts). When chat-app sends that message
+  // to duet-agent, the runner must still inject the SKILL.md body so the
+  // model has skill context. Today `parseSlashCommands` only matches
+  // whitespace-separated `/name` tokens, so this case currently no-ops.
+  // This test pins the desired behavior so the gap is visible and the
+  // resolver can be extended to recognize the `<Skill name="..." />` form.
+  testIfDocker(
+    "injects the SKILL.md body when the user message contains the chat-app compose-bar `<Skill name=... path=... />` tag",
+    async () => {
+      const skillBody = "Audit changed code for naming, dead refs, and stale comments.";
+      const skill = await writeSkill("review", skillBody);
+
+      const ctx = new SkillContext({
+        skills: [skill],
+        skillDiscovery: { includeDefaults: false },
+      });
+      await ctx.ensureLoaded();
+
+      // Literal payload emitted by the chat-app web + mobile compose bars
+      // when the user picks the `review` skill from the `/` picker.
+      const userPrompt =
+        '<Skill name="review" path="/home/app/.duet/skills/review" />\n\nplease review the diff';
+      const resolved = ctx.resolveSlashSkillPrompt(userPrompt);
+
+      // Original user prompt preserved verbatim at the head.
+      expect(resolved.startsWith(userPrompt)).toBe(true);
+
+      // Skill body must be injected in the same XML envelope used for the
+      // bare `/review` slash form, so downstream consumers see one shape.
+      expect(resolved).toContain('<skill name="review">');
+      expect(resolved).toContain("<instructions>");
+      expect(resolved).toContain(skillBody);
+      expect(resolved).toContain("</instructions>");
+      expect(resolved).toContain("</skill>");
+
+      // Exactly one skill block — the `<Skill .../>` tag in the prompt must
+      // not double-resolve into two injected blocks.
+      const skillOpenings = resolved.match(/<skill name="/g) ?? [];
+      expect(skillOpenings.length).toBe(1);
+    },
+  );
 });


### PR DESCRIPTION
## Why

chat-app's compose-bar `/` skill picker (web + mobile) emits a literal `<Skill name="..." path="..." />` XML tag into the message markdown, **not** a bare `/name` slash token. See [`mention-markdown-codec.ts:301`](https://github.com/aomni-com/chat-app/blob/staging/apps/web/components/chat/compose-bar/primitives/input/features/mention/mention-markdown-codec.ts#L301) on web and [`markdown.ts:105`](https://github.com/aomni-com/chat-app/blob/staging/apps/mobile/src/lib/markdown.ts#L105) on mobile.

The chat-app backend forwards that message verbatim. duet-agent's `parseSlashCommands` only matched `^/[A-Za-z0-9_.-]+$` whitespace tokens, so picker-driven activations silently no-op'd — the model received no SKILL.md context. Only manually typed `/review` style messages worked.

## What

`parseSlashCommands` in `src/turn-runner/skill-context.ts` now also pulls names from `<Skill name="X" ... />` tags via a second regex pass. Same downstream envelope: a single `<skill name="X"><instructions>...</instructions></skill>` block appended to the original prompt.

## Tests

Two new `testIfDocker` regression cases in `test/skill-context-resolve.test.ts`:

1. **Real `/review` user message** — pins down the full XML envelope ordering (`<skill>` → `<instructions>` → body → `</instructions>` → `</skill>`) and exactly-one-block.
2. **Literal compose-bar `<Skill name="review" path="..." />` tag** — pins down that the XML tag form produces the same injection as the slash form.

All 7 `SkillContext.resolveSlashSkillPrompt` tests pass. Pre-existing 6 failures in `test/skills.test.ts` are unrelated (host-env pollution from real `~/.duet/skills`, present on `main`).

## Risk

Low. New regex runs once per prompt resolution. No change to the `/name` codepath. If the same skill is referenced both ways in one prompt (rare), it'll inject twice — matches existing duplicate-slash-token behavior.