### PR TITLE
[david] fix(runner): no spurious 'Error: cancelled' on state-machine terminal

### DIFF
--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -909,7 +909,16 @@ export class TurnRunner {
       case "interrupted":
         return { type: "interrupted", state: { ...state, status: "interrupted" } };
       case "terminal":
-        return completeTurn(state, result.status, result.result, result.error);
+        // A state machine reaching ANY terminal (completed/failed/cancelled,
+        // incl. the auto-injected `cancelled` that `wont do` maps to) is a
+        // deliberate, successful turn outcome — not a user abort. Report
+        // turn-completion status as "completed" so the backend does not surface
+        // the "Error: cancelled — try again" system message. The terminal's own
+        // status survives on state.stateMachine.terminal.status (set by
+        // recordStateMachineCompleted), which is what the board column resolves
+        // from. Only an explicit user stop — which emits type:"interrupted" via
+        // interrupt() — can still surface the cancel message.
+        return completeTurn(state, "completed", result.result, result.error);
     }
   }
 

--- a/test/turn-runner-protocol.test.ts
+++ b/test/turn-runner-protocol.test.ts
@@ -441,14 +441,20 @@ describe("TurnRunner protocol scenarios", () => {
     });
     const terminal = await turn;
 
+    // Reaching the `failed` terminal is still a successful turn outcome, so the
+    // turn-completion status is "completed"; the terminal's own `failed` status
+    // survives on stateMachine.terminal for board column resolution.
     expect(terminal).toMatchObject({
       type: "complete",
-      status: "failed",
+      status: "completed",
       state: {
-        status: "failed",
+        status: "completed",
         mode: "auto",
         agent: { status: "completed" },
-        stateMachine: { currentState: "send_email" },
+        stateMachine: {
+          currentState: "send_email",
+          terminal: { state: "send_email", status: "failed" },
+        },
       },
     });
   });
@@ -530,7 +536,11 @@ describe("TurnRunner protocol scenarios", () => {
     if (terminal.type !== "complete") {
       throw new Error("Expected complete event");
     }
-    expect(terminal.status).toBe("failed");
+    // The unknown-state error settles into a `failed` terminal, which is a
+    // successful turn outcome — the turn reports "completed" while the failure
+    // detail rides on terminal.error and stateMachine.terminal.status.
+    expect(terminal.status).toBe("completed");
+    expect(terminal.state.stateMachine?.terminal?.status).toBe("failed");
     const error = terminal.error ?? "";
     expect(error.includes("Unknown state: invented_state")).toBe(true);
     expect(error.includes("research_prospect")).toBe(true);
@@ -1041,7 +1051,7 @@ describe("TurnRunner protocol scenarios", () => {
 
     expect(terminal).toMatchObject({
       type: "complete",
-      status: "failed",
+      status: "completed",
       error: expect.stringContaining('Poll state "poll_email_reply" timed out'),
     });
     expect(terminal.state.stateMachine?.history).toContainEqual(
@@ -1125,7 +1135,7 @@ describe("TurnRunner protocol scenarios", () => {
     expect(runner.workerInputs[4]?.prompt).toContain("retry 3 of 3");
     expect(terminal).toMatchObject({
       type: "complete",
-      status: "failed",
+      status: "completed",
       error: "State completed, but the runner did not call select_state_machine_state.",
     });
   });
@@ -1166,7 +1176,7 @@ describe("TurnRunner protocol scenarios", () => {
 
     expect(terminal).toMatchObject({
       type: "complete",
-      status: "failed",
+      status: "completed",
       error:
         "Cannot create a new state-machine definition while the current state machine is still active.",
     });


### PR DESCRIPTION
## Problem

When the agent routes a relay/state machine to a terminal whose status is `cancelled` (or `wont do`, which maps to cancelled) via `select_state_machine_state`, the runner emitted its turn-completion event with `status=cancelled`. The backend can't distinguish this from a user-initiated abort (stop button), so it logged `[runner complete error] <session> status=cancelled error=<none>` and injected a user-facing system message:

> Error: cancelled — This session is still active, try sending your message again.

This appeared **after** an otherwise-successful turn and recurred constantly in gateway.log across many sessions.

## Root cause

The runner reused the same `status=cancelled` turn-completion signal for two different things: (1) an explicit user abort, and (2) a deliberate state-machine terminal selection. Only (1) should surface the error. In `controllerResultToTerminal`, the `terminal` case forwarded the terminal's own status (`result.status`) as the turn-completion status.

## Fix

When a turn ends because the state machine reached **any** terminal state, report turn-completion `status=completed` regardless of the terminal's own status (completed/failed/cancelled). The terminal's own status still rides on `state.stateMachine.terminal.status` (set by `recordStateMachineCompleted`), which is what the board column resolves from — so column resolution is unaffected.

A genuine user stop is unchanged: it emits `type:"interrupted"` via `interrupt()`, the only path that can still surface the cancel/try-again message. Genuine fatal errors still emit `status:"failed"` via `rpc.ts`.

## Changes
- `src/turn-runner/turn-runner.ts` — `controllerResultToTerminal` terminal case reports `completed`.
- `test/turn-runner-protocol.test.ts` — 5 assertions updated from the old contract (turn status mirrors terminal status) to the new one (turn `completed`; failure detail on `terminal.error` + `stateMachine.terminal.status`).

## Verification
- `tsc --noEmit` ✅
- `oxlint src/` ✅ 0 warnings/errors
- `oxfmt` ✅ formatted
- `bun test` ✅ 755 pass / 0 fail (protocol file: 36 pass)