### PR TITLE
[walter] feat(tui): Ctrl+C confirms before exit instead of quitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ In the input box:
 - `@<query>` opens a file picker; ↑/↓ navigate, Enter / Tab inserts a markdown link like `[app.ts](./src/tui/app.ts)` (basename label, repo-relative target). The model can then read the file via the `read` tool.
 - `/<query>` opens a skill picker that inserts `/skill-name` so the model receives the full SKILL.md inline with its instructions for that turn.
 - Enter sends; **Shift+Enter** queues the message as a follow-up while the agent is running, instead of steering the active turn.
-- `Esc` cancels the current pickers; on its own it interrupts the active turn, or no-ops when idle. Use Ctrl+C (or close the terminal) to quit — both paths drain through the SessionManager so the local memory database (PGlite) flushes cleanly.
+- `Esc` cancels the current pickers; on its own it interrupts the active turn, or no-ops when idle.
+- `Ctrl+C` is contextual rather than an instant quit: it interrupts the active turn while one is running, clears the composer when it has text, and on an idle empty composer asks for confirmation first ("Press Ctrl+C again or Enter to exit"). Confirming — or closing the terminal — drains through the SessionManager so the local memory database (PGlite) flushes cleanly.
 
 Tool calls render with custom per-tool headers (e.g. `$ <command>`, `read <path> (lines a–b)`, `edit <path> (N edits)`, `[question]`). Resumed sessions render history through the same formatters so live and replay match.
 

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -10,7 +10,11 @@ import { createTuiControllers } from "./controllers.js";
 import { createDinoPanel } from "./dino/index.js";
 import { replayResumeHistory } from "./history-replay.js";
 import { bootstrapInitialPrompt } from "./initial-prompt.js";
-import { type EscapeSuppressionFlag, installKeyHandlers } from "./key-handlers.js";
+import {
+  type CtrlCSuppressionFlag,
+  type EscapeSuppressionFlag,
+  installKeyHandlers,
+} from "./key-handlers.js";
 import { buildLayout } from "./layout.js";
 import { acquireRenderer, waitForRendererDestroy } from "./renderer-lifecycle.js";
 import { bindSessionToUi } from "./session-subscription.js";
@@ -228,6 +232,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
   };
 
   const escapeState: EscapeSuppressionFlag = { suppress: false };
+  const ctrlCState: CtrlCSuppressionFlag = { suppress: false };
   const setEscapeSuppress = () => {
     escapeState.suppress = true;
   };
@@ -285,10 +290,34 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     appendUserBlock,
   });
 
-  // Esc cancels the in-flight turn; idle Esc is a no-op (Ctrl+C quits).
+  // Esc cancels the in-flight turn; idle Esc is a no-op.
   function handleEscape(): void {
     if (!statusController.isRunning()) return;
     void input.session.interrupt().catch(reportError);
+  }
+
+  // Ctrl+C is a small state machine rather than an immediate quit:
+  //   1. running turn  → interrupt it (identical to Esc), no exit prompt.
+  //   2. composer text → clear the composer (multiline included) only;
+  //                       attachments, autocomplete, and picker state stay.
+  //   3. idle + empty  → first press arms a persistent exit confirmation,
+  //                       a second press (or Enter) quits.
+  // The exit itself reuses `renderer.destroy()`, the same teardown the old
+  // OpenTUI exitOnCtrlC handler used, so shutdown semantics are unchanged.
+  function handleCtrlC(): void {
+    if (statusController.isRunning()) {
+      handleEscape();
+      return;
+    }
+    if (ui.inputField.plainText.length > 0) {
+      ui.inputField.clear();
+      return;
+    }
+    if (statusController.isExitConfirmActive()) {
+      renderer.destroy();
+      return;
+    }
+    statusController.showExitConfirm();
   }
 
   // Shared dispatch for submit (follow_up) and Ctrl+Enter (steer): log the
@@ -390,6 +419,11 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     onEscape: handleEscape,
     onSteer: handleSteer,
     dinoPanel,
+    ctrlCState,
+    onCtrlC: handleCtrlC,
+    isExitConfirmActive: () => statusController.isExitConfirmActive(),
+    onExitConfirmAccept: () => renderer.destroy(),
+    onExitConfirmCancel: () => statusController.clearExitConfirm(),
   });
 
   // Typing hides starter chrome; backspacing empty brings it back until

