### PR TITLE
[walter] fix(tui): cap transcript renderables to stop long-session scroll freeze

### DIFF
--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -203,7 +203,6 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   const stepRenderer = new StepRenderer({
     renderer,
-    transcript: ui.transcript,
     transcriptWriter,
     statusController,
     onStepStart: () => {

--- a/src/tui/step-renderer.ts
+++ b/src/tui/step-renderer.ts
@@ -1,4 +1,4 @@
-import { type CliRenderer, type ScrollBoxRenderable, TextRenderable } from "@opentui/core";
+import { type CliRenderer, TextRenderable } from "@opentui/core";
 import { formatElapsed, runningMarker, StatusController } from "./status-controller.js";
 import { SIDEBAR_WIDTH } from "./sidebar.js";
 import { COLORS } from "./theme.js";
@@ -40,7 +40,6 @@ interface ToolBlock {
 
 export interface StepRendererOptions {
   renderer: CliRenderer;
-  transcript: ScrollBoxRenderable;
   transcriptWriter: TranscriptWriter;
   statusController: StatusController;
   /** Invoked at the start of `renderStep` so a stale question picker
@@ -210,7 +209,7 @@ export class StepRenderer {
       } satisfies StreamingBlock);
     if (!block) {
       this.opts.transcriptWriter.beginBlock();
-      this.opts.transcript.add(next.line);
+      this.opts.transcriptWriter.mount(next.line);
     }
     next.body += delta;
     updateStreamingBlock(next);
@@ -252,7 +251,7 @@ export class StepRenderer {
       fg,
     });
     this.opts.transcriptWriter.beginBlock();
-    this.opts.transcript.add(line);
+    this.opts.transcriptWriter.mount(line);
     const block: ToolBlock = {
       line,
       header: formatted.header,

--- a/src/tui/transcript-writer.ts
+++ b/src/tui/transcript-writer.ts
@@ -23,7 +23,7 @@ import type { TranscriptEntry } from "./transcript-log.js";
  * is invisible in normal use while keeping a steady-state frame well under
  * the responsiveness budget.
  */
-const MAX_TRANSCRIPT_RENDERABLES = 1500;
+export const MAX_TRANSCRIPT_RENDERABLES = 1500;
 
 export interface TranscriptWriterOptions {
   /** Reads the last drag-selected text; surfaced in `/diag` key dumps so we

--- a/src/tui/transcript-writer.ts
+++ b/src/tui/transcript-writer.ts
@@ -7,6 +7,24 @@ import {
 import { COLORS } from "./theme.js";
 import type { TranscriptEntry } from "./transcript-log.js";
 
+/**
+ * Hard cap on the number of renderables kept in the transcript ScrollBox.
+ *
+ * OpenTUI runs a full Yoga layout pass over every transcript child on each
+ * frame, so an unbounded content tree makes per-frame layout O(n). Long
+ * sessions append thousands of lines; once the tree grows tall enough, a
+ * single frame (or a single streaming append, which re-lays out the whole
+ * tree) costs hundreds of milliseconds to over a second, which starves the
+ * event loop and makes mouse-wheel scrolling stop responding entirely — the
+ * v0.1.171 long-transcript freeze. Capping the live node count keeps layout
+ * cost constant regardless of session length.
+ *
+ * 1500 rows is a generous scrollback bound — dozens of screens — so eviction
+ * is invisible in normal use while keeping a steady-state frame well under
+ * the responsiveness budget.
+ */
+const MAX_TRANSCRIPT_RENDERABLES = 1500;
+
 export interface TranscriptWriterOptions {
   /** Reads the last drag-selected text; surfaced in `/diag` key dumps so we
    *  can correlate "key fired" with "selection state at that moment". */
@@ -55,7 +73,7 @@ export class TranscriptWriter {
     if (this.destroyed) return undefined;
     try {
       const line = new TextRenderable(this.renderer, { content, fg });
-      this.transcript.add(line);
+      this.mount(line);
       return line;
     } catch (error) {
       if (isTextBufferDestroyedError(error)) {
@@ -91,8 +109,51 @@ export class TranscriptWriter {
    *  space for empty content so the renderable still occupies a row. */
   addLine(content: string, fg: string): TextRenderable {
     const line = new TextRenderable(this.renderer, { content: content || " ", fg });
-    this.transcript.add(line);
+    this.mount(line);
     return line;
+  }
+
+  /** Mount a renderable into the transcript ScrollBox and enforce the
+   *  renderable cap. Every transcript write — this writer's own lines plus
+   *  the step renderer's streaming / tool-call lines — funnels through here
+   *  so the eviction policy lives in exactly one place. */
+  mount(line: TextRenderable): void {
+    this.transcript.add(line);
+    this.evictOverflow();
+  }
+
+  /** Drop the oldest renderables once the tree grows past
+   *  {@link MAX_TRANSCRIPT_RENDERABLES} so per-frame Yoga layout stays O(1)
+   *  in session length (see the constant's doc for the freeze it prevents).
+   *
+   *  Eviction only runs while the view is pinned to the bottom. When the
+   *  user has scrolled up to read history, removing lines from the top
+   *  shifts the content under the viewport and yanks what they are reading;
+   *  deferring until they return to the bottom keeps scrolled-up reading
+   *  stable. The freeze this guards against happens during bottom-pinned
+   *  streaming, so trimming there is both sufficient and invisible. */
+  private evictOverflow(): void {
+    if (!this.isPinnedToBottom()) return;
+    const children = this.transcript.getChildren();
+    const overflow = children.length - MAX_TRANSCRIPT_RENDERABLES;
+    if (overflow <= 0) return;
+    // Snapshot the victims before mutating the live children array.
+    for (const victim of children.slice(0, overflow)) {
+      this.transcript.remove(victim.id);
+      victim.destroyRecursively();
+    }
+  }
+
+  /** Whether the transcript is scrolled to (or pinned at) the bottom, using
+   *  the same `scrollTop >= maxScrollTop` test OpenTUI applies internally for
+   *  `stickyStart: "bottom"`. Reads last-rendered scroll geometry, which is
+   *  exactly the "was the user at the bottom" signal eviction needs. */
+  private isPinnedToBottom(): boolean {
+    const maxScrollTop = Math.max(
+      0,
+      this.transcript.scrollHeight - this.transcript.viewport.height,
+    );
+    return this.transcript.scrollTop >= maxScrollTop;
   }
 
   // ---- transcript log ------------------------------------------------------

--- a/test/tui-transcript-cap.test.ts
+++ b/test/tui-transcript-cap.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect } from "bun:test";
+import { createTestRenderer } from "@opentui/core/testing";
+import { buildLayout } from "../src/tui/layout.js";
+import { COLORS } from "../src/tui/theme.js";
+import { TranscriptWriter } from "../src/tui/transcript-writer.js";
+import { testIfDocker } from "./helpers/docker-only.js";
+
+/**
+ * Regression coverage for the v0.1.171 long-transcript scroll freeze.
+ *
+ * Root cause: the transcript ScrollBox kept one renderable per line with no
+ * bound, and OpenTUI runs a full Yoga layout pass over every child each
+ * frame. Once the tree grew to thousands of nodes a single append/render
+ * cost ~1s, starving the event loop so mouse-wheel scroll stopped reacting —
+ * and because a resumed session replays the whole transcript, it was frozen
+ * from the first frame. `TranscriptWriter` now caps the live node count by
+ * evicting the oldest renderables while pinned to the bottom.
+ *
+ * These tests assert the policy, not timing: node count stays bounded under
+ * heavy bottom-pinned streaming, and eviction pauses while the user has
+ * scrolled up so history they are reading is never yanked out from under them.
+ */
+describe("transcript renderable cap", () => {
+  // Mirrors MAX_TRANSCRIPT_RENDERABLES in transcript-writer.ts; the constant
+  // is intentionally private, so we assert against the same generous bound.
+  const CAP = 1500;
+
+  testIfDocker("bottom-pinned streaming caps live renderables", async () => {
+    const { renderer, renderOnce } = await createTestRenderer({
+      width: 120,
+      height: 40,
+      kittyKeyboard: true,
+    });
+    const ui = buildLayout(renderer);
+    const writer = new TranscriptWriter(renderer, ui.transcript, {
+      getLastSelectionText: () => "",
+    });
+
+    // Stream far past the cap through the production append path. Render
+    // periodically like a real turn so sticky-bottom geometry stays current.
+    for (let i = 0; i < 8000; i++) {
+      writer.appendBlock(null, `agent line ${i} the quick brown fox jumps`, COLORS.agent);
+      if (i % 500 === 0) await renderOnce();
+    }
+    await renderOnce();
+
+    expect(ui.transcript.getChildren().length).toBeLessThanOrEqual(CAP);
+    renderer.destroy();
+  });
+
+  testIfDocker("eviction pauses while scrolled up so history is not yanked", async () => {
+    const { renderer, renderOnce } = await createTestRenderer({
+      width: 120,
+      height: 40,
+      kittyKeyboard: true,
+    });
+    const ui = buildLayout(renderer);
+    const writer = new TranscriptWriter(renderer, ui.transcript, {
+      getLastSelectionText: () => "",
+    });
+
+    // Fill to the cap while pinned to the bottom.
+    for (let i = 0; i < CAP; i++) {
+      writer.appendBlock(null, `line ${i}`, COLORS.agent);
+      if (i % 500 === 0) await renderOnce();
+    }
+    await renderOnce();
+    const atCap = ui.transcript.getChildren().length;
+    expect(atCap).toBeLessThanOrEqual(CAP);
+
+    // Scroll up to read history, then append more. Eviction must not trim
+    // while scrolled away from the bottom, so the node count exceeds the cap
+    // rather than removing the lines the user is reading.
+    ui.transcript.scrollTop = 0;
+    await renderOnce();
+    for (let i = 0; i < 600; i++) {
+      writer.appendBlock(null, `more ${i}`, COLORS.agent);
+    }
+    await renderOnce();
+
+    expect(ui.transcript.getChildren().length).toBeGreaterThan(CAP);
+    renderer.destroy();
+  });
+});

--- a/test/tui-transcript-cap.test.ts
+++ b/test/tui-transcript-cap.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from "bun:test";
 import { createTestRenderer } from "@opentui/core/testing";
 import { buildLayout } from "../src/tui/layout.js";
 import { COLORS } from "../src/tui/theme.js";
-import { TranscriptWriter } from "../src/tui/transcript-writer.js";
+import { MAX_TRANSCRIPT_RENDERABLES, TranscriptWriter } from "../src/tui/transcript-writer.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 /**
@@ -21,9 +21,7 @@ import { testIfDocker } from "./helpers/docker-only.js";
  * scrolled up so history they are reading is never yanked out from under them.
  */
 describe("transcript renderable cap", () => {
-  // Mirrors MAX_TRANSCRIPT_RENDERABLES in transcript-writer.ts; the constant
-  // is intentionally private, so we assert against the same generous bound.
-  const CAP = 1500;
+  const CAP = MAX_TRANSCRIPT_RENDERABLES;
 
   testIfDocker("bottom-pinned streaming caps live renderables", async () => {
     const { renderer, renderOnce } = await createTestRenderer({


### PR DESCRIPTION
## Problem
In the TUI (v0.1.171, reported by Walter on iTerm2), **mouse-wheel scroll goes completely dead once the transcript gets very long** and stays dead — it persists even after restarting and *resuming* the same long session.

## Root cause
The transcript `ScrollBoxRenderable` kept one renderable per line with **no bound**, and OpenTUI runs a full Yoga layout pass over every child each frame. Once the tree reached thousands of nodes a single append/render cost ~1s (measured: 50k blocks → ~933ms per streaming tick), starving the event loop so wheel events went unserviced — the hard freeze. Because a resumed session replays the whole transcript (`history-replay.ts`), it was frozen from the first frame.

`viewportCulling` is a red herring: it's already on by default and only skips the *draw* of off-screen nodes, not the layout pass that sizes every child to compute `scrollHeight`. Bounding the live node count is the only mechanism that makes per-frame cost O(1) in session length.

## Fix
- `src/tui/transcript-writer.ts` — a single `mount()` that all transcript writes funnel through, plus `evictOverflow()` which drops the oldest renderables past a generous **1500-row** cap. Eviction runs **only while pinned to the bottom** (`isPinnedToBottom()` mirrors OpenTUI's `scrollTop >= maxScrollTop`), so scrolled-up reading is never yanked.
- `src/tui/step-renderer.ts` / `src/tui/app.ts` — streaming & tool-call lines route through `transcriptWriter.mount()`; removed the now-unused direct `transcript` ref from `StepRenderer`.
- `test/tui-transcript-cap.test.ts` — regression coverage: capped streaming holds node count ≤ 1500; eviction pauses while scrolled up so history isn't yanked. Test derives the cap from the exported `MAX_TRANSCRIPT_RENDERABLES` to avoid drift.

## Measurements
| blocks | streaming tick (uncapped) | capped |
|--------|---------------------------|--------|
| 1,000  | 14 ms  | — |
| 25,000 | 451 ms | — |
| 50,000 | 933 ms | ~7–14 ms (cap 1500) |

No regression to sticky-bottom pinning, drag-select, latest-user banner, keyboard scroll, or resume.

## Gate
- `tsc --noEmit`: pass
- `oxlint src/`: 0 warnings / 0 errors
- `oxfmt --check`: clean
- `bun test ./test/tui-*.test.ts`: 113 pass / 0 fail (incl. 2 new cap tests)