### PR TITLE
[david] feat(memory-cli): rank duet memory TUI by score with paged metadata

### DIFF
--- a/src/cli/memory-db.ts
+++ b/src/cli/memory-db.ts
@@ -1,7 +1,26 @@
 import type { PGlite } from "@electric-sql/pglite";
+import { observationScore, PRIORITY_WEIGHT } from "../memory/loader.js";
 import { runMigrations } from "../memory/migrations.js";
+import { DEFAULT_RECENCY_HALF_LIFE_MS, DEFAULT_REFLECTION_BIAS } from "../memory/observational.js";
 import { DEFAULT_OPEN_LOCK_WAIT_BUDGET_MS, openPGliteWaitingForLock } from "../memory/pglite.js";
 import type { Observation } from "../types/memory.js";
+
+/** Rows fetched per page by the ranked, lazily-paginated TUI list. */
+export const MEMORY_PAGE_SIZE = 25;
+
+/**
+ * Absolute global-pack score for one observation under the CLI defaults.
+ * Reuses the shared {@link observationScore} formula so the displayed value
+ * tracks the runner's ranking exactly. Hardcoded to the runner's global-pack
+ * defaults so the TUI ordering and the per-row score number match what the
+ * runtime ranking would produce (loader.ts), with no flags to drift out of sync.
+ */
+export function scoreObservation(observation: Observation, now: number = Date.now()): number {
+  return observationScore(observation, now, {
+    recencyHalfLifeMs: DEFAULT_RECENCY_HALF_LIFE_MS,
+    reflectionBias: DEFAULT_REFLECTION_BIAS,
+  });
+}
 
 /**
  * Thin read/edit/delete wrapper over the PGlite database the memory pipeline writes
@@ -41,13 +60,60 @@ export class MemoryDb {
     return new MemoryDb(db);
   }
 
-  /** Load all observations ordered most recent first. */
-  async list(): Promise<Observation[]> {
+  /** Total number of observations across every session. */
+  async count(): Promise<number> {
+    const result = await this.db.query<{ count: number }>(
+      `SELECT COUNT(*)::int AS count FROM observations`,
+    );
+    return result.rows[0]?.count ?? 0;
+  }
+
+  /**
+   * Load one page of observations as a single flat list across every session,
+   * ordered by descending global-pack score (highest first). The ORDER BY
+   * materializes the exact score {@link observationScore} computes —
+   * `priorityWeight * 0.5^((now - lastUsedAt)/halfLife) * kindBias` — so the
+   * row order always agrees with the score number the TUI renders per row.
+   *
+   * `now` is passed in (not read from SQL `now()`) so it stays fixed across
+   * every page fetch in a TUI session: pagination with LIMIT/OFFSET is only
+   * stable if the sort key does not drift between calls, and the displayed
+   * score must use the same `now`. Paged with LIMIT/OFFSET so the TUI lazily
+   * fetches and appends pages instead of loading the whole table up front.
+   */
+  async listRanked({
+    limit,
+    offset,
+    now = Date.now(),
+  }: {
+    limit: number;
+    offset: number;
+    now?: number;
+  }): Promise<Observation[]> {
     const result = await this.db.query<ObservationRow>(
       `SELECT id, created_at, last_used_at, session_id, kind, observed_date, referenced_date, relative_date,
               time_of_day, priority, source_json, content, tags_json
        FROM observations
-       ORDER BY created_at DESC`,
+       ORDER BY
+         (CASE priority WHEN 'high' THEN $1::float
+                        WHEN 'medium' THEN $2::float
+                        ELSE $3::float END)
+         * power(0.5::float, ($6::float - last_used_at::float) / $5::float)
+         * (CASE kind WHEN 'reflection' THEN $4::float ELSE 1.0 END)
+         DESC,
+         created_at DESC,
+         id ASC
+       LIMIT $7 OFFSET $8`,
+      [
+        PRIORITY_WEIGHT.high,
+        PRIORITY_WEIGHT.medium,
+        PRIORITY_WEIGHT.low,
+        DEFAULT_REFLECTION_BIAS,
+        DEFAULT_RECENCY_HALF_LIFE_MS,
+        now,
+        limit,
+        offset,
+      ],
     );
     return result.rows.map(rowToObservation);
   }

--- a/src/cli/memory-tui.ts
+++ b/src/cli/memory-tui.ts
@@ -11,11 +11,20 @@ import {
   t,
   TextRenderable,
 } from "@opentui/core";
+import { PRIORITY_WEIGHT } from "../memory/loader.js";
+import { DEFAULT_REFLECTION_BIAS } from "../memory/observational.js";
 import { COLORS } from "../tui/theme.js";
 import type { Observation } from "../types/memory.js";
-import type { MemoryDb } from "./memory-db.js";
+import { MEMORY_PAGE_SIZE, type MemoryDb, scoreObservation } from "./memory-db.js";
 
-const HINT = "↑/↓ navigate · e edit · d delete · q quit";
+const HINT = "↑/↓ navigate · e edit · d delete · q quit (more rows load as you scroll down)";
+
+// Widest score a row can reach: highest priority weight × reflection bias at
+// zero recency decay (0.5^0 = 1). Derived from the shared scoring constants so
+// the score bar normalizes against the true ceiling and the fullest bar maps
+// to the strongest possible memory rather than to whatever tops the page.
+const MAX_SCORE = PRIORITY_WEIGHT.high * DEFAULT_REFLECTION_BIAS;
+const SCORE_BAR_WIDTH = 10;
 
 /**
  * Run the interactive memories browser.
@@ -75,7 +84,22 @@ export async function runMemoryTui(db: MemoryDb, dbPath: string): Promise<void> 
   root.add(hint);
   renderer.root.add(root);
 
-  let observations: Observation[] = await db.list();
+  // Fixed `now` for the whole session. Scores decay with wall-clock time, so
+  // pinning it once keeps the ranking (and therefore LIMIT/OFFSET paging)
+  // stable across page fetches and keeps every displayed score on the same
+  // clock as the order they are sorted by.
+  const renderNow = Date.now();
+  // The list is lazily paginated: we hold only the rows fetched so far
+  // (`observations`) plus the full table size (`totalCount`) so the footer can
+  // show progress and `loadMore` knows when to stop. Rows arrive already
+  // ranked by descending score from `db.listRanked`, so appending the next
+  // page keeps the flat ordering intact.
+  let observations: Observation[] = await db.listRanked({
+    limit: MEMORY_PAGE_SIZE,
+    offset: 0,
+    now: renderNow,
+  });
+  let totalCount = await db.count();
   let selectedIndex = 0;
   // Memorize each row by id so re-renders only update the changed lines'
   // content/foreground rather than re-creating Renderables, which would
@@ -87,6 +111,36 @@ export async function runMemoryTui(db: MemoryDb, dbPath: string): Promise<void> 
   function setStatus(text: string, color: string = COLORS.system): void {
     status.content = text;
     status.fg = color;
+  }
+
+  function setCountStatus(): void {
+    if (totalCount === 0) {
+      setStatus("");
+      return;
+    }
+    setStatus(`${observations.length} of ${totalCount} loaded · ranked by score`);
+  }
+
+  /** Whether more rows remain on disk beyond what is already loaded. */
+  function hasMore(): boolean {
+    return observations.length < totalCount;
+  }
+
+  /** Fetch and append the next page, preserving the ranked order. */
+  async function loadMore(): Promise<void> {
+    if (!hasMore()) return;
+    const next = await db.listRanked({
+      limit: MEMORY_PAGE_SIZE,
+      offset: observations.length,
+      now: renderNow,
+    });
+    if (next.length === 0) {
+      // Defensive: total shrank under us (concurrent delete). Resync so
+      // `hasMore` stops claiming there is more to fetch.
+      totalCount = observations.length;
+      return;
+    }
+    observations = [...observations, ...next];
   }
 
   function rebuildList(): void {
@@ -131,8 +185,10 @@ export async function runMemoryTui(db: MemoryDb, dbPath: string): Promise<void> 
       const marker = selected ? "▶" : " ";
       const headerColor = selected ? COLORS.status : COLORS.user;
       const metaColor = selected ? COLORS.agent : COLORS.hint;
-      const meta = formatMeta(observation);
-      row.content = t`${fg(headerColor)(`${marker} [${observation.priority}] ${observation.observedDate}`)} ${fg(metaColor)(meta)}\n  ${fg(metaColor)(observation.content)}`;
+      const score = scoreObservation(observation, renderNow);
+      const scoreCol = `${scoreBar(score)} ${score.toFixed(2)}`;
+      const meta = formatMeta(observation, renderNow);
+      row.content = t`${fg(headerColor)(`${marker} [${observation.priority}] ${observation.observedDate}`)}  ${fg(COLORS.tool)(scoreCol)}\n  ${fg(metaColor)(meta)}\n  ${fg(metaColor)(observation.content)}`;
       row.fg = selected ? COLORS.agent : COLORS.hint;
     }
 
@@ -152,19 +208,51 @@ export async function runMemoryTui(db: MemoryDb, dbPath: string): Promise<void> 
   }
 
   rebuildList();
+  setCountStatus();
 
-  function moveSelection(direction: -1 | 1): void {
+  /**
+   * Move the cursor by one row. Navigating down off the end of the loaded set
+   * lazily fetches the next page and steps onto it (infinite scroll); only
+   * once everything is loaded does down wrap back to the top. Up wraps to the
+   * bottom of whatever is currently loaded.
+   */
+  async function moveSelection(direction: -1 | 1): Promise<void> {
     if (observations.length === 0) return;
-    selectedIndex = (selectedIndex + direction + observations.length) % observations.length;
+    if (direction === 1 && selectedIndex === observations.length - 1) {
+      if (hasMore()) {
+        await loadMore();
+        selectedIndex = Math.min(selectedIndex + 1, observations.length - 1);
+        rebuildList();
+        setCountStatus();
+        return;
+      }
+      selectedIndex = 0;
+      rebuildList();
+      return;
+    }
+    if (direction === -1 && selectedIndex === 0) {
+      selectedIndex = observations.length - 1;
+      rebuildList();
+      return;
+    }
+    selectedIndex += direction;
     rebuildList();
   }
 
+  /**
+   * Re-fetch the rows currently in view after an edit or delete. Keeps the
+   * same number of rows loaded (clamped to the new total) so the paged view
+   * stays consistent and the cursor never points past the end.
+   */
   async function reload(): Promise<void> {
-    observations = await db.list();
+    totalCount = await db.count();
+    const loaded = Math.max(MEMORY_PAGE_SIZE, observations.length);
+    observations = await db.listRanked({ limit: loaded, offset: 0, now: renderNow });
     if (selectedIndex >= observations.length) {
       selectedIndex = Math.max(0, observations.length - 1);
     }
     rebuildList();
+    setCountStatus();
   }
 
   async function deleteSelected(): Promise<void> {
@@ -221,12 +309,12 @@ export async function runMemoryTui(db: MemoryDb, dbPath: string): Promise<void> 
     }
     if (key.name === "up") {
       key.preventDefault();
-      moveSelection(-1);
+      void moveSelection(-1);
       return;
     }
     if (key.name === "down") {
       key.preventDefault();
-      moveSelection(1);
+      void moveSelection(1);
       return;
     }
     if (key.name === "d") {
@@ -291,10 +379,39 @@ async function editInExternalEditor(
   }
 }
 
-function formatMeta(observation: Observation): string {
+function formatMeta(observation: Observation, now: number): string {
   const parts: string[] = [observation.kind];
   if (observation.tags.length > 0) parts.push(`#${observation.tags.join(" #")}`);
+  parts.push(`used ${relativeTime(observation.lastUsedAt, now)}`);
+  parts.push(`created ${relativeTime(observation.createdAt, now)}`);
   return parts.join(" · ");
+}
+
+/**
+ * Fixed-width unicode bar visualizing `score` against {@link MAX_SCORE}, the
+ * strongest score any row can reach. Filled blocks scale with the score so a
+ * glance separates dominant memories from decayed ones.
+ */
+function scoreBar(score: number, max: number = MAX_SCORE, width: number = SCORE_BAR_WIDTH): string {
+  const ratio = max > 0 ? Math.max(0, Math.min(1, score / max)) : 0;
+  const filled = Math.round(ratio * width);
+  return `${"\u2588".repeat(filled)}${"\u2591".repeat(width - filled)}`;
+}
+
+/** Compact relative age like `just now`, `5m ago`, `3h ago`, `12d ago`. */
+function relativeTime(timestamp: number, now: number): string {
+  const deltaMs = now - timestamp;
+  if (deltaMs < 0) return "in the future";
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 45) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 365) return `${days}d ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
 }
 
 function formatError(prefix: string, error: unknown): string {

--- a/src/memory/loader.ts
+++ b/src/memory/loader.ts
@@ -39,11 +39,40 @@ import { estimateTokens } from "./observational.js";
  * only does the final greedy token-budget fit.
  */
 
-const PRIORITY_WEIGHT: Record<ObservationPriority, number> = {
+export const PRIORITY_WEIGHT: Record<ObservationPriority, number> = {
   high: 3,
   medium: 2,
   low: 1,
 };
+
+/** Tunable inputs to {@link observationScore}; mirror the loader's ranking config. */
+export interface ObservationScoreOptions {
+  /** Half-life in milliseconds applied to time since `lastUsedAt`. */
+  recencyHalfLifeMs: number;
+  /** Multiplier applied to `kind = 'reflection'` rows. */
+  reflectionBias: number;
+}
+
+/**
+ * Compute the absolute global-pack score for one observation:
+ * `priorityWeight * 0.5^((now - lastUsedAt)/halfLife) * kindBias`.
+ *
+ * {@link loadGlobalPack}'s SQL ranking only needs the monotone log-space form
+ * because the `0.5^(now/h)` term is constant within a single ranking pass.
+ * Callers that want the real numeric value per row — e.g. the `duet memory`
+ * TUI rendering a score column, which orders by this exact score — use this so
+ * the displayed number matches the formula the runner ranks by.
+ */
+export function observationScore(
+  observation: Pick<Observation, "priority" | "kind" | "lastUsedAt">,
+  now: number,
+  options: ObservationScoreOptions,
+): number {
+  const priorityWeight = PRIORITY_WEIGHT[observation.priority];
+  const kindBias = observation.kind === "reflection" ? options.reflectionBias : 1.0;
+  const decay = Math.pow(0.5, (now - observation.lastUsedAt) / options.recencyHalfLifeMs);
+  return priorityWeight * decay * kindBias;
+}
 
 export interface LoadGlobalPackOptions {
   /**

--- a/src/memory/observational.ts
+++ b/src/memory/observational.ts
@@ -164,13 +164,13 @@ export const FIXED_OBSERVER_BUDGETS = {
  * chatter decay out of the global pack. Tunable per-caller via
  * `ObservationalMemorySettingsInput.recencyHalfLifeMs`.
  */
-const DEFAULT_RECENCY_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000;
+export const DEFAULT_RECENCY_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * 1.3 keeps reflections preferred at matched priority/recency without
  * shutting raw observations out of the global pack entirely.
  */
-const DEFAULT_REFLECTION_BIAS = 1.3;
+export const DEFAULT_REFLECTION_BIAS = 1.3;
 
 export interface DerivedMemoryBudgets {
   observation: {

--- a/test/memory-db.test.ts
+++ b/test/memory-db.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemoryDb, MEMORY_PAGE_SIZE, scoreObservation } from "../src/cli/memory-db.js";
+import {
+  DEFAULT_RECENCY_HALF_LIFE_MS,
+  DEFAULT_REFLECTION_BIAS,
+} from "../src/memory/observational.js";
+import { PRIORITY_WEIGHT } from "../src/memory/loader.js";
+import type { Observation } from "../src/types/memory.js";
+import { testIfDocker } from "./helpers/docker-only.js";
+
+/**
+ * Tests for the `duet memory` CLI database wrapper: the ranked, lazily-paged
+ * query that backs the TUI list, the row count it pairs with, and the
+ * per-row score the TUI displays. The ranked order must match the runner's
+ * global-pack ranking (loader.ts) — highest `priority * 0.5^(age/halfLife) *
+ * kindBias` first — across every session in one flat list.
+ */
+
+const NOW = Date.UTC(2026, 5, 5); // 2026-06-05
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("MemoryDb ranked paging", () => {
+  testIfDocker("count returns the total across all sessions", async () => {
+    await withDb(async (db) => {
+      await seed(db, makeFixtures(60));
+      expect(await db.count()).toBe(60);
+    });
+  });
+
+  testIfDocker("listRanked returns one flat list ordered by score descending", async () => {
+    await withDb(async (db) => {
+      // A high-priority reflection used today must outrank a low-priority
+      // observation that has not been touched in 60 days, regardless of
+      // which session each came from or its created_at.
+      await seed(db, [
+        fixture({ id: "low_old", priority: "low", kind: "observation", lastUsedAt: ago(60) }),
+        fixture({
+          id: "high_reflection_today",
+          priority: "high",
+          kind: "reflection",
+          lastUsedAt: NOW,
+          sessionId: "s2",
+        }),
+        fixture({
+          id: "medium_recent",
+          priority: "medium",
+          kind: "observation",
+          lastUsedAt: ago(2),
+        }),
+      ]);
+
+      const rows = await db.listRanked({ limit: 25, offset: 0, now: NOW });
+      expect(rows.map((r) => r.id)).toEqual(["high_reflection_today", "medium_recent", "low_old"]);
+
+      // The displayed score is the real numeric formula, not the SQL
+      // log-space rank. Verify the top row matches the hand-computed value.
+      const top = rows[0]!;
+      const expected =
+        PRIORITY_WEIGHT.high *
+        DEFAULT_REFLECTION_BIAS *
+        Math.pow(0.5, (NOW - top.lastUsedAt) / DEFAULT_RECENCY_HALF_LIFE_MS);
+      expect(scoreObservation(top, NOW)).toBeCloseTo(expected, 6);
+    });
+  });
+
+  testIfDocker("listRanked honors LIMIT/OFFSET for lazy pagination", async () => {
+    await withDb(async (db) => {
+      await seed(db, makeFixtures(60));
+
+      const page1 = await db.listRanked({ limit: MEMORY_PAGE_SIZE, offset: 0, now: NOW });
+      const page2 = await db.listRanked({
+        limit: MEMORY_PAGE_SIZE,
+        offset: MEMORY_PAGE_SIZE,
+        now: NOW,
+      });
+      const page3 = await db.listRanked({
+        limit: MEMORY_PAGE_SIZE,
+        offset: MEMORY_PAGE_SIZE * 2,
+        now: NOW,
+      });
+
+      expect(page1).toHaveLength(25);
+      expect(page2).toHaveLength(25);
+      expect(page3).toHaveLength(10); // 60 total - 50 = 10
+
+      // Walking the pages in order reproduces a single full-table ranked
+      // query: pages are disjoint, gapless, and globally ordered.
+      const all = [...page1, ...page2, ...page3];
+      expect(new Set(all.map((r) => r.id)).size).toBe(60);
+      const full = await db.listRanked({ limit: 60, offset: 0, now: NOW });
+      expect(all.map((r) => r.id)).toEqual(full.map((r) => r.id));
+
+      // Order is the true score descending: the displayed score never
+      // increases as we walk down the list.
+      const scores = all.map((r) => scoreObservation(r, NOW));
+      for (let i = 1; i < scores.length; i++) {
+        expect(scores[i]!).toBeLessThanOrEqual(scores[i - 1]! + 1e-9);
+      }
+    });
+  });
+
+  testIfDocker("delete keeps the paged view consistent", async () => {
+    await withDb(async (db) => {
+      await seed(db, makeFixtures(30));
+      const before = await db.listRanked({ limit: MEMORY_PAGE_SIZE, offset: 0, now: NOW });
+      const victim = before[0]!.id;
+
+      await db.delete(victim);
+
+      expect(await db.count()).toBe(29);
+      const after = await db.listRanked({ limit: MEMORY_PAGE_SIZE, offset: 0, now: NOW });
+      expect(after.map((r) => r.id)).not.toContain(victim);
+      expect(after).toHaveLength(25);
+    });
+  });
+});
+
+async function withDb(fn: (db: MemoryDb) => Promise<void>): Promise<void> {
+  const tempDir = await mkdtemp(join(tmpdir(), "duet-memory-db-"));
+  const db = await MemoryDb.open(join(tempDir, "memory.db"));
+  try {
+    await fn(db);
+  } finally {
+    await db.close();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+interface FixtureInput {
+  id: string;
+  priority: Observation["priority"];
+  kind: Observation["kind"];
+  lastUsedAt: number;
+  createdAt?: number;
+  sessionId?: string | null;
+}
+
+function fixture(input: FixtureInput): Required<FixtureInput> {
+  return {
+    createdAt: input.lastUsedAt,
+    sessionId: null,
+    ...input,
+  };
+}
+
+function ago(days: number): number {
+  return NOW - days * DAY_MS;
+}
+
+const PRIORITIES: Observation["priority"][] = ["high", "medium", "low"];
+
+function makeFixtures(n: number): Required<FixtureInput>[] {
+  return Array.from({ length: n }, (_, i) =>
+    fixture({
+      id: `obs_${i}`,
+      priority: PRIORITIES[i % 3]!,
+      kind: i % 5 === 0 ? "reflection" : "observation",
+      lastUsedAt: ago(i),
+      sessionId: i % 2 === 0 ? "s_even" : "s_odd",
+    }),
+  );
+}
+
+async function seed(db: MemoryDb, fixtures: Required<FixtureInput>[]): Promise<void> {
+  // MemoryDb does not expose an insert, so reach through to the underlying
+  // PGlite handle the same shape the runner writes rows in.
+  const pg = (db as unknown as { db: import("@electric-sql/pglite").PGlite }).db;
+  for (const f of fixtures) {
+    await pg.query(
+      `INSERT INTO observations (
+        id, created_at, last_used_at, session_id, kind, observed_date, referenced_date, relative_date,
+        time_of_day, priority, source_json, content, tags_json
+      ) VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7, '{"kind":"system"}', $8, '[]')`,
+      [
+        f.id,
+        f.createdAt,
+        f.lastUsedAt,
+        f.sessionId,
+        f.kind,
+        new Date(f.createdAt).toISOString().slice(0, 10),
+        f.priority,
+        `content for ${f.id}`,
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## What

Reworks the `duet memory` (alias `duet memories`) TUI to rank by the runner's real **global-pack score** instead of `created_at`, surfaces score + recency metadata per row, and replaces the load-everything query with lazy pagination.

## Changes

- **Ranking by true score.** Rows are ordered by the exact runner formula `priorityWeight * 0.5^((now - lastUsedAt)/halfLife) * kindBias` (priority 3/2/1, 7-day half-life, 1.3 reflection bias — hardcoded to the runner defaults, no flags). One flat list across **all** sessions. SQL orders by the true score (not loader's log-space rank) so list order always matches the displayed number; deterministic tie-breakers (`created_at DESC, id ASC`) keep LIMIT/OFFSET pages stable at equal scores.
- **Lazy pagination.** New `MemoryDb.listRanked({limit, offset, now})` + `count()`; page size 25, infinite-scroll load-more — pages are fetched/appended on demand rather than loading the whole table. `now` is fixed once per TUI session so paging and scores don't drift.
- **Richer rows.** Each row shows a score bar + numeric score on the header line and `kind · #tags · used <rel> · created <rel>` on the meta line. Edit/delete refetch the loaded window to stay consistent.
- **Shared scoring seam.** Exported `PRIORITY_WEIGHT` + new `observationScore()` helper from `loader.ts`, and the `DEFAULT_RECENCY_HALF_LIFE_MS` / `DEFAULT_REFLECTION_BIAS` constants from `observational.ts`, so the CLI reuses the runner's ranking instead of duplicating literals. Loader's hot path is unchanged.

## Tests

New `test/memory-db.test.ts` (Docker-gated, like the other PGlite tests): count, flat ranked ordering with a hand-verified score, disjoint/gapless score-descending LIMIT/OFFSET paging, and delete consistency. 4/4 pass in the Docker harness; typecheck/lint/format green.