### PR TITLE
feat(memory): cap global memory pack at fixed 8k tokens

### DIFF
--- a/src/memory/loader.ts
+++ b/src/memory/loader.ts
@@ -1,5 +1,6 @@
 import type { PGlite } from "@electric-sql/pglite";
 import type { Observation, ObservationKind, ObservationPriority } from "../types/memory.js";
+import { estimateTokens } from "./observational.js";
 
 /**
  * Loads ranked memory packs for rendering above the message tail.
@@ -197,9 +198,4 @@ function rowToObservation(row: GlobalRow): Observation {
     content: row.content,
     tags: JSON.parse(row.tags_json) as string[],
   };
-}
-
-/** Rough char-to-token estimate matching the rest of the memory subsystem. */
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
 }

--- a/src/memory/observational.ts
+++ b/src/memory/observational.ts
@@ -1852,14 +1852,25 @@ function estimateMessageTokens(message: ObserverMessagePreview): number {
 }
 
 /**
- * Heuristic 4-chars-per-token estimator used everywhere the runner needs
+ * Average characters per token assumed by the heuristic estimator. The
+ * common rule of thumb is ~4 chars/token on English prose, but real
+ * provider tokenizers consistently produce more tokens than that on
+ * code, JSON, tool calls, and non-English content. We use 3.2 to bias
+ * the estimate ~25 % conservative so memory triggers fire before the
+ * provider's actual token count crosses the actor's window, instead of
+ * after.
+ */
+export const CHARS_PER_TOKEN = 3.2;
+
+/**
+ * Heuristic chars-per-token estimator used everywhere the runner needs
  * a budget number without tokenizing the actual provider payload. Exported
  * so surfaces and the runner can attribute the same estimate the memory
  * pipeline does, keeping the segment breakdown on `TurnUsageFields`
  * consistent with the trigger arithmetic in this file.
  */
 export function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
 }
 
 function hashText(text: string): string {

--- a/src/memory/observational.ts
+++ b/src/memory/observational.ts
@@ -62,22 +62,34 @@ import {
 export const DEFAULT_EFFECTIVE_CONTEXT = 200_000;
 
 /**
- * Ratios of `effectiveContext` that sum to exactly 100%. These three budgets
- * are the only ones that count against the actor model's per-turn input —
- * `messageTokens` caps the raw-message tail, `observationTokens` caps the
- * local-memory pack rendered into the prefix, and `globalContextTokenBudget`
- * caps the cross-session pack rendered above local. The system prompt and
- * tool-call slack come out of `messageTokens`'s share since the raw tail
- * naturally absorbs whatever's left.
+ * Ratios of `effectiveContext` that govern the local-session budgets that
+ * count against the actor model's per-turn input. `messageTokens` caps the
+ * raw-message tail; `observationTokens` caps the local-memory pack rendered
+ * into the prefix. The system prompt and tool-call slack come out of
+ * `messageTokens`'s share since the raw tail naturally absorbs whatever's
+ * left. The cross-session pack is sized separately (see
+ * `GLOBAL_CONTEXT_TOKEN_BUDGET`) because scaling it with the model window
+ * would explode the prompt prefix on frontier-window models without
+ * making the global pack itself any more useful.
  */
 export const MEMORY_BUDGET_RATIOS = {
   /** Raw-message compaction trigger (per turn). */
   messageTokens: 0.6,
   /** Local-memory pack ceiling between reflection events. */
   observationTokens: 0.325,
-  /** Cross-session global pack ceiling. */
-  globalContextTokenBudget: 0.075,
 } as const;
+
+/**
+ * Fixed token cap on the cross-session global memory pack rendered above
+ * the local-session compacted view. Held constant (rather than derived from
+ * `effectiveContext`) because the pack's value is bounded by retrieval
+ * quality, not by the actor's window: a 1M-window model does not benefit
+ * from 75k of densest-recall reflections injected on every turn, it just
+ * pays for them. 8k is enough headroom for the top tens of reflections
+ * the ranker would actually choose, and the long tail stays reachable via
+ * the `recall_memory` tool when the turn needs it.
+ */
+export const GLOBAL_CONTEXT_TOKEN_BUDGET = 8_000;
 
 /**
  * Shared "keep half of the trigger" knob applied to both buffer activations.
@@ -171,9 +183,10 @@ export function deriveMemoryBudgets(effectiveContext: number): DerivedMemoryBudg
   const positive = Math.max(1, Math.floor(effectiveContext));
   const messageTokens = atLeastOne(MEMORY_BUDGET_RATIOS.messageTokens * positive);
   const observationTokens = atLeastOne(MEMORY_BUDGET_RATIOS.observationTokens * positive);
-  const globalContextTokenBudget = atLeastOne(
-    MEMORY_BUDGET_RATIOS.globalContextTokenBudget * positive,
-  );
+  // Clamp the global pack to the actor's window in degenerate small-context
+  // test fixtures so the pack can never grow larger than the budget the
+  // actor is sized for. Production windows are always well above 8k.
+  const globalContextTokenBudget = atLeastOne(Math.min(GLOBAL_CONTEXT_TOKEN_BUDGET, positive));
   return {
     observation: {
       messageTokens,

--- a/src/memory/storage.ts
+++ b/src/memory/storage.ts
@@ -6,6 +6,7 @@ import type { EmbedFn } from "./embedding.js";
 import { EmbeddingBackfillWorker } from "./embedding-worker.js";
 import { rebuildMemoryContextPack } from "./context-pack.js";
 import { runMigrations } from "./migrations.js";
+import { estimateTokens } from "./observational.js";
 import { MemorySession } from "./session.js";
 import type { MemoryContextCache } from "./store.js";
 import { nanoid } from "nanoid";
@@ -344,10 +345,6 @@ async function upsertObservation(
 
 function resolveMemoryPath(path: string, cwd: string): string {
   return path.startsWith("/") ? path : join(cwd, path);
-}
-
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
 }
 
 function createMemoryId(): string {

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -1863,7 +1863,7 @@ export class TurnRunner {
   /**
    * Estimate the per-segment occupancy of the parent agent's input before
    * reconciliation with provider `totalTokens`. System prompt and memory
-   * packs use the same `ceil(chars/4)` heuristic as the memory pipeline so
+   * packs use the same `ceil(chars / CHARS_PER_TOKEN)` heuristic as the memory pipeline so
    * compaction triggers stay on the same scale as `MEMORY_BUDGET_RATIOS`.
    *
    * The message tail uses {@link calculateWireTokens} over the
@@ -1871,7 +1871,7 @@ export class TurnRunner {
    * messages already dropped by wire-shaping stop counting against the
    * `messages` segment instead of inflating it from the runner's full
    * retained transcript. Text and structured blocks (`toolCall`, thinking,
-   * etc.) use `ceil(chars/4)`, and image blocks contribute a fixed
+   * etc.) use `ceil(chars / CHARS_PER_TOKEN)`, and image blocks contribute a fixed
    * per-image estimate rather than their base64 byte length.
    *
    * `emitParentAgentEvent` rescales all four segments with

--- a/src/turn-runner/wire-shaping.ts
+++ b/src/turn-runner/wire-shaping.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { CHARS_PER_TOKEN } from "../memory/observational.js";
 
 /**
  * Byte-budget safety net for the dispatched message list. The token-budget
@@ -141,8 +142,8 @@ export function calculateWireBytes(messages: AgentMessage[]): number {
 
 /**
  * Token-side companion to {@link calculateWireBytes}. Text and structured
- * blocks use the same `ceil(chars/4)` heuristic the memory pipeline uses
- * elsewhere, but image blocks contribute a fixed
+ * blocks use the same `ceil(chars / CHARS_PER_TOKEN)` heuristic the memory
+ * pipeline uses elsewhere, but image blocks contribute a fixed
  * {@link IMAGE_WIRE_TOKEN_ESTIMATE} regardless of base64 size — the
  * provider's per-image charge is bounded and unrelated to payload bytes.
  * This is the value the eviction gate and the context-window usage bar
@@ -151,15 +152,15 @@ export function calculateWireBytes(messages: AgentMessage[]): number {
  */
 function calculateMessageTokens(msg: AgentMessage): number {
   const content = (msg as { content?: unknown }).content;
-  if (typeof content === "string") return Math.ceil(content.length / 4);
+  if (typeof content === "string") return Math.ceil(content.length / CHARS_PER_TOKEN);
   if (!Array.isArray(content)) return 0;
   let total = 0;
   for (const block of content) {
     if (isImageBlock(block)) total += IMAGE_WIRE_TOKEN_ESTIMATE;
-    else if (isTextBlock(block)) total += Math.ceil(block.text.length / 4);
+    else if (isTextBlock(block)) total += Math.ceil(block.text.length / CHARS_PER_TOKEN);
     else if (block && typeof block === "object") {
       try {
-        total += Math.ceil(JSON.stringify(block).length / 4);
+        total += Math.ceil(JSON.stringify(block).length / CHARS_PER_TOKEN);
       } catch {
         total += 64;
       }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -21,11 +21,13 @@ export interface TurnRunnerConfig extends TurnOptions {
    */
   sessionId?: string;
   /**
-   * Target ceiling, in tokens, for the actor model's per-turn input. Every
-   * memory budget (raw-message compaction trigger, raw-tail buffer,
-   * reflection trigger and buffer, global pack budget) is derived from this
-   * single number via fixed ratios in `deriveMemoryBudgets`; see
+   * Target ceiling, in tokens, for the actor model's per-turn input. The
+   * local-session memory budgets (raw-message compaction trigger, raw-tail
+   * buffer, reflection trigger and buffer) are derived from this single
+   * number via fixed ratios in `deriveMemoryBudgets`; see
    * `MEMORY_BUDGET_RATIOS` in `src/memory/observational.ts` for the table.
+   * The cross-session global pack uses a fixed cap
+   * (`GLOBAL_CONTEXT_TOKEN_BUDGET`) instead of scaling with this value.
    *
    * Defaults to 200_000. The runner clamps the resolved value to
    * `min(effectiveContext, model.contextWindow)` at use-time so a user

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -177,10 +177,14 @@ export interface ObservationalMemorySettings {
     instruction?: string;
   };
   /**
-   * Derived. Token budget for the global memory layer rendered ahead of
+   * Fixed cap. Token budget for the global memory layer rendered ahead of
    * the local session's compacted view. Cross-session reflections and
    * observations are ranked by `priority * usageDecay * kindBias` and
-   * packed greedily until this budget is exhausted. `0.075 * effectiveContext`.
+   * packed greedily until this budget is exhausted. Held at a fixed value
+   * (`GLOBAL_CONTEXT_TOKEN_BUDGET`, currently 8k) instead of scaling with
+   * `effectiveContext` so larger model windows do not bloat the rendered
+   * prefix — the long tail of reflections stays reachable via the
+   * `recall_memory` tool.
    */
   globalContextTokenBudget: number;
   /**

--- a/test/memory-budgets.test.ts
+++ b/test/memory-budgets.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_EFFECTIVE_CONTEXT,
   deriveMemoryBudgets,
   FIXED_OBSERVER_BUDGETS,
+  GLOBAL_CONTEXT_TOKEN_BUDGET,
   MEMORY_BUDGET_RATIOS,
   resolveObservationalMemorySettings,
   validateObservationalMemorySettings,
@@ -16,16 +17,16 @@ import {
  * derivation cannot drift apart silently.
  */
 describe("Memory budgets", () => {
-  test("actor-context ratios sum to 1.0 and global pack is 7.5 % of effectiveContext", () => {
-    const total =
-      MEMORY_BUDGET_RATIOS.messageTokens +
-      MEMORY_BUDGET_RATIOS.observationTokens +
-      MEMORY_BUDGET_RATIOS.globalContextTokenBudget;
-    // Floating point: the three ratios are exact decimals chosen so the
-    // sum equals 1 without rounding. If anyone shifts a ratio they must
-    // also shift another to preserve the invariant.
-    expect(total).toBe(1);
-    expect(MEMORY_BUDGET_RATIOS.globalContextTokenBudget).toBe(0.075);
+  test("local-session ratios stay below 1.0 and global pack is a fixed 8k cap", () => {
+    const total = MEMORY_BUDGET_RATIOS.messageTokens + MEMORY_BUDGET_RATIOS.observationTokens;
+    // The two local-session ratios used to share `effectiveContext` with
+    // the global pack so the three summed to 1. The global pack is now a
+    // fixed cap, so the remaining ratios only need to leave headroom for
+    // the system prompt and tool slack the raw tail absorbs.
+    expect(total).toBeLessThan(1);
+    expect(MEMORY_BUDGET_RATIOS.messageTokens).toBe(0.6);
+    expect(MEMORY_BUDGET_RATIOS.observationTokens).toBe(0.325);
+    expect(GLOBAL_CONTEXT_TOKEN_BUDGET).toBe(8_000);
   });
 
   test("deriveMemoryBudgets produces the documented numbers at the 200k default", () => {
@@ -42,8 +43,23 @@ describe("Memory budgets", () => {
         observationTokens: 65_000,
         bufferActivation: 32_500,
       },
-      globalContextTokenBudget: 15_000,
+      globalContextTokenBudget: GLOBAL_CONTEXT_TOKEN_BUDGET,
     });
+  });
+
+  test("globalContextTokenBudget is fixed across actor windows", () => {
+    for (const effectiveContext of [50_000, 200_000, 1_000_000]) {
+      const budgets = deriveMemoryBudgets(effectiveContext);
+      expect(budgets.globalContextTokenBudget).toBe(GLOBAL_CONTEXT_TOKEN_BUDGET);
+    }
+  });
+
+  test("globalContextTokenBudget clamps down on tiny effectiveContext", () => {
+    // Test-mode fixtures sometimes pass effectiveContext smaller than the
+    // global cap; the loader should never be told to pack more tokens than
+    // the actor can hold.
+    const budgets = deriveMemoryBudgets(2_000);
+    expect(budgets.globalContextTokenBudget).toBe(2_000);
   });
 
   test("observer-only budgets are fixed regardless of effectiveContext", () => {
@@ -112,7 +128,7 @@ describe("Memory budgets", () => {
     // Derived numbers come from deriveMemoryBudgets unchanged.
     expect(settings.observation.messageTokens).toBe(120_000);
     expect(settings.reflection.observationTokens).toBe(65_000);
-    expect(settings.globalContextTokenBudget).toBe(15_000);
+    expect(settings.globalContextTokenBudget).toBe(GLOBAL_CONTEXT_TOKEN_BUDGET);
 
     // User knobs flow through.
     expect(settings.observation.instruction).toBe("always remember X");

--- a/test/memory-budgets.test.ts
+++ b/test/memory-budgets.test.ts
@@ -11,9 +11,10 @@ import {
 } from "../src/memory/observational.js";
 
 /**
- * The whole memory budget surface is now one knob: every numeric trigger
- * and buffer falls out of `effectiveContext`. These tests pin the
- * documented ratios so the README, the type docs, and the runtime
+ * The local-session memory triggers and buffers all fall out of
+ * `effectiveContext` via fixed ratios; the cross-session global pack uses
+ * a separate fixed token cap (`GLOBAL_CONTEXT_TOKEN_BUDGET`). These tests
+ * pin both surfaces so the README, the type docs, and the runtime
  * derivation cannot drift apart silently.
  */
 describe("Memory budgets", () => {

--- a/test/memory-loader.test.ts
+++ b/test/memory-loader.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadGlobalPack, loadLocalPack } from "../src/memory/loader.js";
 import { runMigrations } from "../src/memory/migrations.js";
+import { CHARS_PER_TOKEN } from "../src/memory/observational.js";
 import type { Observation } from "../src/types/memory.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
@@ -88,7 +89,7 @@ describe("Memory loader", () => {
         });
 
         const usedTokens = pack.reduce(
-          (sum, observation) => sum + Math.ceil(observation.content.length / 4),
+          (sum, observation) => sum + Math.ceil(observation.content.length / CHARS_PER_TOKEN),
           0,
         );
         expect(usedTokens).toBeLessThanOrEqual(tokenBudget);

--- a/test/memory-reflect-planner.test.ts
+++ b/test/memory-reflect-planner.test.ts
@@ -99,7 +99,7 @@ describe("planReflectionBatches", () => {
   });
 
   test("packs eligible rows greedily up to batchTokens, then rolls over", () => {
-    // Each content is ~40 chars => ~10 tokens via the 4-chars-per-token heuristic.
+    // Each content is 40 chars => 13 tokens via the CHARS_PER_TOKEN=3.2 heuristic.
     const content = "x".repeat(40);
     const observations = Array.from({ length: 6 }, (_, i) =>
       makeObservation({
@@ -111,7 +111,7 @@ describe("planReflectionBatches", () => {
 
     const { batches } = planReflectionBatches(observations, {
       cutoff,
-      batchTokens: 25, // fits 2 rows (10+10=20) but not 3 (30) per batch
+      batchTokens: 30, // fits 2 rows (13+13=26) but not 3 (39) per batch
     });
 
     // Eligible rows packed chronologically (oldest → newest). Originals
@@ -124,7 +124,7 @@ describe("planReflectionBatches", () => {
       ["o1", "o0"],
     ]);
     for (const batch of batches) {
-      expect(batch.estimatedTokens).toBeLessThanOrEqual(25);
+      expect(batch.estimatedTokens).toBeLessThanOrEqual(30);
     }
   });
 

--- a/test/turn-runner-memory.test.ts
+++ b/test/turn-runner-memory.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@earendil-works/pi-ai";
 import {
   agentMessageToRaw,
+  CHARS_PER_TOKEN,
   enforceObservationTokenBudget,
   getUnobservedMessageTail,
   trimMessagesToTranscriptBudget,
@@ -743,7 +744,7 @@ describe("TurnRunner memory", () => {
       },
     });
 
-    expect(retryTokens).toBe(25);
+    expect(retryTokens).toBe(Math.ceil(100 / CHARS_PER_TOKEN));
     expect(result).toBe("short");
   });
 
@@ -1027,11 +1028,11 @@ describe("TurnRunner memory", () => {
     // global content is longer than local, so the scaled global segment
     // should still exceed the scaled local segment by a healthy margin.
     const expectedGlobalRaw = seeded.global.reduce(
-      (sum, row) => sum + Math.ceil(row.content.length / 4),
+      (sum, row) => sum + Math.ceil(row.content.length / CHARS_PER_TOKEN),
       0,
     );
     const expectedLocalRaw = seeded.local.reduce(
-      (sum, row) => sum + Math.ceil(row.content.length / 4),
+      (sum, row) => sum + Math.ceil(row.content.length / CHARS_PER_TOKEN),
       0,
     );
     expect(expectedGlobalRaw).toBeGreaterThan(expectedLocalRaw);

--- a/test/wire-shaping.test.ts
+++ b/test/wire-shaping.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { describe, expect, test } from "bun:test";
 
+import { CHARS_PER_TOKEN } from "../src/memory/observational.js";
 import {
   applyEvictionHorizon,
   calculateWireBytes,
@@ -166,9 +167,9 @@ describe("calculateWireTokens", () => {
     expect(calculateWireTokens([huge])).toBe(IMAGE_WIRE_TOKEN_ESTIMATE);
   });
 
-  test("uses ceil(chars/4) for text blocks", () => {
+  test("uses ceil(chars / CHARS_PER_TOKEN) for text blocks", () => {
     const messages = [userText("x".repeat(401), 1)];
-    expect(calculateWireTokens(messages)).toBe(Math.ceil(401 / 4));
+    expect(calculateWireTokens(messages)).toBe(Math.ceil(401 / CHARS_PER_TOKEN));
   });
 
   test("sums image, text, and structured contributions across messages", () => {
@@ -181,14 +182,14 @@ describe("calculateWireTokens", () => {
       } as AgentMessage,
       assistantToolCall("toolu_1", 3),
     ];
-    const textTokens = Math.ceil("hello world".length / 4);
+    const textTokens = Math.ceil("hello world".length / CHARS_PER_TOKEN);
     const structuredJson = JSON.stringify({
       type: "toolCall",
       id: "toolu_1",
       name: "bash",
       arguments: {},
     });
-    const structuredTokens = Math.ceil(structuredJson.length / 4);
+    const structuredTokens = Math.ceil(structuredJson.length / CHARS_PER_TOKEN);
     expect(calculateWireTokens(messages)).toBe(
       textTokens + IMAGE_WIRE_TOKEN_ESTIMATE + structuredTokens,
     );


### PR DESCRIPTION
## Summary

The cross-session global memory pack injected ahead of every turn was sized as **7.5% of `effectiveContext`** — so a 200k-window model got ~15k of reflections in the prompt prefix, and a 1M-window model would get ~75k. That scales the wrong direction: bigger windows = bigger bloat, not better recall. The top reflections the ranker actually picks fit comfortably under 10k; the long tail belongs behind `recall_memory`, not in every turn's prefix.

## Change

- Drop `globalContextTokenBudget` from `MEMORY_BUDGET_RATIOS`.
- Introduce `GLOBAL_CONTEXT_TOKEN_BUDGET = 8_000` as a fixed cap.
- `deriveMemoryBudgets` returns the fixed cap, clamped down to `effectiveContext` only for degenerate tiny-context test fixtures (production windows are always well above 8k).
- Update doc comments on `ObservationalMemorySettings.globalContextTokenBudget` and `TurnRunnerConfig.effectiveContext` so the divergence between local-session ratios and the fixed global cap is explicit.
- Update `memory-budgets` tests: replace the "ratios sum to 1.0" invariant with a fixed-cap invariant + an across-windows test that confirms the budget doesn't grow with `effectiveContext`.

Selection logic (priority × usageDecay × kindBias, greedy pack) is unchanged — this is purely a volume cap. The reflection writer is untouched. Eviction past the cap remains reachable via `recall_memory` on demand.

## Why token cap (not top-N)

Discussed in the originating thread — token cap is safer against one runaway long reflection than a fixed N=10 count cap, while still being trivially small to reason about.

## Test plan

- [x] `bun test test/memory-budgets.test.ts` — 9/9 pass
- [x] `bun test` (full suite) — 481 pass, 0 fail
- [x] `bun run check-types` — clean
- [x] `bun run format` — clean