--- a/src/tui/key-handlers.ts
+++ b/src/tui/key-handlers.ts
@@ -17,6 +17,27 @@ export interface EscapeSuppressionFlag {
   suppress: boolean;
 }
 
+/**
+ * Mutable dedupe flag for Ctrl+C, mirroring {@link EscapeSuppressionFlag}.
+ * The composer's `onKeyDown` hook runs before the renderer's global
+ * keypress handler, so when it consumes a Ctrl+C it sets `suppress = true`
+ * to stop the global fallback from running the state machine a second time
+ * for the same press.
+ */
+export interface CtrlCSuppressionFlag {
+  suppress: boolean;
+}
+
+/** A *plain* Ctrl+C keystroke, by name or by the raw 0x03 byte legacy
+ *  terminals send. Shared by the global handler and the composer hook so
+ *  both agree on what counts as Ctrl+C. Shift is excluded so Ctrl+Shift+C
+ *  (the copy keystroke, which some kitty parsers report as `name:"c"`
+ *  with `shift:true`) is left for the copy handler rather than triggering
+ *  the exit state machine. */
+function isCtrlCKey(key: KeyEvent): boolean {
+  return Boolean(key.ctrl) && !key.shift && (key.name === "c" || key.sequence === "\u0003");
+}
+
 interface InternalKeyHandlerLike {
   onInternal(event: "keypress", handler: (key: KeyEvent) => void): void;
 }
