### PR TITLE
[david] fix(rpc): emit terminal event on uncaught exception / unhandled rejection

### DIFF
--- a/src/cli/rpc.ts
+++ b/src/cli/rpc.ts
@@ -104,6 +104,34 @@ export async function runRpcCommand(args: string[], pkg: PackageMetadata): Promi
   };
   runner.subscribe(writeEvent);
 
+  // Without these handlers, an unhandled rejection or uncaught exception
+  // anywhere in start()/turn() setup (memory load, skill load, state
+  // hydration, MCP connect) kills the process under Node's default policy
+  // with no terminal event written and nothing on stderr. Hosts then see
+  // `code=null stderr=` and have no way to surface a real error to the
+  // user. Emit a system error event with the cause, then — if the runner
+  // already has a hydrated state — also emit a `complete` terminal so the
+  // host can settle the in-flight turn cleanly. The system event alone is
+  // the floor; the terminal is best-effort because TurnCompletedEvent
+  // requires `state`, which doesn't exist if we died before `start()`
+  // finished hydrating.
+  const emitFatalAndExit = (reason: unknown): void => {
+    const message = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+    try {
+      writeEvent({ type: "system", level: "error", message: `fatal: ${message}` });
+      const state = runner.getState();
+      if (state) {
+        writeEvent({ type: "complete", status: "failed", error: message, state });
+      }
+    } catch {
+      // stdout may be closed if the parent already gave up on us; nothing
+      // useful to do at this point besides exiting.
+    }
+    process.exit(1);
+  };
+  process.on("unhandledRejection", emitFatalAndExit);
+  process.on("uncaughtException", emitFatalAndExit);
+
   const removeShutdownHandlers = installShutdownHandlers(() => runner.dispose());
 
   try {


### PR DESCRIPTION
## Problem

When the RPC runner dies from an unhandled rejection or uncaught exception during `start()`/`turn()` setup (memory load, skill load, state hydration, MCP connect), Node's default policy kills the process **with no terminal event written and nothing on stderr**.

Hosts (e.g. the Duet sandbox gateway) see:
```
[runner exit without terminal] <session-id> code=<none> stderr=
[runner complete error] <session-id> status=failed error=Runner exited (code=null) without emitting a terminal event
[session] turn_started never arrived <session-id> Error: Runner exited before turn_started (code=null). Stderr:
```

…with no way to surface the actual cause to the user. The session just appears to silently fail, and the host has to guess whether to retry, evict, or escalate.

Caught this morning in a real session: a runner restarted against a hydrated state (~9.9MB runner output, ~540k tokens) and crashed 4 times in a row with `code=null stderr=` before eventually recovering on a later spawn. No log line told us what actually killed it.

## Fix

Install `unhandledRejection` and `uncaughtException` handlers in `runRpcCommand` that:

1. **Always emit a `TurnSystemEvent` at `error` level** with the cause's stack/message so the failure is visible in the host's event stream. This is the floor.
2. **Best-effort emit a `complete` terminal event with `status: 'failed'`** when `runner.getState()` returns a hydrated state, so the host can settle the in-flight turn cleanly instead of timing out waiting for a terminal.

The terminal emission is best-effort because `TurnCompletedEvent` requires `state`, which doesn't exist if we died before `start()` finished hydrating the runner. In that pre-hydration case the system event alone is the floor — still strictly better than the current silent exit.

## Test plan

- `bun run check-types` clean
- `bun test test/` — 1006 pass, 0 fail (no regression)
- No existing process-level test harness; adding one would mean spawning a child process per test, which is heavier than the safety net itself. The change is purely additive in the failure path; the happy path is untouched.

## Follow-ups (not in this PR)

- We still don't know **why** the runner crashed in the original session. This PR just makes the next crash debuggable instead of opaque. Once we see one in the wild with this fix landed, the system event will tell us what the root cause is (likely OOM during state hydration on large sessions, or an MCP transport rejection).