### PR TITLE
feat(skills): walk up from cwd to discover ancestor project skills

### DIFF
--- a/src/turn-runner/skills.ts
+++ b/src/turn-runner/skills.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import type { ResourceDiagnostic, Skill } from "@earendil-works/pi-coding-agent";
 import { loadSkills } from "@earendil-works/pi-coding-agent";
 import type { SkillDiscoveryOptions } from "../types/config.js";
@@ -48,11 +48,36 @@ function buildSkillDiscoveryOptions(options: SkillDiscoveryOptions | undefined, 
 function defaultSkillPaths(globalSkillRoots: string[], cwd: string): string[] {
   // Project before global so a project-local skill can shadow a same-named
   // global one. Within each scope, .duet > .agents > .claude (first scanned
-  // wins on name collisions).
-  return [
-    ...DEFAULT_SKILL_DIR_NAMES.map((dirName) => join(cwd, dirName, "skills")),
-    ...globalSkillRoots.map((root) => join(root, "skills")),
-  ];
+  // wins on name collisions). Project scope walks from cwd up to the
+  // filesystem root so skills declared in any ancestor directory (e.g. a
+  // repo root or workspace root above the current package) are discovered
+  // — nearer directories win on collisions because they appear first.
+  const ancestorPaths: string[] = [];
+  for (const ancestor of walkAncestors(cwd)) {
+    for (const dirName of DEFAULT_SKILL_DIR_NAMES) {
+      ancestorPaths.push(join(ancestor, dirName, "skills"));
+    }
+  }
+  return [...ancestorPaths, ...globalSkillRoots.map((root) => join(root, "skills"))];
+}
+
+// Yields cwd, its parent, grandparent, ... up to the filesystem root. The
+// home directory is excluded so global skills do not get double-counted as
+// project skills when cwd lives somewhere inside $HOME.
+function walkAncestors(cwd: string): string[] {
+  const home = resolve(homedir());
+  const seen = new Set<string>();
+  const result: string[] = [];
+  let current = resolve(cwd);
+  while (true) {
+    if (seen.has(current)) break;
+    seen.add(current);
+    if (current !== home) result.push(current);
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return result;
 }
 
 function uniquePaths(paths: string[]): string[] {
@@ -179,8 +204,10 @@ export function resolveSkillScope(
   for (const dirName of DEFAULT_SKILL_DIR_NAMES) {
     if (isUnderPath(baseDir, join(home, dirName, "skills"))) return "user";
   }
-  for (const dirName of DEFAULT_SKILL_DIR_NAMES) {
-    if (isUnderPath(baseDir, join(cwd, dirName, "skills"))) return "project";
+  for (const ancestor of walkAncestors(cwd)) {
+    for (const dirName of DEFAULT_SKILL_DIR_NAMES) {
+      if (isUnderPath(baseDir, join(ancestor, dirName, "skills"))) return "project";
+    }
   }
   return "temporary";
 }

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -546,6 +546,28 @@ describe("TurnRunner skills", () => {
         filePath: agentSkillPath,
       }),
     );
+  });
+
+  testIfDocker("walks up from cwd to discover ancestor project skills", async () => {
+    app = await createTestTurnRunner();
+    const ancestorSkillPath = await app.addProjectDuetSkill({
+      name: "ancestor-skill",
+      description: "Project skill installed at an ancestor directory of the cwd.",
+      body: "# Ancestor Skill\n\nVerify discovery walks up from cwd.",
+    });
+
+    const nestedCwd = join(app.projectRoot, "packages", "web", "src");
+    await mkdir(nestedCwd, { recursive: true });
+    const nestedRunner = new TurnRunner({
+      model: "anthropic:claude-opus-4-7",
+      cwd: nestedCwd,
+    });
+
+    const skills = (await nestedRunner.getSkills()).filter((s) => !isBuiltInSkill(s));
+    expect(skills.map((skill) => skill.name)).toEqual(["ancestor-skill"]);
+    expect(skills[0]).toMatchObject({
+      filePath: ancestorSkillPath,
+    });
   });
 
   testIfDocker("discovers global skills from .duet in the home directory", async () => {


### PR DESCRIPTION
Skill discovery previously scanned `.duet/skills`, `.agents/skills`, and `.claude/skills` only directly under the configured `cwd`, so a skill installed at a repo root above a nested working directory was invisible to the agent.

This change walks from `cwd` up to the filesystem root, scanning each ancestor's skill directories. Nearer directories appear first, so a skill in a closer ancestor shadows a same-named one further up. `$HOME` is excluded from the walk so global skills are not double-counted when `cwd` lives inside the home directory.

### Changes

- `src/turn-runner/skills.ts`
  - New `walkAncestors(cwd)` helper yields every directory from cwd up to root, skipping `$HOME`.
  - `defaultSkillPaths` expands `DEFAULT_SKILL_DIR_NAMES` across every ancestor before falling back to global roots.
  - `resolveSkillScope` checks the same ancestor walk so a skill discovered at an ancestor of cwd is labelled `"project"` instead of `"temporary"`.
- `test/skills.test.ts`: docker-gated test installs a skill at `projectRoot/.duet/skills/ancestor-skill` and runs a TurnRunner with `cwd = projectRoot/packages/web/src`, verifying discovery picks it up.

### Tests

`bun test test/skills.test.ts` in docker: 17/17 pass (including the new ancestor-walk test). Full local suite: 988 pass / 0 fail.