### PR TITLE
feat(state-machine): auto-expand /skill slash commands in agent state prompts

### DIFF
--- a/src/turn-runner/skill-context.ts
+++ b/src/turn-runner/skill-context.ts
@@ -76,13 +76,22 @@ export class SkillContext {
     return state.allowedSkills.map((name) => skillsByName.get(name)!);
   }
 
-  resolveSlashSkillPrompt(prompt: string): string {
+  /**
+   * Expand `/skill` slash commands in a prompt into injected `<skill>` blocks.
+   * `skills` scopes which skills are eligible to expand; callers pass a
+   * restricted set (e.g. a state's `allowedSkills`) so a background agent only
+   * expands skills it actually has. Defaults to every discovered skill, which
+   * is what the parent prompt path wants. Passing `undefined` (the result of
+   * `resolveStateAgentSkills` for an unrestricted state) also falls through to
+   * the full set.
+   */
+  resolveSlashSkillPrompt(prompt: string, skills: readonly Skill[] = this.skills): string {
     const slash = parseSlashCommands(prompt);
     if (slash.commands.length === 0) return prompt;
 
     const skillBlocks: string[] = [];
     for (const command of slash.commands) {
-      const skill = this.skills.find((item) => item.name === command);
+      const skill = skills.find((item) => item.name === command);
       if (!skill) continue;
 
       const instructions = readSkillInstructions(skill).trim();

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -1077,11 +1077,17 @@ export class TurnRunner {
       options: this.requireRunnerState().options,
       agent: { status: "running", messages: [] },
     };
+    const stateSkills = this.skillContext.resolveStateAgentSkills(input.state);
+    // Expand `/skill` slash commands the same way the parent prompt path does,
+    // scoped to the skills this state is actually allowed to use. Lets state
+    // prompts say "use the /foo skill to do xyz" and have the skill body
+    // injected, instead of shipping the literal `/foo` text to the model.
+    const expandedPrompt = this.skillContext.resolveSlashSkillPrompt(input.prompt, stateSkills);
     const agent = this.createAgent(
       {
         state,
         appendSystemPrompt: input.state.systemPrompt,
-        skills: this.skillContext.resolveStateAgentSkills(input.state),
+        skills: stateSkills,
         // Per-state cwd lets one agent state operate on a different
         // repository or subdirectory than the parent runner without
         // mutating shared config.
@@ -1111,7 +1117,7 @@ export class TurnRunner {
       prompt: async () => {
         unsubscribe = agent.subscribe((event) => this.emitAgentEvent(event, origin));
         try {
-          await agent.prompt(input.prompt);
+          await agent.prompt(expandedPrompt);
           await this.retryTransientServerErrors(agent);
           return interruptedReason ? { type: "interrupted" } : finish();
         } catch (error) {

--- a/test/skill-context-resolve.test.ts
+++ b/test/skill-context-resolve.test.ts
@@ -62,6 +62,28 @@ describe("SkillContext.resolveSlashSkillPrompt", () => {
     },
   );
 
+  testIfDocker(
+    "only expands skills in the scoped list when one is passed (state allowedSkills)",
+    async () => {
+      const review = await writeSkill("review", "REVIEW_BODY");
+      const release = await writeSkill("release", "RELEASE_BODY");
+      const ctx = new SkillContext({
+        skills: [review, release],
+        skillDiscovery: { includeDefaults: false },
+      });
+      await ctx.ensureLoaded();
+
+      // Scope to just `review` — mirrors a state whose allowedSkills omits
+      // `release`. The /release token must NOT expand even though the skill
+      // exists in the session, because the state agent cannot use it.
+      const resolved = ctx.resolveSlashSkillPrompt("/review then /release", [review]);
+      expect(resolved).toContain('<skill name="review"');
+      expect(resolved).toContain("REVIEW_BODY");
+      expect(resolved).not.toContain('<skill name="release"');
+      expect(resolved).not.toContain("RELEASE_BODY");
+    },
+  );
+
   testIfDocker("returns the prompt unchanged when no slash command matches a skill", async () => {
     const skill = await writeSkill("review", "body");
     const ctx = new SkillContext({ skills: [skill], skillDiscovery: { includeDefaults: false } });


### PR DESCRIPTION
## What

State-machine agent states now auto-expand `/skill` slash commands in their prompts, scoped to the state's `allowedSkills`.

Previously a state prompt like "use the /review skill to do xyz" shipped the literal `/review` text to the model — only the **parent** prompt path expanded slash commands into `<skill>` instruction blocks. State agents went straight to `agent.prompt(input.prompt)` with no expansion.

## How

- `SkillContext.resolveSlashSkillPrompt(prompt, skills?)` now takes an optional scoped skill list. Defaults to all discovered skills, so the parent prompt path is unchanged. Passing `undefined` (the result of `resolveStateAgentSkills` for an unrestricted state) also falls through to the full set.
- `createStateAgentHandle` resolves the state's skills once (`resolveStateAgentSkills(state)`), expands the prompt through `resolveSlashSkillPrompt` with that scoped set, then dispatches the expanded prompt.

## Scoping

- If a state sets `allowedSkills`, only those skills expand. A `/release` token won't expand if `release` isn't allowed — matching the fact that the sub-agent can't use it anyway.
- Unrestricted states expand any discovered skill, same as the parent.

## Notes

- Skill *discovery* is still keyed off the **session cwd**, not the per-state `cwd`. A state pointed at a different repo via `cwd` expands skills from the session's set, not that repo's local `.agents/skills`. Out of scope for this change.

## Test

- New `skill-context-resolve` test asserts scoped expansion drops out-of-scope skills (asserts actual injected bodies, not just counts; gated on `testIfDocker`).
- `tsc`, `oxlint`, and the full `skill-context-resolve` suite (8/8) pass.