### PR TITLE
[david] feat(skills): path on every <skill> tag, remove read_skill tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ In a TTY, `duet` opens an interactive TUI: live transcript on the left, a right-
 In the input box:
 
 - `@<query>` opens a file picker; ↑/↓ navigate, Enter / Tab inserts a markdown link like `[app.ts](./src/tui/app.ts)` (basename label, repo-relative target). The model can then read the file via the `read` tool.
-- `/<query>` opens a skill picker that inserts `/skill-name` so the model is primed to call `read_skill`.
+- `/<query>` opens a skill picker that inserts `/skill-name` so the model receives the full SKILL.md inline with its instructions for that turn.
 - Enter sends; **Shift+Enter** queues the message as a follow-up while the agent is running, instead of steering the active turn.
 - `Esc` cancels the current pickers; on its own it interrupts the active turn, or no-ops when idle. Use Ctrl+C (or close the terminal) to quit — both paths drain through the SessionManager so the local memory database (PGlite) flushes cleanly.
 
@@ -335,7 +335,7 @@ Type `/` in the composer to open the command picker, or send any of these as a m
 
 The inline form also works for the non-TUI one-shot CLI: `duet "hey can you review this /model gpt-5.5"` swaps the model and dispatches the stripped prompt to the agent; `duet "/model gpt-5.5"` applies the swap and exits without dispatching a turn.
 
-Slash commands are intercepted locally; they never reach the model unless the picker inserts a `/skill-name` skill reference for the agent to call `read_skill`.
+Slash commands are intercepted locally; they never reach the model unless the picker inserts a `/skill-name` skill reference, in which case the runner expands it into the matching skill's full SKILL.md inline for that turn.
 
 </details>
 

--- a/RPC.md
+++ b/RPC.md
@@ -40,9 +40,10 @@ duet --rpc \
   `--workdir`. Pass `--no-system-prompt-files` to disable, or repeat
   `--system-prompt-file` for multiple files.
 - Skills are discovered from `--workdir/.duet/skills`, `--workdir/.agents/skills`,
-  and the same directories under `$HOME` by default. Skills appear in the
-  runner's system prompt as metadata; the model lazy-loads each
-  `SKILL.md` via the `read_skill` tool.
+  and the same directories under `$HOME` by default. Each skill appears in
+  the runner's system prompt as metadata with a `path` attribute pointing
+  at its `SKILL.md`; the model loads full instructions on demand by
+  `read`ing that path.
 
 The process writes a one-line banner to **stderr** on start:
 
@@ -191,10 +192,10 @@ override the model, pick one that does.
   The model sees them as part of its system prompt. Use
   `--no-system-prompt-files` to skip, or override with `--system-prompt-file`.
 - **Skills**: discovered from `--workdir` and `$HOME` by default. Each skill's
-  metadata (name, description) appears in the system prompt; the body is
-  loaded on-demand by the model via the `read_skill` tool. To bundle skills
-  with your tool, drop them under `<workdir>/.duet/skills/<name>/SKILL.md`
-  before spawning `duet --rpc`.
+  metadata (name, description, SKILL.md `path`) appears in the system
+  prompt; the body is loaded on-demand by the model `read`ing the path.
+  To bundle skills with your tool, drop them under
+  `<workdir>/.duet/skills/<name>/SKILL.md` before spawning `duet --rpc`.
 
 ## Event types you will see
 