@@ -36,6 +57,18 @@ export interface KeyHandlerDeps {
   onSubmit(value: string): void;
   /** Cancel any in-flight turn (Escape when running). */
   onEscape(): void;
+  /** Dedupe flag shared with the global Ctrl+C fallback. */
+  ctrlCState: CtrlCSuppressionFlag;
+  /** Run the Ctrl+C state machine: interrupt a running turn, else clear a
+   *  non-empty composer, else arm/confirm the exit prompt. */
+  onCtrlC(): void;
+  /** Whether the persistent exit-confirm prompt is currently showing. */
+  isExitConfirmActive(): boolean;
+  /** Confirm the pending exit and tear the TUI down via the normal quit
+   *  teardown path. */
+  onExitConfirmAccept(): void;
+  /** Cancel the pending exit prompt and return to normal editing. */
+  onExitConfirmCancel(): void;
   /** Dispatch the composer text with behavior:"steer" (Ctrl+Enter). */
   onSteer(): void;
   /** Dino mini-game panel. The panel always owns Ctrl-G, which
@@ -75,6 +108,11 @@ export function installKeyHandlers(deps: KeyHandlerDeps): void {
     onEscape,
     onSteer,
     dinoPanel,
+    ctrlCState,
+    onCtrlC,
+    isExitConfirmActive,
+    onExitConfirmAccept,
+    onExitConfirmCancel,
   } = deps;
 
   const keyHandler = (renderer as unknown as { _keyHandler: InternalKeyHandlerLike })._keyHandler;
@@ -86,6 +124,19 @@ export function installKeyHandlers(deps: KeyHandlerDeps): void {
     // path stops firing right when the user has something to copy. The
     // global handler always fires regardless of focus.
     if (copyController.handleCopyKeystroke(key)) return;
+    // Ctrl+C. Normally the composer's onKeyDown (below) handles it first and
+    // sets `ctrlCState.suppress`; this branch is the fallback for when focus
+    // has drifted off the textarea (e.g. mid drag-select) so onKeyDown never
+    // fired.
+    if (isCtrlCKey(key)) {
+      key.preventDefault();
+      if (ctrlCState.suppress) {
+        ctrlCState.suppress = false;
+        return;
+      }
+      onCtrlC();
+      return;
+    }
     if (key.name !== "escape") return;
     if (escapeState.suppress) {
       escapeState.suppress = false;
@@ -125,6 +176,30 @@ export function installKeyHandlers(deps: KeyHandlerDeps): void {
   // fires, so we intercept at the Renderable's onKeyDown hook which runs first.
   inputField.onKeyDown = (key: KeyEvent) => {
     transcriptWriter.logKey("keydown", key);
+
+    // Ctrl+C owns the highest priority: it must beat submit, newline, and the
+    // dino toggle. The state machine (interrupt / clear / arm-or-confirm exit)
+    // lives in `onCtrlC`. We set `ctrlCState.suppress` so the global keypress
+    // fallback does not double-fire for the same press.
+    if (isCtrlCKey(key)) {
+      key.preventDefault();
+      ctrlCState.suppress = true;
+      onCtrlC();
+      return;
+    }
+
+    // While the exit-confirm prompt is up (idle + empty composer), Enter
+    // confirms the exit and any other keystroke cancels the prompt and
+    // resumes normal editing. A second Ctrl+C also confirms, handled above.
+    if (isExitConfirmActive()) {
+      if (key.name === "return" || key.name === "enter") {
+        key.preventDefault();
+        onExitConfirmAccept();
+        return;
+      }
+      onExitConfirmCancel();
+      // Fall through so the cancelling keystroke is processed normally.
+    }
 
     // Ctrl-G: the dino panel always owns this keystroke regardless of
     // focus, the agent's running state, or whether the composer has

--- a/src/tui/renderer-lifecycle.ts
+++ b/src/tui/renderer-lifecycle.ts
@@ -2,9 +2,15 @@ import { type CliRenderer, createCliRenderer } from "@opentui/core";
 
 /**
  * useMouse: true so the scroll wheel reaches the transcript and OpenTUI
- * receives drag events for in-app text selection. Bare Ctrl+C is the
- * always-exit keystroke (via exitOnCtrlC) so the convention every other
- * interactive Linux/Windows terminal app follows still works here.
+ * receives drag events for in-app text selection.
+ *
+ * exitOnCtrlC is deliberately FALSE: OpenTUI's built-in handler would
+ * call `renderer.destroy()` the instant it sees Ctrl+C, which is too
+ * eager. We route Ctrl+C through our own key handlers instead so it can
+ * interrupt a running turn, clear a non-empty composer, or require a
+ * confirmation before quitting (see `installKeyHandlers`). The actual
+ * exit still goes through `renderer.destroy()` — the same teardown path
+ * OpenTUI's handler used — so shutdown semantics are unchanged.
  *
  * Tests inject a `createTestRenderer` instance via `input.renderer`; in
  * that mode we skip the production renderer construction and the
@@ -15,7 +21,7 @@ export async function acquireRenderer(injected?: CliRenderer): Promise<CliRender
   if (injected) return injected;
   const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
   const renderer = await createCliRenderer({
-    exitOnCtrlC: true,
+    exitOnCtrlC: false,
     useMouse: true,
     useKittyKeyboard: {},
     targetFps: 60,

--- a/src/tui/status-controller.ts
+++ b/src/tui/status-controller.ts
@@ -1,5 +1,11 @@
 import { type CliRenderer, type TextRenderable } from "@opentui/core";
-import { HINT_IDLE, HINT_RUNNING, HINT_SELECTION_COPY } from "./theme.js";
+import {
+  COLORS,
+  HINT_EXIT_CONFIRM,
+  HINT_IDLE,
+  HINT_RUNNING,
+  HINT_SELECTION_COPY,
+} from "./theme.js";
 import { isTextBufferDestroyedError } from "./transcript-writer.js";
 import type { TurnTerminalEvent } from "../types/protocol.js";
 
@@ -38,6 +44,11 @@ export interface StatusControllerOptions {
 export class StatusController {
   private destroyed = false;
   private running = false;
+  /** True while the bare-Ctrl+C exit confirmation is showing. Set by
+   *  `showExitConfirm`, cleared by `clearExitConfirm`. While active the
+   *  status line is pinned to the confirm prompt and other refreshes are
+   *  suppressed so an unrelated chrome write cannot wipe it. */
+  private exitConfirmActive = false;
   /** Subscribers notified on every running→idle / idle→running transition.
    *  Used by the dino panel to drive its freeze (idle) / resume (running)
    *  lifecycle without coupling the panel to the session event stream. */
@@ -54,6 +65,33 @@ export class StatusController {
 
   isRunning(): boolean {
     return this.running;
+  }
+
+  /** Whether the bare-Ctrl+C exit confirmation prompt is currently shown. */
+  isExitConfirmActive(): boolean {
+    return this.exitConfirmActive;
+  }
+
+  /** Pin the persistent "press Ctrl+C again or Enter to exit" prompt to the
+   *  status line. Only reached from an idle, empty composer, so the status
+   *  line is otherwise blank and free to host it. Painted amber so it reads
+   *  as a prompt rather than the green working-status line. */
+  showExitConfirm(): void {
+    if (this.destroyed) return;
+    this.exitConfirmActive = true;
+    this.opts.status.fg = COLORS.system;
+    this.setStatus(HINT_EXIT_CONFIRM);
+  }
+
+  /** Tear the exit prompt down and restore the normal status/hint surface.
+   *  Idempotent so callers can fire it on any cancelling keystroke without
+   *  first checking whether the prompt was up. */
+  clearExitConfirm(): void {
+    if (!this.exitConfirmActive) return;
+    this.exitConfirmActive = false;
+    if (!this.destroyed) this.opts.status.fg = COLORS.status;
+    this.refreshWorkingStatus();
+    this.refreshHint();
   }
 
   lastTerminal(): TurnTerminalEvent | undefined {
@@ -163,7 +201,7 @@ export class StatusController {
    *  input that changes a hint segment (attachments, selection) and from
    *  the running-state transitions in `markRunning` / `markIdle`. */
   refreshHint(): void {
-    if (this.destroyed) return;
+    if (this.destroyed || this.exitConfirmActive) return;
     const base = this.running ? HINT_RUNNING : HINT_IDLE;
     const segments: string[] = [];
     if (this.pendingImageCount > 0) segments.push(this.attachmentHint());
@@ -182,6 +220,9 @@ export class StatusController {
 
   refreshWorkingStatus(): void {
     if (this.destroyed) return;
+    // The exit-confirm prompt owns the status line while it is up; do not
+    // let a ticker tick or a queued-follow-up update paint over it.
+    if (this.exitConfirmActive) return;
     this.opts.refreshActiveToolBlocks();
     if (this.workingStartedAt === undefined) {
       this.setStatus(this.queuedFollowUps > 0 ? `queued follow-ups: ${this.queuedFollowUps}` : "");

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -15,9 +15,16 @@ export const COLORS = {
 } as const;
 
 // Esc is intentionally absent from the idle hint: when no turn is running
-// it is a no-op (it only closes open pickers, which is self-evident). Use
-// Ctrl+C to quit the TUI — the universal terminal convention.
-export const HINT_IDLE = "Enter: send · Shift+Enter: newline · PgUp/PgDn: scroll · Ctrl+C: quit";
+// it is a no-op (it only closes open pickers, which is self-evident).
+// The label is "exit" not "quit" because Ctrl+C on an empty idle composer
+// asks for confirmation first (see HINT_EXIT_CONFIRM) rather than quitting
+// on the first press.
+export const HINT_IDLE = "Enter: send · Shift+Enter: newline · PgUp/PgDn: scroll · Ctrl+C: exit";
+
+// Persistent prompt shown in the status line after a bare Ctrl+C on an
+// empty, idle composer. It does not auto-dismiss: the user either confirms
+// (Ctrl+C again or Enter) or cancels by pressing any other key.
+export const HINT_EXIT_CONFIRM = "Press Ctrl+C again or Enter to exit";
 // Ctrl+Enter surfaces in the running hint only; advertising it on the
 // idle hint would be noise (idle has nothing to steer against). The
 // keystroke is a no-op when the composer is empty, so a single line

--- a/test/helpers/tui-harness.ts
+++ b/test/helpers/tui-harness.ts
@@ -52,6 +52,15 @@ export interface TuiHarness {
   interruptCalls: number;
   /** Number of times the TUI fired its `onResetRequest` callback. */
   resetRequestCalls: number;
+  /** True once `runTui` has resolved (the renderer was destroyed / the TUI
+   *  exited). Lets Ctrl+C tests assert a clean quit happened. */
+  exited: boolean;
+  /**
+   * Resolve once the TUI has exited (renderer destroyed), or throw on
+   * timeout. Use after pressing a confirming Ctrl+C / Enter to prove the
+   * quit path fired without the harness's own `dispose()` triggering it.
+   */
+  waitForExit(options?: { timeoutMs?: number }): Promise<void>;
   /**
    * Wait until either:
    *  - `session.answer` has been called at least `count` times (default 1), or
@@ -160,6 +169,11 @@ export async function bootTui(options: BootTuiOptions = {}): Promise<TuiHarness>
     width,
     height,
     kittyKeyboard: true,
+    // Mirror production (`acquireRenderer`): Ctrl+C is routed through our
+    // own key handlers, not OpenTUI's built-in destroy-on-Ctrl+C. Without
+    // this the test renderer would default to exitOnCtrlC:true and tear
+    // down before the Ctrl+C state machine ran.
+    exitOnCtrlC: false,
   });
 
   const sessionPath = await mkdtemp(join(tmpdir(), "duet-tui-harness-"));
@@ -215,6 +229,7 @@ export async function bootTui(options: BootTuiOptions = {}): Promise<TuiHarness>
   // `renderer.destroy()` resolves `runTui` normally; only a real crash
   // populates `tuiError`.
   let tuiError: unknown;
+  let exited = false;
   const tuiPromise = runTui({
     session,
     workDir,
@@ -228,9 +243,13 @@ export async function bootTui(options: BootTuiOptions = {}): Promise<TuiHarness>
     onResetRequest: () => {
       resetRequestCalls += 1;
     },
-  }).catch((error) => {
-    tuiError = error;
-  });
+  })
+    .catch((error) => {
+      tuiError = error;
+    })
+    .finally(() => {
+      exited = true;
+    });
 
   // Give runTui time to subscribe to the session and render the initial
   // frame before the test starts driving keys. Without this, the first
@@ -275,6 +294,18 @@ export async function bootTui(options: BootTuiOptions = {}): Promise<TuiHarness>
     },
     get resetRequestCalls() {
       return resetRequestCalls;
+    },
+    get exited() {
+      return exited;
+    },
+    async waitForExit({ timeoutMs = 2000 } = {}) {
+      const start = Date.now();
+      while (!exited) {
+        if (Date.now() - start > timeoutMs) {
+          throw new Error(`waitForExit: TUI did not exit within ${timeoutMs}ms`);
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 5));
+      }
     },
     async waitForAnswer({ count = 1, timeoutMs = 1000 } = {}) {
       await waitForCount(() => answerCalls.length, count, timeoutMs, "waitForAnswer");
@@ -353,6 +384,7 @@ export async function bootTui(options: BootTuiOptions = {}): Promise<TuiHarness>
       await yieldToEventLoop();
     },
     async dispose() {
+      // Idempotent: a Ctrl+C test may have already destroyed the renderer.
       renderer.destroy();
       await tuiPromise;
       await session.dispose();

--- a/test/tui-ctrl-c-exit.test.ts
+++ b/test/tui-ctrl-c-exit.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect } from "bun:test";
+
+import { bootTui, type TuiHarness } from "./helpers/tui-harness.js";
+import { testIfDocker } from "./helpers/docker-only.js";
+import { HINT_EXIT_CONFIRM } from "../src/tui/theme.js";
+
+/**
+ * Ctrl+C is no longer an immediate quit. It is a small state machine whose
+ * branch is chosen by the current turn / composer state at press time:
+ *
+ *   1. running turn   → interrupt it (identical to Esc); no exit prompt.
+ *   2. composer text  → clear the composer text only (multiline included);
+ *                        attachments / pickers are left untouched.
+ *   3. idle + empty   → first press arms a persistent exit confirmation, a
+ *                        second press (or Enter) quits; any other key cancels.
+ *
+ * The exit itself reuses `renderer.destroy()` — the same teardown the old
+ * OpenTUI exitOnCtrlC handler used — which the harness surfaces as `exited`.
+ */
+describe("TUI Ctrl+C exit state machine", () => {
+  let harness: TuiHarness;
+
+  beforeEach(async () => {
+    harness = await bootTui();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  async function startLongRunningTurn(): Promise<void> {
+    await harness.mockInput.typeText("/working 30");
+    await harness.flush();
+    harness.mockInput.pressEnter();
+    await harness.waitForPrompt();
+  }
+
+  testIfDocker("Ctrl+C while a turn is running interrupts instead of quitting", async () => {
+    await startLongRunningTurn();
+    const interruptsBefore = harness.interruptCalls;
+
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+
+    expect(harness.interruptCalls).toBe(interruptsBefore + 1);
+    expect(harness.exited).toBe(false);
+  });
+
+  testIfDocker("Ctrl+C with text in the composer clears it and stays in the app", async () => {
+    await harness.mockInput.typeText("a half-typed thought");
+    await harness.flush();
+    expect(harness.inputField.plainText).toBe("a half-typed thought");
+
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+
+    expect(harness.inputField.plainText).toBe("");
+    expect(harness.exited).toBe(false);
+    // Clearing text is not an interrupt and never shows the exit prompt.
+    expect(harness.interruptCalls).toBe(0);
+    const frame = await harness.captureCharFrame();
+    expect(frame).not.toContain(HINT_EXIT_CONFIRM);
+  });
+
+  testIfDocker("Ctrl+C clears multiline composer content", async () => {
+    await harness.mockInput.typeText("first line");
+    await harness.flush();
+    harness.mockInput.pressEnter({ shift: true });
+    await harness.flush();
+    await harness.mockInput.typeText("second line");
+    await harness.flush();
+    expect(harness.inputField.plainText).toContain("first line");
+    expect(harness.inputField.plainText).toContain("second line");
+
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+
+    expect(harness.inputField.plainText).toBe("");
+    expect(harness.exited).toBe(false);
+  });
+
+  testIfDocker("first Ctrl+C on an idle empty composer arms the exit prompt", async () => {
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+
+    const frame = await harness.captureCharFrame();
+    expect(frame).toContain(HINT_EXIT_CONFIRM);
+    expect(harness.exited).toBe(false);
+  });
+
+  testIfDocker("a second Ctrl+C confirms the exit", async () => {
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+    expect(await harness.captureCharFrame()).toContain(HINT_EXIT_CONFIRM);
+
+    harness.mockInput.pressCtrlC();
+    await harness.waitForExit();
+    expect(harness.exited).toBe(true);
+  });
+
+  testIfDocker("Enter confirms the exit while the prompt is showing", async () => {
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+    expect(await harness.captureCharFrame()).toContain(HINT_EXIT_CONFIRM);
+
+    harness.mockInput.pressEnter();
+    await harness.waitForExit();
+    expect(harness.exited).toBe(true);
+  });
+
+  testIfDocker("any other keystroke cancels the prompt and resumes editing", async () => {
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+    expect(await harness.captureCharFrame()).toContain(HINT_EXIT_CONFIRM);
+
+    // A printable key dismisses the prompt and is typed into the composer.
+    await harness.mockInput.typeText("h");
+    await harness.flush();
+
+    expect(harness.exited).toBe(false);
+    expect(harness.inputField.plainText).toBe("h");
+    const frame = await harness.captureCharFrame();
+    expect(frame).not.toContain(HINT_EXIT_CONFIRM);
+  });
+});


### PR DESCRIPTION
## What

Ctrl+C no longer quits the CLI instantly. It's now a small state machine:

- **Turn running** → interrupts the running turn (same effect as Esc). No exit prompt.
- **Composer has text** → clears the composer text only (multiline included). Attachments, autocomplete, and picker state are left untouched.
- **Idle + empty composer** → first press arms a persistent `Press Ctrl+C again or Enter to exit` confirmation (no timeout). **Enter** or a **second Ctrl+C** exits; **any other key** cancels and resumes editing.

## How

- Disables OpenTUI's built-in `exitOnCtrlC` and routes the keystroke through the existing key-handler graph (composer `onKeyDown` with a global-keypress fallback, deduped via a suppress flag mirroring the Esc pattern).
- Reuses the existing Esc interrupt mechanism (`session.interrupt()`) and the existing `renderer.destroy()` teardown, so interrupt and shutdown semantics are unchanged.
- `isCtrlCKey` matches plain Ctrl+C only (`!key.shift`) so Ctrl+Shift+C copy is unaffected.

## Files

- `src/tui/renderer-lifecycle.ts`, `src/tui/theme.ts`, `src/tui/status-controller.ts`, `src/tui/key-handlers.ts`, `src/tui/app.ts`
- `test/helpers/tui-harness.ts`, `test/tui-ctrl-c-exit.test.ts` (new, 7 tests)
- `README.md` keybinding doc

## Tests

- `bun run check-types`, `bun run lint`, `bun run format` → clean
- New suite: 7 pass / 0 fail covering every branch
- Full TUI suite: 118 pass / 0 fail (incl. the Esc-interrupt regression test)