--- a/evals/rpc.eval.ts
+++ b/evals/rpc.eval.ts
@@ -227,14 +227,15 @@ describe("RPC CLI mode", () => {
   );
 
   testIfDocker(
-    "discovers a workdir-local skill and lazy-loads it via read_skill",
+    "discovers a workdir-local skill and loads it via the path in the metadata",
     async () => {
       const workDir = await mkdtemp(join(tmpdir(), "duet-rpc-skill-"));
       try {
         const skillDir = join(workDir, ".duet", "skills", "rpc-ping-skill");
         await mkdir(skillDir, { recursive: true });
+        const skillPath = join(skillDir, "SKILL.md");
         await writeFile(
-          join(skillDir, "SKILL.md"),
+          skillPath,
           dedent`
             ---
             name: rpc-ping-skill
@@ -268,13 +269,18 @@ describe("RPC CLI mode", () => {
         const terminal = expectTerminal(session.events);
         expect(terminal.type).toBe("complete");
 
-        // The model should have lazy-loaded SKILL.md via the read_skill tool;
-        // its call shows up as a step event with toolName "read_skill".
-        const readSkillCalls = session.events
+        // The model should have loaded the SKILL.md from the path the
+        // metadata exposed (replacing the old read_skill tool). Any tool
+        // call whose input references the SKILL.md path counts (read,
+        // bash cat, etc.) — assert on behavior, not tool name.
+        const skillReadCalls = session.events
           .filter((event): event is Extract<TurnEvent, { type: "step" }> => event.type === "step")
           .map((event) => event.step)
-          .filter((step) => step.type === "tool_call" && step.toolName === "read_skill");
-        expect(readSkillCalls.length).toBeGreaterThan(0);
+          .filter(
+            (step) =>
+              step.type === "tool_call" && JSON.stringify(step.input ?? {}).includes(skillPath),
+          );
+        expect(skillReadCalls.length).toBeGreaterThan(0);
 
         const text = terminalResult(terminal);
         expect(text).toContain("RPC_SKILL_PINGED");

--- a/evals/rpc.eval.ts
+++ b/evals/rpc.eval.ts
@@ -269,10 +269,10 @@ describe("RPC CLI mode", () => {
         const terminal = expectTerminal(session.events);
         expect(terminal.type).toBe("complete");
 
-        // The model should have loaded the SKILL.md from the path the
-        // metadata exposed (replacing the old read_skill tool). Any tool
-        // call whose input references the SKILL.md path counts (read,
-        // bash cat, etc.) — assert on behavior, not tool name.
+        // The model should have loaded the SKILL.md at the path surfaced
+        // in its metadata. Any tool call whose input references the
+        // SKILL.md path counts (read, bash cat, etc.) so the assertion
+        // stays behavioral and is not coupled to a specific tool.
         const skillReadCalls = session.events
           .filter((event): event is Extract<TurnEvent, { type: "step" }> => event.type === "step")
           .map((event) => event.step)

--- a/evals/skill-metadata.eval.ts
+++ b/evals/skill-metadata.eval.ts
@@ -74,10 +74,10 @@ describe("skill metadata + path-based loading", () => {
       ).turn;
 
       expect(terminal.type).toBe("complete");
-      // The model must have loaded the SKILL.md from the path the metadata
-      // exposed — that's the path-based replacement for the old read_skill
-      // tool. Any tool whose input references the absolute SKILL.md path
-      // counts (read, bash, etc.), so we assert on behavior, not tool name.
+      // The model must have loaded the SKILL.md at the path surfaced in
+      // its metadata. We accept any tool whose input references the
+      // absolute path (read, bash cat, etc.) so the assertion stays
+      // behavioral and is not coupled to a specific tool implementation.
       expect(skillReads.length).toBeGreaterThanOrEqual(1);
       expect(terminal.type === "complete" ? terminal.result?.trim() : "").toBe(
         "PONG_SKILL_LAZY_LOADED",

--- a/evals/skills-tool.eval.ts
+++ b/evals/skills-tool.eval.ts
@@ -11,11 +11,11 @@ import { testIfDocker } from "../test/helpers/docker-only.js";
 
 const model = process.env.EVAL_MODEL ?? "sonnet-4.6";
 
-describe("read_skill tool", () => {
+describe("skill metadata + path-based loading", () => {
   testIfDocker(
-    "system prompt lists skill metadata only and the model lazy-loads instructions via read_skill",
+    "system prompt lists skill metadata with path and the model reads the SKILL.md from disk",
     async () => {
-      const tempDir = await mkdtemp(join(tmpdir(), "duet-read-skill-eval-"));
+      const tempDir = await mkdtemp(join(tmpdir(), "duet-skill-path-eval-"));
       const skillPath = join(tempDir, "SKILL.md");
       await writeFile(
         skillPath,
@@ -54,15 +54,19 @@ describe("read_skill tool", () => {
         skills,
       });
 
-      const readSkillCalls: Array<{ name?: string }> = [];
+      // The model should `read` (or `bash cat`) the SKILL.md from the path
+      // surfaced in the system prompt's skill metadata. Either way produces a
+      // tool call whose input mentions the absolute skill path.
+      const skillReads: Array<{ tool: string; input: unknown }> = [];
       runner.subscribe((event: TurnEvent) => {
         if (event.type !== "step") return;
         const step = event.step;
         if (step.type !== "tool_call") return;
-        if (step.toolName !== "read_skill") return;
         if (step.status !== "running") return;
-        const input = step.input as { name?: string } | undefined;
-        readSkillCalls.push({ name: input?.name });
+        const serialized = JSON.stringify(step.input ?? {});
+        if (serialized.includes(skillPath)) {
+          skillReads.push({ tool: step.toolName, input: step.input });
+        }
       });
 
       const terminal = await (
@@ -70,10 +74,11 @@ describe("read_skill tool", () => {
       ).turn;
 
       expect(terminal.type).toBe("complete");
-      // The model must call read_skill at least once with the exact skill name
-      // listed in the metadata — that's the whole point of lazy loading.
-      expect(readSkillCalls.length).toBeGreaterThanOrEqual(1);
-      expect(readSkillCalls.some((call) => call.name === "pong-skill")).toBe(true);
+      // The model must have loaded the SKILL.md from the path the metadata
+      // exposed — that's the path-based replacement for the old read_skill
+      // tool. Any tool whose input references the absolute SKILL.md path
+      // counts (read, bash, etc.), so we assert on behavior, not tool name.
+      expect(skillReads.length).toBeGreaterThanOrEqual(1);
       expect(terminal.type === "complete" ? terminal.result?.trim() : "").toBe(
         "PONG_SKILL_LAZY_LOADED",
       );

--- a/evals/source-of-truth-first.eval.ts
+++ b/evals/source-of-truth-first.eval.ts
@@ -48,10 +48,9 @@ afterEach(async () => {
 });
 
 interface RunResult {
-  // Absolute paths to any SKILL.md files that the agent loaded (via
-  // `read`, `bash cat`, etc.). Replaces the old `readSkillNames` signal
-  // now that skills are discovered via the `path` attribute in the
-  // system-prompt metadata rather than a dedicated read_skill tool.
+  // Absolute paths to any SKILL.md files the agent loaded during the
+  // scenario (via `read`, `bash cat`, etc.). A non-empty entry proves
+  // the agent consulted the named source-of-truth skill before answering.
   skillFileReads: string[];
   bashCommands: string[];
   recallQueries: string[];

--- a/evals/source-of-truth-first.eval.ts
+++ b/evals/source-of-truth-first.eval.ts
@@ -48,7 +48,11 @@ afterEach(async () => {
 });
 
 interface RunResult {
-  readSkillNames: string[];
+  // Absolute paths to any SKILL.md files that the agent loaded (via
+  // `read`, `bash cat`, etc.). Replaces the old `readSkillNames` signal
+  // now that skills are discovered via the `path` attribute in the
+  // system-prompt metadata rather than a dedicated read_skill tool.
+  skillFileReads: string[];
   bashCommands: string[];
   recallQueries: string[];
   finalText: string;
@@ -75,10 +79,15 @@ async function runScenario(input: {
     cwd: input.cwd,
   });
 
-  const readSkillNames: string[] = [];
+  const skillFileReads: string[] = [];
   const bashCommands: string[] = [];
   const recallQueries: string[] = [];
   const assistantChunks: string[] = [];
+
+  // Matches the SKILL.md file at the top of a skill directory. Anything
+  // the agent reads (`read`, `bash cat`, etc.) whose input mentions a
+  // path of that shape counts as loading the skill.
+  const skillPathPattern = /(\/[^\s'"`]*\/SKILL\.md)/g;
 
   runner.subscribe((event: TurnEvent) => {
     if (event.type !== "step") return;
@@ -88,10 +97,11 @@ async function runScenario(input: {
     }
     if (step.type !== "tool_call") return;
     if (step.status !== "running") return;
-    if (step.toolName === "read_skill") {
-      const inp = step.input as { name?: string } | undefined;
-      if (inp?.name) readSkillNames.push(inp.name);
-    } else if (step.toolName === "bash") {
+    const serializedInput = JSON.stringify(step.input ?? {});
+    for (const match of serializedInput.matchAll(skillPathPattern)) {
+      skillFileReads.push(match[1]!);
+    }
+    if (step.toolName === "bash") {
       const inp = step.input as { command?: string } | undefined;
       if (inp?.command) bashCommands.push(inp.command);
     } else if (step.toolName === "recall_memory") {
@@ -113,7 +123,7 @@ async function runScenario(input: {
   }
 
   return {
-    readSkillNames,
+    skillFileReads,
     bashCommands,
     recallQueries,
     finalText: assistantChunks.join(""),
@@ -194,13 +204,14 @@ describe("source-of-truth-first lookups", () => {
       });
 
       console.log(
-        `\n[crm scenario] read_skill=${JSON.stringify(result.readSkillNames)} bash=${JSON.stringify(result.bashCommands)} recall=${JSON.stringify(result.recallQueries)}\nfinal=${result.finalText.slice(0, 400)}\n`,
+        `\n[crm scenario] skillFiles=${JSON.stringify(result.skillFileReads)} bash=${JSON.stringify(result.bashCommands)} recall=${JSON.stringify(result.recallQueries)}\nfinal=${result.finalText.slice(0, 400)}\n`,
       );
 
       // The crm skill is the named, advertised source of truth for
-      // person info. The agent must load it via `read_skill` before
-      // answering, even when memory looks confident.
-      expect(result.readSkillNames).toContain("crm");
+      // person info. The agent must load its SKILL.md (via the `path`
+      // surfaced in the metadata block) before answering, even when
+      // memory looks confident.
+      expect(result.skillFileReads.some((p) => p.endsWith("/crm/SKILL.md"))).toBe(true);
     },
     180_000,
   );
@@ -240,7 +251,7 @@ describe("source-of-truth-first lookups", () => {
       });
 
       console.log(
-        `\n[file scenario] bash=${JSON.stringify(result.bashCommands)} read_skill=${JSON.stringify(result.readSkillNames)} recall=${JSON.stringify(result.recallQueries)}\nfinal=${result.finalText.slice(0, 400)}\n`,
+        `\n[file scenario] bash=${JSON.stringify(result.bashCommands)} skillFiles=${JSON.stringify(result.skillFileReads)} recall=${JSON.stringify(result.recallQueries)}\nfinal=${result.finalText.slice(0, 400)}\n`,
       );
 
       // The agent must inspect the file before answering. A bash
@@ -283,10 +294,10 @@ describe("source-of-truth-first lookups", () => {
       });
 
       console.log(
-        `\n[negative scenario] read_skill=${JSON.stringify(result.readSkillNames)} bash=${JSON.stringify(result.bashCommands)} recall=${JSON.stringify(result.recallQueries)}\n`,
+        `\n[negative scenario] skillFiles=${JSON.stringify(result.skillFileReads)} bash=${JSON.stringify(result.bashCommands)} recall=${JSON.stringify(result.recallQueries)}\n`,
       );
 
-      expect(result.readSkillNames).toEqual([]);
+      expect(result.skillFileReads).toEqual([]);
       expect(result.recallQueries).toEqual([]);
     },
     120_000,

--- a/examples/tui-playground.ts
+++ b/examples/tui-playground.ts
@@ -536,8 +536,8 @@ export class FakePlaygroundRunner implements SessionTurnRunner {
         output: "wrote 56 bytes",
       },
       {
-        toolName: "read_skill",
-        input: { name: "release" },
+        toolName: "read",
+        input: { path: "/home/duet/.duet/skills/release/SKILL.md" },
         output:
           "# Release\n\nUse this workflow to publish a new version through the GitHub release workflow.",
       },

--- a/src/tui/tool-formatters.ts
+++ b/src/tui/tool-formatters.ts
@@ -362,12 +362,6 @@ function todoStatusGlyph(status: string): string {
   }
 }
 
-const formatReadSkill: Formatter = (spec) => {
-  const input = pickObject(spec.input);
-  const name = stringField(input, "name") ?? "?";
-  return { header: `read skill: ${name}`, result: buildDefaultResult(spec) };
-};
-
 /**
  * Kind glyphs for state-machine states. Picked so each state kind is
  * scannable in a column without relying on color: agent uses the runner's
@@ -598,7 +592,6 @@ const TOOL_FORMATTERS: Record<string, Formatter> = {
   find: formatFind,
   ask_user_question: formatAskUserQuestion,
   todo_write: formatTodoWrite,
-  read_skill: formatReadSkill,
   create_state_machine_definition: formatCreateStateMachine,
   select_state_machine_state: formatSelectStateMachineState,
   get_current_state_machine_state: formatGetCurrentStateMachineState,

--- a/src/turn-runner/prompts.ts
+++ b/src/turn-runner/prompts.ts
@@ -152,7 +152,7 @@ export function createSourceOfTruthSystemPromptLayer(): string {
     "When you need a fact that is not already in the active transcript, never make it up. Reach for whichever lookup actually has the answer: a live source (connected tool, skill, file in cwd) if one exists for this topic, or `recall_memory` if the topic only lives in durable memory. Both are first-class lookups — the rule is *some* lookup before answering, not silence and not fabrication.",
     "Prefer a *live* source over memory when both could answer. A confident-looking observation in the rendered memory block is NOT a substitute for the live source on anything that could have changed externally (subscriptions, payments, deploys, file contents, account state, ticket status, integration data, CRM rows). Observations can be stale or wrong — including ones the agent itself wrote in a prior turn. Treat memory as a hint, not as authoritative state whenever a live source exists.",
     'Yes/no confirmation questions about external state are the highest-risk shape. "You did X already, right?", "is X currently true?", "did we ship Y?", "is contact Z unsubscribed?" — never answer yes/no from memory alone when a live source can answer authoritatively. Verify with the live source first, then confirm or correct. If memory and the live source disagree, the live source wins.',
-    "Skills advertised as the source of truth for a topic must be loaded via `read_skill` when that topic comes up. If a skill's description names it as the lookup path for people, deals, contacts, accounts, integrations, or a specific service, treat that as a hard pointer: read the skill and run the lookup it documents before answering questions in its domain.",
+    "Skills advertised as the source of truth for a topic must be read from the SKILL.md at the `path` listed in the skill's metadata when that topic comes up. If a skill's description names it as the lookup path for people, deals, contacts, accounts, integrations, or a specific service, treat that as a hard pointer: read the skill and run the lookup it documents before answering questions in its domain.",
     "Workspace files in the cwd that the user names or that the skill points at are also live sources — `bash`/`read` them before answering. A file in the cwd that obviously holds the ground truth (a data file, a config, a CSV, a JSON) outranks any memory observation about the same fact.",
     'When no live source exists for the question — a personal fact, a past decision, a named referent with no tool behind it ("Doughy", "my starter", a past project codename, a teammate the agent should already know) — `recall_memory` IS the right first move, not a fallback. Recall before answering, never invent.',
   ].join("\n\n");
@@ -164,10 +164,13 @@ function createSkillsSystemPrompt(skills: readonly Skill[]): string | undefined 
   }
 
   return dedent`
-    Available skills (metadata only — call the \`read_skill\` tool with the skill name to load full instructions on demand):
+    Available skills (metadata only — \`read\` the SKILL.md at the listed \`path\` to load full instructions when a skill's description matches the task at hand, or to edit the skill itself):
     ${toXML({
       skills: skills.map((skill) => ({
-        skill: { _attrs: { name: skill.name }, description: skill.description },
+        skill: {
+          _attrs: { name: skill.name, path: skill.filePath },
+          description: skill.description,
+        },
       })),
     })}
   `;

--- a/src/turn-runner/skill-context.ts
+++ b/src/turn-runner/skill-context.ts
@@ -88,7 +88,10 @@ export class SkillContext {
       const instructions = readSkillInstructions(skill).trim();
       skillBlocks.push(
         [
-          `<skill name="${skill.name}">`,
+          // path= lets the agent edit the SKILL.md directly without a
+          // discovery step when the user asks to modify the skill itself
+          // (e.g. "add this rule to /review").
+          `<skill name="${skill.name}" path="${skill.filePath}">`,
           "Use the following skill instructions for this request.",
           "<instructions>",
           instructions,

--- a/src/turn-runner/tools.ts
+++ b/src/turn-runner/tools.ts
@@ -31,7 +31,6 @@ import { recallMemory, reciprocalRankFusion, type RecallScope } from "../memory/
 import type { Observation } from "../types/memory.js";
 import type { MemorySession } from "../memory/session.js";
 import type { ActiveStateOutput } from "./state-machine-controller.js";
-import { readSkillInstructions } from "./skills.js";
 import { withBundledRipgrep } from "./bundled-ripgrep.js";
 
 const jsonSchemaValidator = new Ajv({ strictSchema: false });
@@ -92,13 +91,6 @@ const askUserQuestionSchema = Type.Object({
 });
 
 type AskUserQuestionParams = Static<typeof askUserQuestionSchema>;
-
-const readSkillSchema = Type.Object({
-  name: Type.String({
-    description:
-      "Skill name from the available skills metadata in the system prompt. Returns the full SKILL.md instructions (with shell expansions resolved).",
-  }),
-});
 
 const todoStatusSchema = Type.Union(
   [
@@ -503,7 +495,6 @@ export interface RecallMemoryToolStorage {
 export function createDefaultTurnRunnerTools(
   cwd: string,
   todoStorage: TodoWriteToolStorage,
-  skills: readonly Skill[] = [],
   recallStorage?: RecallMemoryToolStorage,
 ): AgentTool[] {
   const tools: AgentTool[] = [
@@ -514,7 +505,6 @@ export function createDefaultTurnRunnerTools(
     }),
     createTodoWriteTool(todoStorage),
     createAskUserQuestionTool(),
-    createReadSkillTool(skills),
   ];
   if (recallStorage) {
     tools.push(createRecallMemoryTool(recallStorage));
@@ -524,12 +514,7 @@ export function createDefaultTurnRunnerTools(
 
 export function createTurnRunnerTools(input: TurnRunnerToolsInput): AgentTool[] {
   const tools = [
-    ...createDefaultTurnRunnerTools(
-      input.cwd,
-      input.todoStorage,
-      input.skills,
-      input.recallStorage,
-    ),
+    ...createDefaultTurnRunnerTools(input.cwd, input.todoStorage, input.recallStorage),
   ];
   if (input.mode === "agent") {
     return tools;
@@ -754,40 +739,6 @@ function formatRecallHit(observation: Observation): string {
   const priority =
     observation.priority === "high" ? "HIGH" : observation.priority === "medium" ? "MED" : "LOW";
   return `- ${priority} ${observation.kind} ${observation.observedDate}${time}${referenced}${session}\n  ${observation.content}`;
-}
-
-function createReadSkillTool(skills: readonly Skill[]): AgentTool<typeof readSkillSchema> {
-  return {
-    name: "read_skill",
-    label: "Read skill",
-    description: dedent`
-      Load the full SKILL.md instructions for one of the available skills listed in the system prompt.
-
-      The system prompt only lists skill names and one-line descriptions to keep the context small. When a skill's description matches the task at hand, call this tool with its name to fetch the full instructions, then follow them.
-
-      The response also includes the SKILL.md path so you can read sibling reference files (e.g. \`<dirname(path)>/reference/<file>\`) referenced by the instructions.
-    `,
-    parameters: readSkillSchema,
-    async execute(_toolCallId, params) {
-      const skill = skills.find((candidate) => candidate.name === params.name);
-      if (!skill) {
-        const available = skills.map((candidate) => candidate.name).join(", ") || "(none)";
-        throw new Error(`Unknown skill: ${params.name}. Available skills: ${available}`);
-      }
-
-      const instructions = readSkillInstructions(skill);
-      const header = dedent`
-        Skill: ${skill.name}
-        Path: ${skill.filePath}
-
-        ---
-      `;
-      return {
-        content: [{ type: "text", text: `${header}\n\n${instructions}` }],
-        details: { type: "read_skill", name: skill.name, filePath: skill.filePath },
-      };
-    },
-  };
 }
 
 export function createTodoWriteTool(

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -1440,10 +1440,7 @@ export class TurnRunner {
     };
     if (mode === "agent") {
       return {
-        tools: [
-          ...createDefaultTurnRunnerTools(cwd, todoStorage, skills, recallStorage),
-          ...mcpTools,
-        ],
+        tools: [...createDefaultTurnRunnerTools(cwd, todoStorage, recallStorage), ...mcpTools],
       };
     }
 

--- a/test/built-in-skills.test.ts
+++ b/test/built-in-skills.test.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { SkillContext } from "../src/turn-runner/skill-context.js";
 import { discoverInstalledSkills, resolveSkillScope } from "../src/turn-runner/skills.js";
-import { createTurnRunnerTools } from "../src/turn-runner/tools.js";
 
 let tempDir: string;
 
@@ -34,45 +33,14 @@ describe("built-in skills surface through discovery", () => {
 
     // Token stays in the prompt verbatim.
     expect(resolved).toContain("monitor the inbox /relay every hour");
-    // Skill block was injected with the relay instructions.
-    expect(resolved).toContain('<skill name="relay">');
+    // Skill block was injected with the relay instructions, including the
+    // `path` attribute so the agent can read/edit the SKILL.md directly.
+    expect(resolved).toMatch(/<skill name="relay" path="[^"]+">/);
     expect(resolved).toContain("state-machine tools");
     expect(resolved).toContain("</skill>");
     // The legacy `<system-reminder>` wrapper is gone — the body must not
     // smuggle one in.
     expect(resolved).not.toContain("<system-reminder>");
-  });
-
-  test("read_skill returns the inline body for a built-in skill", async () => {
-    // Drive through the same factory the runner uses, so we exercise the
-    // exact tool wiring callers see — not the internal readSkillInstructions
-    // helper.
-    const { skills } = discoverInstalledSkills(tempDir);
-    const tools = createTurnRunnerTools({
-      cwd: tempDir,
-      mode: "agent",
-      skills,
-      todoStorage: { getTodos: () => [], setTodos: () => {} },
-    });
-    const readSkillTool = tools.find((tool) => tool.name === "read_skill");
-    expect(readSkillTool).toBeDefined();
-
-    const relay = skills.find((s) => s.name === "relay")!;
-    const result = await readSkillTool!.execute("tool-1", { name: "relay" });
-    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
-
-    // Header carries the synthetic built-in path so callers know where
-    // sibling files would live (there aren't any for built-ins, but the
-    // shape stays uniform with disk-resident skills).
-    expect(text).toContain("Skill: relay");
-    expect(text).toContain(`Path: ${relay.filePath}`);
-    // Body is the inline RELAY_INSTRUCTIONS, not a disk read.
-    expect(text).toContain("state-machine tools");
-    expect(result.details).toEqual({
-      type: "read_skill",
-      name: "relay",
-      filePath: relay.filePath,
-    });
   });
 
   test("a user-installed skill named 'relay' shadows the built-in", async () => {

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -163,15 +163,17 @@ describe("TurnRunner skills", () => {
 
       expect(systemPrompt).toContain("Available skills");
       expect(systemPrompt).toContain("<skills>");
-      expect(systemPrompt).toContain('<skill name="first-skill">');
+      // Each skill entry must include the SKILL.md `path` attribute so the
+      // agent can read/edit the file directly without a discovery step.
+      expect(systemPrompt).toMatch(/<skill name="first-skill" path="[^"]+\/SKILL\.md">/);
       expect(systemPrompt).toContain("First skill description.");
-      expect(systemPrompt).toContain('<skill name="second-skill">');
+      expect(systemPrompt).toMatch(/<skill name="second-skill" path="[^"]+\/SKILL\.md">/);
       expect(systemPrompt).toContain("Second skill description.");
       expect(systemPrompt).toContain("Base instructions.");
-      // Full SKILL.md bodies must NOT be inlined — they're loaded on demand via the read_skill tool.
+      // Full SKILL.md bodies must NOT be inlined — they're loaded on demand
+      // by `read`-ing the path surfaced in the skill metadata.
       expect(systemPrompt).not.toContain("First skill instructions.");
       expect(systemPrompt).not.toContain("Second skill instructions.");
-      expect(systemPrompt).toContain("read_skill");
     },
   );
 

--- a/test/turn-runner-tools.test.ts
+++ b/test/turn-runner-tools.test.ts
@@ -1,8 +1,5 @@
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
-import type { BashOperations, Skill } from "@earendil-works/pi-coding-agent";
+import type { BashOperations } from "@earendil-works/pi-coding-agent";
 import dedent from "dedent";
 import {
   createTurnRunnerTools as createTurnRunnerToolsWithStorage,
@@ -962,55 +959,6 @@ describe("TurnRunner tools", () => {
       false,
     );
     expect(stateMachineTools.some((tool) => tool.name === "select_state_machine_state")).toBe(true);
-  });
-
-  test("read_skill returns full SKILL.md instructions for a known skill", async () => {
-    const tempDir = mkdtempSync(join(tmpdir(), "duet-skill-tool-"));
-    try {
-      const skillPath = join(tempDir, "SKILL.md");
-      writeFileSync(
-        skillPath,
-        dedent`
-          ---
-          name: lazy-skill
-          description: Lazy-loaded skill body.
-          ---
-
-          # Lazy Skill
-
-          Full instructions live here.
-        `,
-      );
-      const skill: Skill = {
-        name: "lazy-skill",
-        description: "Lazy-loaded skill body.",
-        filePath: skillPath,
-        baseDir: tempDir,
-        sourceInfo: {} as Skill["sourceInfo"],
-        disableModelInvocation: false,
-      };
-
-      const tools = createTurnRunnerTools({ cwd: process.cwd(), mode: "agent", skills: [skill] });
-      const readSkillTool = tools.find((tool) => tool.name === "read_skill");
-
-      expect(readSkillTool).toBeDefined();
-      if (!readSkillTool) throw new Error("read_skill tool missing");
-
-      const result = await readSkillTool.execute("tool-1", { name: "lazy-skill" });
-      const text = result.content[0]?.type === "text" ? result.content[0].text : "";
-      expect(text).toContain("Full instructions live here.");
-      expect(text).toContain(`Path: ${skillPath}`);
-      expect(result.details).toEqual({
-        type: "read_skill",
-        name: "lazy-skill",
-        filePath: skillPath,
-      });
-
-      const missing = readSkillTool.execute("tool-2", { name: "does-not-exist" });
-      await expect(missing).rejects.toThrow(/Unknown skill: does-not-exist/);
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
   });
 
   test("describes tool schema properties for provider tool prompts", () => {


### PR DESCRIPTION
## Why

The agent had no breadcrumb from a skill name to its SKILL.md on disk. When the user asked to *edit* a skill (e.g. "add this rule to /review"), the only signal in context was a name + description — finding the file required grep or a `read_skill` round-trip.

## What changed

**path= on both surfaces**

1. **System-prompt metadata block** — every skill listing now includes its absolute path:
   ```xml
   <skill name="review" path="/path/to/SKILL.md">
   <description>...</description>
   </skill>
   ```
2. **`/skill` slash-expansion in user messages** — the opening tag carries the same path attribute.

**`read_skill` removed**

With path on both surfaces, `read_skill` was a thin wrapper around `read(filePath)`. Deleted:

- `createReadSkillTool`, `readSkillSchema`, and the tool array entry in `src/turn-runner/tools.ts`
- `read_skill` entry from `src/tui/tool-formatters.ts`
- The now-unused `skills` param on `createDefaultTurnRunnerTools`
- Source-of-truth prompt bullet rewritten to point at the path

**Evals migrated to behavior-based assertions**

`skills-tool.eval.ts`, `rpc.eval.ts`, and `source-of-truth-first.eval.ts` previously asserted `toolName === "read_skill"`. They now assert the agent loaded the SKILL.md via *any* tool whose input mentions the path that appeared in the metadata block (matches `read`, `bash cat`, etc.). Per /review rule 13: test behavior, not structure.

Unit tests that only exercised `read_skill` deleted (rule 12: tests don't justify keeping dead production code).

## Verification

- `bunx tsc --noEmit` clean
- `bun test` — 1006 pass / 0 fail across 139 files
- `bun run lint` — 0 warnings
- `bun run format` — applied