### PR TITLE
fix(wire-shaping): keep a recent tail when no user turn survives eviction

### DIFF
--- a/evals/fixtures/session_rUjMi_pUNzhB/memory-dump.json
+++ b/evals/fixtures/session_rUjMi_pUNzhB/memory-dump.json
@@ -1,0 +1,4882 @@
+[
+  {
+    "id": "mem_YoRti_eqNSuo",
+    "createdAt": 1781811938641,
+    "lastUsedAt": 1781811938641,
+    "ageDays": 0.028829212962962963,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-18",
+    "timeOfDay": "19:45",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"b9c6d89ec1865e7b\" range=\"msg_user_1781811031668_b1727e44:msg_tool_toolu_01GHHCJTyuZNVQi1Eo6WwYGp\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (2026-06-18 19:45) Continued the model-translation refactor in `chat-app` after the user said to continue; kept the working thesis that the gateway should stay a dumb pipe and backend should translate role ids to runner-native `duet:<gatewaySlug>` values.\n-> Tightened `packages/shared/src/types/ai-models.ts` with `isEnabledModelId` and a `RunnerModelId` type, and updated the docstring to reflect that Convex stores role ids while the backend translates at push time.\n-> Changed `packages/backend/convex/model/kanban.ts` so kanban per-state model writes now validate/store the role id instead of normalizing to `duet:<slug>`.\n-> Added `toRunnerKanbanDefinition` in `packages/backend/convex/domains/kanban/definitions.ts` and wired `buildTurnChannelContext` in `packages/backend/convex/domains/sandboxes/actions.ts` to translate kanban state models at push time; handled the fact that the backend’s `StateMachineAgentState` type doesn’t expose `model` by treating the persisted state structurally.\n-> Updated the session push path in `packages/backend/convex/domains/sandboxes/actions.ts` to translate `session.runnerModelId` before `gateway.startSession` and to translate `setSessionModel` before pushing to the gateway, while keeping DB storage as the role id.\n-> Removed `getModelById` from `packages/agent-gateway/src/session-controller.ts` so the gateway forwards `metadata.model` unchanged; this makes the gateway AI_MODELS-free.\n🟡 (2026-06-18 19:45) Current blocker: `bunx turbo check-types --filter=@repo/shared --filter=@repo/agent-gateway --filter=@repo/backend` failed twice while validating the new kanban translation helper because the backend `StateMachineAgentState` type from `@duetso/agent@0.1.174` lacks `model`, then because the helper’s casts needed to go through `unknown`/structural typing. The last edit switched the cast to `unknown as Record<string, unknown>` and `unknown as KanbanState`; typecheck still needs to be rerun.\n🟡 (2026-06-18 19:45) The todo list is now at: shared-helpers, kanban-store-role, kanban-translate-push, and session-translate-push completed; `gateway-dumb-pipe` is in progress; tests/typecheck remain pending.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_O-w0oTzWez0B",
+    "createdAt": 1781810896316,
+    "lastUsedAt": 1781810896316,
+    "ageDays": 0.040893159722222225,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-18",
+    "timeOfDay": "19:28",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"7f711cc76dc9057f\" range=\"msg_user_1781810892757_340f297a:msg_user_1781810892757_340f297a\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (2026-06-18 19:28) User agreed the gateway should stay a dumb pipe and not import `AI_MODELS`; backend should do the translation, preferably using `GatewayModelId` types, and no migration is needed because existing kanban data should be handled in code (generalized if possible).\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_MEEUi-zk81Jf",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user decided to cap sandbox recovery retries because endless retrying failed or preflight-failed sandboxes would waste money, explicitly asking for “retries 5.” The implementation raised `MAX_RECOVERY_ATTEMPTS` in `packages/backend/convex/domains/sandboxes/internal.ts` from 3 to 5, refreshed the backoff comments in `packages/backend/convex/domains/sandboxes/mutations.ts`, updated the cap-dependent backend recovery suites in `packages/backend/tests/convex/sm-recovery.test.ts` and `packages/backend/tests/convex/relay-self-healing.test.ts`, and verified `check-types` plus the relevant tests before committing and pushing `3e4aedaee` to `david/relay-self-healing`. The durable lesson is that recovery loops should be tuned from an explicit cost/benefit constraint, and once that cap is chosen, the tests and comments need to encode the same limit so future changes don’t drift back toward unbounded retry cost.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_eDBCoDG7wqXI",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user wanted a `write-tests` skill created from the recent review/test lessons, with `review` kept as the summary surface rather than the source of truth. The resulting `.agents/skills/write-tests/SKILL.md` in chat-app was written with Vitest-only guidance and repo-specific conventions that emphasize not testing what TypeScript already guarantees, avoiding too many separate seams, keeping tests behavior-focused and decoupled from implementation, and reusing review lessons about outermost-entry testing, asserting actual values, and removing dead code; it also cross-referenced the earlier config-mocking lesson so test advice would not regress into conditional or skip-based coupling. The lesson is that when a repo’s testing philosophy is being formalized, the skill file should capture the stable principles and the review skill should merely point back to it, preventing duplicated guidance from drifting apart.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_mLHgg4Kn0ZHx",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user redirected the documentation layout so `review` would contain only summary test guidance and link to `write-tests`, because `write-tests` was intended to be the source of truth. The follow-up edit collapsed the old standalone review test items into a single `#9` summary pointing at `.agents/skills/write-tests/SKILL.md` and renumbered the rest of `.agents/skills/review/SKILL.md` so the review skill remained aligned with that split. The higher-level lesson is that when one skill becomes the canonical policy surface, related skills should stop duplicating detailed guidance and instead reference the canonical file, otherwise the repo accumulates competing sources of truth.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_M51qGBeNxjcF",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user wanted the Search experience to treat the first user message as a search-term reminder rather than a conversation opener, and later clarified that a short system-prompt reminder should also exist for search channels. The initial change in `packages/shared/src/constants/search.ts` prepended `SEARCH_SYSTEM_REMINDER` so the first user message is treated as a query typed into a search bar and the assistant should not answer conversationally or ask clarifying questions before searching; when the user asked for a channel-level prompt too, an always-on `SEARCH_CHANNEL_SYSTEM_PROMPT` was added and wired through `packages/backend/convex/domains/sandboxes/actions.ts` for `channel:search` sessions, while `SEARCH_SYSTEM_REMINDER` remained the first-message-only steer. The lesson is that search-mode intent needs both a persistent channel invariant and a first-turn reminder: the channel prompt establishes the workspace contract, and the reminder handles the moment when the model first sees the user’s query.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_OAVu4-IlsNR7",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user later asked to make the Search modal dismissable again after an earlier attempt had made it non-dismissible. The modal implementation in `apps/web/components/search/search-modal.tsx` was adjusted to restore `onOpenChange` close handling and remove the Escape/outside-click guards, while keeping the header Close button and the new search-channel framing intact; the commit `eeee799c3` was then rebased onto `837c1b316` and pushed after `check-types`, `lint`, and `format` passed. The durable lesson is that UX restrictions added for clarity should remain reversible, and when a user steers back toward ordinary dismiss behavior, the implementation should preserve the informational framing without trapping the dialog.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_072v1EnmWwEl",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user noticed the `Computer` sandbox stats component looked cramped in a screenshot, which traced to `apps/web/spa/files/components/sandbox-stats.tsx` laying a 64px progress ring beside the value in a too-narrow 3-across grid. The fix stacked the ring above the value in the DISK / MEMORY / CPU cards when they render three across, keeping the side-by-side layout only where the cards are already vertically stacked, and the comment above the grid was updated to match the new structure; type-check and lint both passed afterward. The lesson is that dense dashboard cards should privilege value readability over preserving a uniform micro-layout, especially when the same design can adapt differently at the width where the cramped wrapping appears.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_oqAZBz45FRrR",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user wanted the default Search model to be “just fast, not fast google,” which required changing the model-id default rather than only tweaking a caller override. The edit in `packages/shared/src/constants/search.ts` changed `SEARCH_DEFAULT_MODEL_ID` to resolve to `'fast'` instead of `'fast:google'`, so Search sessions now default to the generic fast role while compose-bar overrides still apply. The lesson is that when a default is semantically too specific, the fix belongs at the canonical default constant; leaving the override path intact preserves user-specific routing without forcing the whole feature onto a branded variant.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_LwqS9Vtkp844",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user first noticed that orphaned streaming messages could remain stuck when a session parked on ask or sleep, and later clarified the invariant that a message should stop being streaming once the session is in ask/waiting-for-input because streaming only exists while the turn runner is actively running. Investigation across `packages/backend/convex/domains/sandboxes/mutations.ts` and `packages/agent-gateway/src/session-controller.ts` showed the normal ask path already flushes buffered messages via `handleTerminal(..., 'ask')`, so the bug lived in the orphan cleanup predicate: it only finalized when the session was terminal and therefore missed `waiting-for-input`/`sleeping` sessions if cleanup raced after ask. The completed fix broadened `cleanupOrphanedStreamingMessages` in `packages/backend/convex/domains/messages/internal.ts` and added `RUNNER_ACTIVE_SESSION_STATES = ['running', 'pending']` in `packages/backend/convex/schema.ts`, so the cron now finalizes `ai-streaming`/`ai-pending` messages whenever the session is not runner-active; the age-gate alternative was rejected as too risky for long legitimate runs, and the lesson is that “runner active” is the real lifecycle boundary, not “terminal,” when deciding whether a streaming indicator may still be valid.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_PwX3dXG9101X",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "low",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, a review pass over the orphaned-streaming-message cleanup diff found that the cron doc-comment had become redundant with `RUNNER_ACTIVE_SESSION_STATES` in `packages/backend/convex/schema.ts`. The review confirmed a suspected `['running','pending']` set in `packages/backend/convex/domains/sandboxes/internal.ts` was a separate sandbox-idle gating concept and should not be refactored into the runner-active definition, so the only code change was trimming the cron comment to cross-reference the constant instead of restating it. The durable lesson is that once a state set is canonized in a shared constant, comments should point at it rather than duplicating the semantics, because duplicated prose is where future drift and false coupling start.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_QaWEcyILbcza",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user requested a push after the orphaned-streaming-message cleanup was reviewed, and the change was committed as `fix: finalize orphaned streaming messages on parked sessions` before being rebased and pushed to `staging`. The final behavior in `packages/backend/convex/domains/messages/internal.ts` now finalizes `ai-streaming` and `ai-pending` messages whenever the session is not runner-active, which means messages stranded while a session parks on `waiting-for-input`, sleeps, or reaches terminal state no longer stay stuck in the streaming indicator. The lesson is that once the state boundary has been corrected and tested, the workflow should end by rebasing cleanly onto the advancing staging branch so the fix lands without leaving behind a divergent local history.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_uTUawLiIkPut",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user reported that the free-promo deletion had been restored in later work, and the final resolution was to end the promo without removing the surrounding free-aware infrastructure. The live promo cleanup and the related billing-test hardening both had to be pushed through a rebased `staging` branch because the remote had advanced; after the rebase, the repository still kept `isFree` plumbing for future promos but no longer marked any current model free, and the billing tests were isolated from the live catalogue so the reverted flags would not be silently reintroduced. The higher-level lesson is that when a business rule is being retired, keep the framework only if future exceptions are expected, but separate that framework from live product state so the test suite does not become the enforcement mechanism for old pricing policy.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ZDHATWIwkxKp",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the duet-agent repo, the user asked for a `/release`, and the release workflow became its own durable pattern. The agent bumped `package.json` from `0.1.185` to `0.1.186`, verified `v0.1.186` was free, ran `bun run check-types` and `bun run lint`, committed `chore: release v0.1.186` as `2d9fcab`, created annotated tag `v0.1.186`, and pushed both `main` and the tag to origin. The lesson is that the release path is not just version editing; it includes checking tag availability, running the repo’s quality gates, and publishing both branch and tag so later sessions can navigate from the semver marker rather than guessing which commit was intended.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_pMHhfQpO3Qvj",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the duet-agent repo, the user asked whether state-machine usage accounting should include sub-agent models plus the memory model, and explicitly requested that it be covered by eval. The work added `evals/state-machine-usage-by-model.eval.ts` to verify end-to-end `usageByModel` attribution across the parent, the state-machine sub-agent, and the memory observer; the eval passed, then a falsification run intentionally broke memory attribution and failed as expected, proving the eval would catch the regression. Investigation also exposed that `src/turn-runner/turn-runner.ts` already attributed parent and sub-agent usage under resolved model ids, while the memory observer still used the configured shorthand `gpt-5.4-mini` via `resolveMemoryActorModel(...)`; the lesson is that once accounting is expected to be uniform, the eval should cover the whole attribution chain so a mismatch in one actor does not slip past because the other actors were already normalized.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ipEeScn14zL0",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the duet-agent repo, the user wanted memory usage to follow the same resolved-model-id convention as the rest of usage accounting. The change in `src/turn-runner/turn-runner.ts` updated `updateMemoryAfterAgentRun` so it resolves the memory model once and records usage under `resolveModelName(...).id` instead of the shorthand string; the companion eval `evals/state-machine-usage-by-model.eval.ts` was updated to assert the memory entry against that resolved id as well, and the live Docker eval plus `bun run check-types`/`bun run lint` confirmed the new `usageByModel` shape. The lesson is that accounting systems should use one identifier scheme end to end whenever possible, because mixed shorthand and resolved IDs make it harder to reason about coverage and harder for evals to assert invariants consistently.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_s8Cm-gebd3IF",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the duet-agent repo, after the usage-accounting fix passed, the work was released as `v0.1.187`. The feature commit `f69208d` and the release commit `8888bfa` were tagged, `main` and the tag were pushed to origin, and the tree was left clean so the release marker now captures the resolved memory-model usage change and its eval coverage. The durable lesson is that a release tag is the stable handoff point for future sessions, so the actual fix, the verification, and the tag should stay linked in memory rather than only remembering the version number.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_hmScKUsVTTpF",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781329192510,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user then chose the narrower promo-ending scope: remove `isFree` only from `deepseek-v4-pro` and `glm-4.7`, while leaving the `isFree` field and helper functions in place for future promos. The cleanup re-applied the removal in `packages/shared/src/types/ai-models.ts`, updated `packages/backend/tests/convex/message-billable-cost.test.ts` to mock `isModelFree`/`isGatewayModelFree` against stable fake ids and slugs instead of depending on live catalogue state, and verified the billing test plus the shared AI-model tests and `bun run check-types`/`bun run lint` all passed; a later push on `staging` confirmed there were `0` `isFree: true` entries left in `packages/shared/src/types/ai-models.ts`. The lesson is that if the intent is simply to end two promo-free entries, the tests should be decoupled first so the repository does not keep restoring the promo state just to satisfy a brittle billing assertion.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_6JJnRwJm-O5s",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user initially asked why `isFree` model flags that they had deleted in commit `4f51df6e53ce876e83e295dbb0c104d5b53aa5e8` were later restored, and the investigation showed PR `cb54b53de` (`[david] feat: agentic search modal`) had branched from the deletion commit and reintroduced `fix(models): restore DeepSeek V4 Pro + GLM-4.7 free-promo flags` because `message-billable-cost.test.ts` was failing on staging once the flags were removed. After the user clarified that “when I say I put a commit of x, it means a human made the commit,” the scope was narrowed to removing only the two free flags while keeping the free-aware infra; the durable insight is that billing tests can encode hidden product policy, so changing a promo flag without updating the test/callers can look like a regression and get reverted even if the deletion was intentional.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_YTx0ty5MKUx2",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the duet-agent repo, a design concern surfaced when the user noticed that once skill sync completed, the agent did not reload its system prompt, so newly synced skills would never enter the passive prompt mid-session. Investigation in `src/turn-runner/skill-context.ts` and `src/turn-runner/turn-runner.ts` showed that live `/`-picker and `/skill` expansion already reloaded discovered skills, but the parent agent prompt was captured once at session start; that made fire-and-forget sync unsafe because the session would continue with a stale discovery block. The fix was to restore awaiting `maybeAutoSyncDefaultSkills(...)` in `src/cli/run.ts` for both the TUI and one-shot paths, and the lesson is that when prompt construction happens only once per session, any skill-install path must complete synchronously before the turn runner starts or it will create a hidden stale-context bug.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ZWAmIldJgYE-",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the duet-agent repo, the user then clarified that the same stale-skill problem applied to RPC mode too, and steered the fix toward making skill sync resilient rather than maintaining a backgrounded path. The implementation followed that steer by making both `src/cli/rpc.ts` and `src/cli/run.ts` await `maybeAutoSyncDefaultSkills`, then reworking `src/lib/sync-skills.ts` so default skills are staged in a per-call sibling directory and swapped into place atomically with `rename`, which prevents concurrent `duet` processes sharing one HOME from seeing or deleting a half-written tree. A Docker-gated regression in `test/cli-login.test.ts` was kept to exercise the real CLI sync path and assert that concurrent syncs converge without `.staging-` or `.old-` leftovers, and the broader lesson is that cross-process filesystem state needs atomic publish semantics plus a real concurrency test, not just a happy-path unit stub.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_-5E4mKWPSpaQ",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the duet-agent repo, the user asked for an eval-first approach to a suspected mid-turn steer failure during an answered-ask turn, and specifically wanted to know how common it was before any code change. A new eval, `evals/state-machine-steer-during-answered-ask.eval.ts`, was derived from `state-machine-answered-ask-enforces-transition.eval.ts` and first ran on `sonnet-4.6`, where 0/5 relay deaths appeared; instrumentation then showed the first harness version was invalid because the steer landed after the decision point (`steerAfterSteps=0`, first step was `tool_call:select_state_machine_state`), so `thinkingLevel: \"high\"` was added to move the steer into reasoning (`steerAfterSteps=1`). Even with the corrected harness, the model still called `select_state_machine_state` first and completed the relay, so the eval could not reproduce the issue on the tested Sonnet configurations; the lesson is that timing bugs need harness validation before diagnosis, and if the failure only appears on a specific model/context, the eval should be rerun against that exact model rather than generalized too early.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_CHa1t_DqSMjb",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the duet-agent repo, the suspected answered-ask relay death was eventually dropped after the user said, in effect, “if you can't repro let's just drop it,” and the eval continued to show no reproduction on `sonnet-4.6` even after expanding to 0/15 runs across three steer/thinking configurations. The eval directory `evals/state-machine-steer-during-answered-ask.eval.ts` was removed, the tree was confirmed clean, and the final diagnosis was that `select_state_machine_state` still happens first with the steer handled afterward, which made the bug look model/context-specific rather than a generic answered-ask relay defect. The durable lesson is that when a suspected race or prompt-order issue refuses to reproduce across controlled configurations, it is better to remove the exploratory harness and treat the case as model-specific until a concrete failing model/session is identified.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_SLgTjgeE-8lD",
+    "createdAt": 1781206982060,
+    "lastUsedAt": 1781206982060,
+    "ageDays": 7.030641493055556,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "19:43",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in the chat-app repo, the user objected to brittle free-model tests after all free models were removed, saying the tests “shouldn’t matter what I set in model config.” The first repair was to stop pinning promo assertions to `balanced`: `packages/shared/src/types/ai-models.test.ts` synthesized a free model by cloning an existing entry with `isFree: true`, and `packages/shared/src/constants/credits.test.ts` derived free/paid model ids from `AI_MODELS` at runtime and skipped the free-path assertion when no promo model existed; later, after the user explicitly asked to mock AI models instead of skipping, the tests were hardened again so `credits.test.ts` uses fixed `fake-free`/`fake-paid` ids and `ai-models.test.ts` synthesizes both cases from real basis entries. The lesson across both iterations is that tests should not depend on live promo catalog state; if billing behavior is what matters, the fixtures should be isolated and deterministic so a config cleanup does not silently rewrite the test contract.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Om8S5vUGI7Ei",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-07",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-07 in duet-agent, the user explicitly said to commit and push after tweaking the timeout and clarified there was “no need to ask permission to tweak timeout,” so the state-machine eval budget was increased from `ITERATIONS * 120_000` to `ITERATIONS * 180_000` in `evals/state-machine-agent-stays-in-state-scope.eval.ts`. The change was committed and pushed to `main` as `3e149f0` (`test(state-machine): make stays-in-state-scope prompt fair`), and the note from the commit made the purpose explicit: the eval should test whether a planning sub-agent over-reaches on its own initiative under a clean prompt, not punish obedience to a contradictory instruction buried in the prompt. The lesson is that when a slow model’s retries are hiding signal behind timeouts, the budget should be raised to measure behavior fairly rather than using the timeout as an accidental correctness filter.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_JCyoCOI0EE_y",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in chat-app, the user asked to add Fireworks and Together AI as fallback providers for DeepSeek, and the shared model config in `packages/shared/src/types/ai-models.ts` was updated so `deepseek/deepseek-v4-pro` now uses `providerLock: ['baseten', 'fireworks', 'togetherai']` with the comment updated to reflect the Baseten-first ordering. A test was initially added in `packages/shared/src/types/ai-models.test.ts` to assert the full provider order, but the user pushed back on that extra coverage and it was removed, leaving only the config change. The lesson is that provider fallback lists are durable policy and should be explicit in the shared model definitions, but tests should only remain when they add value the user actually wants to maintain.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_RKkVSsSqRv_-",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-06-06 in the duet-agent repo, the first DeepSeek state-machine sweep came back 28 pass / 5 fail across 33 tests, and the pattern was not random: `stays-in-state-scope` over-reached into `kanban.tsx` during planning-only iterations, `routing` both timed out on the multi-phase refactor case and under-routed a small task with zero `todo_write` calls, `slash-skill-expansion` returned `failed`, and `supersede-rpc-event` never emitted the `state_machine` event for a cancelled terminal. The comparison against the earlier GLM-4.7 baseline showed the same structural weakness in routing, but DeepSeek also had extra failures, so the next move was to treat the shared `stays-in-scope` defect as the best model-agnostic target while assuming the other DeepSeek reds might need tracing or might be model-specific. The lesson is that cross-model evals are most actionable when the failure set is split into shared defects versus model-specific behavior before any fix is attempted.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_NwX9MDgJ_Xl7",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Still on 2026-06-06 in chat-app `packages/agent-gateway`, profiling showed that the hot path was not tiny streaming deltas but the real receive path (`JSON.parse` → redaction → stringify) on realistic event mixes, especially large canonical text/tool-output payloads and `redactUnknown` object rebuilding. That led to the redaction optimization in `packages/shared/src/constants/redaction.ts` and `packages/agent-gateway/src/redaction.ts`: add an anchor prefilter to skip full regex scans when no secret anchor is present, and make recursive redaction allocation-free on clean trees by preserving referential equality for unchanged arrays and objects; tests were added to assert unchanged-event identity and subtree sharing. Benchmarks in a Docker 1-vCPU container then showed the change was real—throughput improved from 1.32 µs/delta to 0.27 µs/delta, receive-path redaction dropped from 214 ms to 49 ms, and paced 16×800 tok/s CPU fell from 6.35% to 2.52% of one core—so the durable lesson is that targeted structural optimizations can remove a genuine cost without requiring a runtime architecture rewrite.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_9teHoHWV38DU",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Later on 2026-06-06 in chat-app `packages/agent-gateway`, the next perf question shifted from redaction CPU to Convex write cost after it became clear that stringify of the whole `currentParts` array dominated flush work. The design exploration first considered larger rewrites like append-only Convex writes, reusing raw lines for clean deltas, and narrower parsing, but the actual implementation went one level deeper: `packages/backend/convex/domains/messages/mutations.ts` gained `appendAgentMessageStream`, `packages/agent-gateway/src/convex-client.ts` got a wrapper, and `packages/agent-gateway/src/session-controller.ts` was reworked to send append deltas on the hot text/reasoning path with `streamSentLen`/`streamSentTailLen` bookkeeping and fallback to full `updateAgentMessageStream` when the server is out of sync or a part closes. Integration coverage in `session-controller.integration.test.ts` was added with a replay helper for `updateAgentMessageStream`/`appendAgentMessageStream`, and the work was committed as `ecbb3e739` and later amended to `7c3565df1` after removing a speculative `status` parameter that did not belong on the append path. The lesson is that stream-write optimizations should preserve the server’s actual state machine: append only the finalized bytes, keep the volatile tail bounded, and let terminal state changes continue through the existing mutations instead of inventing new semantics.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_NOHD-1GNsWps",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-06 in duet-agent, the deep eval work eventually converged on a single real defect after several reported failures were rechecked as flakes: the planning sub-agent was over-reaching because its own prompt contained a direct imperative meant for a later state, and it could mutate files through `bash` heredocs, redirects, or `sed -i`. The fix path was deliberately model-agnostic and minimal—add one paragraph in `src/turn-runner/prompts.ts:createStateAgentMachineContext` to forbid file-mutating `bash` and to clarify that state-local prompts do not override the current planning/review boundary—while leaving the cwd runtime path in `src/turn-runner/tools.ts` and `state-machine-controller.ts` untouched after verifying `resolveStateCwd` already resolves against `runner config.cwd` / `--workDir`. The lesson was that when only one shared defect remains and the rest are flakes, the safest fix is to harden the instruction boundary rather than chase the eval outputs themselves.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_OGEGBR6DrTlH",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-06 in duet-agent, Sonnet later gave the cleanest post-fix confirmation: `verify-sonnet` passed 33/33 evals, including `state-machine-agent-stays-in-state-scope`, `state-machine-cwd-override`, `state-machine-executed-state-not-no-op`, `state-machine-poll-misconfigured-gate`, `state-machine-real-session-carry-forward`, and `state-machine-routing`, which established that the prompt fix did not regress the previously healthy model. GLM then improved but still showed residual over-reach on `stays-in-scope`, and DeepSeek eventually settled at 32/33 with the same remaining miss, so the cross-model conclusion became that the prompt-only lever was exhausted and any stronger guarantee would require code-level tool gating rather than more wording. The durable lesson is that a fix should be judged against the strongest clean baseline first, then against weaker models, because “good enough” prompt changes can mask instruction-following ceilings rather than solve them.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_UCx3cKZikZ1V",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-06 in chat-app `packages/agent-gateway`, the user pushed back on the earlier idea that extra app-level routing could be solved by moving runners into separate processes, and the response clarified that each runner is already a separate child process; the true hotspot is the gateway’s single Node event loop doing parse/redact/dispatch per streamed event. That led to a staged scaling menu: narrow redaction first, then `worker_threads` with per-session pinning to preserve ordering, and only as a heavier fallback a multi-process gateway/cluster with sticky routing and a single-leader scheduler. The lesson is that concurrency architecture should follow the actual shared bottleneck; when the expensive work is centralized in the gateway, adding more runner processes does not remove that choke point.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_-vuhXaJlr6SB",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-06 in chat-app `packages/agent-gateway`, a profiling pass showed that the receive path’s cost split had shifted after redaction optimization: parse and stringify became the remaining major share, while redaction was reduced to a smaller but still real cost. That changed the strategic recommendation from “optimize redaction further” to “measure the full gateway under real load,” including Convex writes and I/O, ideally in a constrained environment such as a fresh E2B sandbox or equivalent. The lesson is that microbenchmarks can identify a valid hot spot, but the next decision should be driven by end-to-end profiling once the obvious bottleneck is reduced.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_WTxafQwvKPM3",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-06 in chat-app `packages/agent-gateway`, the user asked whether a super-optimized JSON parser/serializer would beat Node’s native ones, and the answer was effectively no for the current workload: `simdjson` would likely lose on tiny high-frequency deltas because JS↔native boundary overhead dominates, `fast-json-stringify` would still fall back to native `JSON.stringify` on arbitrary `Record<string, any>` tool payloads, and a binary wire format like MessagePack/CBOR/protobuf was rejected as too much blast radius because the runner already speaks NDJSON and third-party agents emit JSON lines. The recommendation instead favored structural wins like keeping raw lines when no redaction occurs, serializing append-only deltas instead of whole messages, and raising the flush threshold. The durable lesson is that when payloads are heterogeneous and already on a text wire format, the biggest wins usually come from reducing copies and resends rather than swapping in exotic serializers.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_bCoq6rsHl0Dg",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-06 in duet-agent, the user later objected that the original `stays-in-state-scope` eval was unfair because it inverted the contract: “even when your own prompt tells you to” was testing obedience to the sub-agent’s own prompt instead of genuine over-reach. After reading `evals/state-machine-agent-stays-in-state-scope.eval.ts`, the assistant agreed the PLAN_PROMPT was too adversarial and proposed to revert the third paragraph in `createStateAgentMachineContext`, rewrite the eval prompt into a cleaner planning task with a softer handoff cue, and re-verify on Sonnet, DeepSeek, and GLM. The lesson is that when an eval is evaluating instruction conflicts, the prompt itself must be part of the fairness review; otherwise the test measures prompt contradiction tolerance more than the behavior it claims to isolate.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_GQJfM8KanEMC",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-06 in duet-agent, the user picked a specific correction scope for that fairness issue: rewrite the `PLAN_PROMPT` to a “clean task” that still keeps a soft “hand off to implementing” cue, rather than deleting or fully cleaning the eval. The implementation then removed the state-boundary paragraph from `src/turn-runner/prompts.ts`, rewrote `evals/state-machine-agent-stays-in-state-scope.eval.ts` to match the cleaner framing, and confirmed `bun run check-types` plus `oxlint` stayed clean while the prompt file itself returned to the committed `v0.1.185` baseline. The durable lesson is that eval design and shipped runtime behavior should be separated carefully: if the evaluation prompt is the problem, fix the eval to measure the intended failure mode rather than carrying a contradictory instruction into the test.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_twPgkhcdxiRA",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-06-06 in duet-agent, the first post-fix DeepSeek verification looked noisy enough that it was treated as infra-poisoned rather than authoritative: several failures were traced to baseten 503s or lock-in behavior, while the stays-in-scope fix itself appeared to work because planning iterations stopped doing file writes and only used non-mutating tool calls. Rather than spending more time on a flaky provider, the orchestrator moved verification to Sonnet first, using that cleaner baseline to confirm whether the prompt fix truly worked before returning to DeepSeek and GLM. The durable lesson is that provider-specific infrastructure noise should be isolated from product behavior; otherwise the team risks relitigating the wrong failure mode.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_gY4kwnNIhGPE",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-07",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-07 in chat-app `packages/agent-gateway`, the user asked if the append-based streaming write path should matter once it became clear that most perf cost might actually come from tool-call writes, and they added a preference that if appending is kept it should be at whole-part granularity: “you can append, but I rather you append a whole complete part.” The response treated that as a design fork—part-level upsert, append-once when a part is final, or keep the current byte-tail append—but no implementation was made because the user later reversed the decision and asked to remove the append logic entirely. The lesson is that write-protocol changes in a shared streaming system should be designed around the user’s preferred data boundary before adding more mutation modes, because otherwise the complexity of the protocol can outgrow the actual perf win.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_3ITMsijX3AT4",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-07",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-07 in chat-app, that same fs-error surfacing work hit the repository’s pre-commit hook because of an unrelated mobile type error on the `'/unread'` route, so the change was pushed with `--no-verify` after the user chose to bypass the stale blocker. The branch advanced from `edff01f5b` to `f707dfa91`, and the note explicitly separated the shipped fix from the pre-existing mobile failure in `apps/mobile/src/components/channels/list.tsx`. The lesson is that pre-existing type errors should not block an otherwise scoped fix when the user approves bypassing the hook, but they should be recorded as unrelated so they can be addressed separately instead of conflated with the new change.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_hPXRy8L9PwDk",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-07",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-07 in chat-app `packages/agent-gateway`, a CI flake was traced to the fake RPC runner in `packages/agent-gateway/src/test-fixtures/fake-rpc-runner.mjs`, where the final stdout write could be truncated if the process exited too quickly under CI load. The fix waited for the last stdout flush before `process.exit()` while preserving the crash-simulation path by flushing its final line too, and that stabilized the integration test that batches Convex stream writes instead of writing on every delta. The full `@repo/agent-gateway` suite, lint, repeated integration runs, and staging CI run `27098133734` then passed on commit `8c499d9e9`. The lesson is that CI flakes in stream-heavy tests often come from process teardown timing, so making the fixture flush explicitly can be enough to turn an intermittent transport failure into a stable regression test.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_jprBczGEdAN_",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781181255789,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-06 in chat-app `packages/agent-gateway`, a CPU-spike concern led to tracing the single Node event loop through `src/runner-manager.ts`, `src/redaction.ts`, and `src/session-controller.ts`, where recursive `redactRunnerEvent` was touching every event field in multiple places. Rather than jumping straight to a cluster or worker rewrite, the investigation considered a narrower and safer progression: first make redaction faster, then consider `worker_threads` to offload parse+redact while preserving per-session ordering, and only then a heavier multi-process gateway with sticky routing and scheduler coordination. The key lesson was that runner processes were already separate child processes, so the real hotspot was the gateway’s per-event CPU work, and the right ordering is to profile and narrow the bottleneck before changing architecture.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_SIF6cHOQL4YR",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in chat-app, the DeepSeek provider-lock change initially failed the repo’s pre-commit hook because of the same pre-existing mobile `check-types` issue on `'/unread'`, and the user chose to repair that locally rather than bypassing the hook. The fix was to regenerate Expo Router typed routes by briefly starting `apps/mobile`, which refreshed `.expo/types/router.d.ts` so `bun run check-types` passed, and because the generated artifact is git-ignored there was nothing extra to commit. The lesson is that when generated route types drift locally, the least risky repair is to regenerate the artifact in place instead of weakening the repository’s checks.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_tlyFX13DJZBu",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-06-08 in chat-app, a separate relay self-healing review required merging staging into PR #1672 (`david/relay-self-healing`) and resolving conflicts in `packages/agent-gateway/src/session-controller.ts`, `packages/backend/convex/domains/sandboxes/mutations.ts`, and `packages/backend/convex/domains/sandboxes/queries.ts`. During review, the duplicate local `TERMINAL_SESSION_STATES` definition was removed in favor of the shared schema constant from `../../schema`, and two separate `if` throw guards were collapsed into one combined check, because the merged branch had started duplicating source-of-truth logic. The underlying flow now relies on a backend-owned `requeueWakeAfterStartFailure` path for scheduled `wake` handshake timeouts, while the gateway skips its own `completeSession` when the backend requeues or has already finalized with a `wake_start_retry_exhausted:` marker. The durable lesson is that self-healing paths belong to one owner at a time, and if the backend has taken responsibility for retries, the gateway should stop trying to finalize the same row independently.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Rlt7w9s7v7eS",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781181255789,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-07",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-06-07 in chat-app `packages/agent-gateway`, the user reversed the earlier streaming-write discussion and said to “just delete the append logic completely, revert back to the way it was before,” making the reaction-logic changes sufficient. Because `7c3565df1` had already landed on `origin/staging`, the agent used a forward `git revert` instead of rewriting shared history and reverted the append path as `edff01f5b` while keeping the redaction perf commit `53eb1f0c4`. The durable lesson is that once a change is shared on staging, revert-forward is the safest corrective action unless the branch is private; that keeps collaboration history intact while backing out the wrong design cleanly.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_4iwbh9tmdA6H",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in chat-app, the user asked whether a prod sandbox session already failed with `recovery_max_retries_exceeded: missed_wake` after three recovery attempts could be revived by the PR, and the answer was no: that session is terminal and must be recreated fresh. The investigation into `packages/backend/convex/domains/sandboxes/internal.ts` showed `missed_wake` is one of the `sm-recovery` buckets, `MAX_RECOVERY_ATTEMPTS` is 3, and once the cap is exceeded the row is terminal-failed with `errorMessage: recovery_max_retries_exceeded: missed_wake` and `lastRecoveryReason: missed_wake`; the PR’s wake retry logic only handles runner/gateway handshakes after a wake reaches the runner, and it explicitly refuses to requeue finalized rows. The user-facing lesson is that some sessions are genuinely dead rather than merely delayed, so the right response is to create a fresh session instead of waiting for a fix to resurrect the old one.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_5Cxov2l-LuqR",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Later on 2026-06-08 in chat-app, the same sandbox recovery area was inspected more deeply and the root cause of the death spiral became clearer: `sm-recovery` runs every five minutes with `MISSED_WAKE_GRACE_MS = 5 * 60 * 1000` and `MAX_RECOVERY_ATTEMPTS = 3`, `recordRecoveryAttempt` increments the counter before the system knows whether the wake was merely skipped on purpose, and the counter only clears when the session returns to `running`. That means silent no-op wake paths—including lookup/preflight failures such as “org cannot pay”—can burn the entire retry budget in roughly 15–20 minutes, even while the sandbox process may still be alive, because `wakeSandboxSession` only re-pokes the gateway and does not re-arm `wakeAt`. The proposed fix was to re-arm `wakeAt` on every re-poke and stop counting deliberate skips as failures, because a retry budget should cap real failed wake attempts, not deliberate billing pauses or other intentional no-ops.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_a9gBoN3lF8_I",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-08 in duet-agent, the user asked whether newly synced skills appear when opening `/` autocomplete in the TUI after a background sync run, and the answer was traced through the actual slash-picker path instead of guessed. `src/cli/run.ts` and `src/cli/rpc.ts` already supported `--no-skill-sync`, the TUI controller in `src/tui/controllers.ts` calls `deps.session.reloadSkills()` when `/` is opened and rebuilds the autocomplete catalog, and that means newly synced skills show up after the atomic swap lands even if the initial session boot started earlier. The lesson is that the TUI autocomplete surface is live and reloads skills on demand, but only after the sync completes; opening `/` before the background sync finishes still shows the old catalog.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Xpvlr-p3OkXB",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-08",
+    "timeOfDay": "10:47",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-06-08 in duet-agent, the user asked whether default skill sync should also be fire-and-forget in TUI mode to speed up boot, then explicitly said to “skip if this is overcomplicated,” so the implementation stayed simple. `src/cli/run.ts` was updated so default-skill sync is fire-and-forget only in TUI mode while one-shot or piped runs still await it, and the reasoning was that interactive startup benefits from not blocking on a slow/modded sync, while non-TUI commands would exit before a detached sync could finish anyway. The durable lesson is to keep launch-path behavior aligned with user experience: optimize TUI boot latency when the process stays alive, but preserve synchronous completion when a command is about to exit.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_nHSq0Ij6OfJQ",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-07",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-07 in chat-app, a user-facing file-tab toast showed only opaque `exit status 1`, which triggered an end-to-end error-surfacing fix across the sandbox stack. The investigation traced the path through the E2B client, Convex sandbox actions, and the web `sprites-provider`, and the chosen solution was to preserve stderr by using `runCommandNoThrow`, wrap fs mutations in `withSurfacedFsError()` so Convex rethrows a `ConvexError`, and have the client read `ConvexError.data` so the real underlying message reaches the UI. The lesson is that when a UI toast loses the root cause, the fix should travel end-to-end through the error boundary rather than trying to synthesize a better message at the very end.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_XlVmEwnibGlV",
+    "createdAt": 1781174871562,
+    "lastUsedAt": 1781174871562,
+    "ageDays": 7.402290775462963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-06",
+    "timeOfDay": "10:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-06 in the duet-agent repo, a user asked to run DeepSeek V4 Pro against the state-machine benchmarks after earlier GLM-4.7 tuning, so the eval setup was checked first: `evals/state-machine-routing.eval.ts` still defaulted to `sonnet-4.6`, `DUET_API_KEY` was present, there were 24 `evals/state-machine-*.eval.ts` files, and only `state-machine-agent-stays-in-state-scope.eval.ts` was clearly slow. That led to a dedicated Docker-backed run of all 24 evals against `duet-gateway:deepseek/deepseek-v4-pro`, teeing to `eval-results/deepseek-state-machine.log` so the expensive execution could be analyzed later rather than rerun. The durable lesson is that these cross-model eval sweeps should be staged with a log-first workflow when one subset is slow, because the benchmark signal is more valuable than repeating the same long run.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_GEUnqaZ3x6Mx",
+    "createdAt": 1781033748862,
+    "lastUsedAt": 1781033748862,
+    "ageDays": 9.035655358796296,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "19:35",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"4aacc8074b59dbcd\" range=\"msg_user_1781033691492_a9fe3b00:msg_assistant_gen_01KTPY2W4P8W7TACSG37XWCETW\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (2026-06-09 19:34) User wants Convex to store `frontier:anthropic` as the canonical role id so model upgrades stay editable, and says the kanban storage is currently wrong because it pins a weights revision instead of a role.\n🟡 (2026-06-09 19:34) Assistant proposed a two-phase fix: migrate kanban rows to role-id storage with backfill; translate role -> `duet:<slug>` at backend push time; make gateway pass `duet:`-prefixed strings through untouched; then remove the gateway catalogue fallback after fleet refresh. The assistant also flagged a warm-sandbox transition hazard where today's gateway could silently default to Opus if it sees an unknown `duet:` slug.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_n0CPuu_7QB0h",
+    "createdAt": 1781033598653,
+    "lastUsedAt": 1781033598653,
+    "ageDays": 9.03739388888889,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "19:33",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"1705ed34acbfae3d\" range=\"msg_user_1781033561599_6ba660f3:msg_assistant_gen_01KTPXYX0VEQYNPQMFVFAV9DMW\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (2026-06-09 19:32) In chat-app, the gateway-vs-backend model-normalization question was resolved toward moving the check out of the sandbox gateway: the assistant argued the gateway’s compiled-in `AI_MODELS` copy is stale on warm sandboxes, so catalogue lookup should live in the Convex backend that deploys atomically with the catalogue.\n-> Chosen shape: backend/session creation should normalize via `normalizeRunnerModelId` before persisting/pushing and reject unknown ids with `invalidModelMessage`; gateway should pass `duet:<slug>` through opaquely to duet-agent, which already owns real `resolveModelName` resolution and loud failure on garbage.\n-> Transitional plan: keep a gateway compat fallback only for already-stored user-facing ids or backfill `sandboxSessions.runnerModelId` to the normalized form, mirroring the repo’s earlier helper-plus-backfill staging for token-field cleanup.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_7gJu9c39L4Bq",
+    "createdAt": 1781033519178,
+    "lastUsedAt": 1781033519178,
+    "ageDays": 9.038313738425925,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "19:31",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"bea4cea95315b723\" range=\"msg_user_1781033192790_3d14a167:msg_assistant_gen_01KTPXWW4KH58REF3MDQ4AXSKP\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (19:26) User reported that a message sent via Frontier showed token usage as Opus in the UI, despite the selected model being Frontier; screenshot shows a token-usage popup listing total 55.6k tokens, per-model rows for `openai/gpt-5.4-mini` and `anthropic/claude-opus-4.8`, and the bottom bar says `Model: AI Frontier`.\n🟡 (19:28) Investigation in `chat-app`/`duet-agent` concluded the Opus label came from model-resolution behavior, not the sandbox runner version: `packages/backend/registry/sandbox/setup.ts` still uses a `MIN_DUET_VERSION` floor, but the relevant failure here is a warm gateway bundle whose compiled-in model catalog cannot map the Frontier Anthropic slug and therefore lets the runner fall back to `opus-4.8`.\n✅ (19:28-19:31) Updated `packages/backend/registry/sandbox/setup.ts` comments while confirming the fix path: distinguish stale-runner failures from stale-gateway fallback, keep the `0.1.189` floor, and note that a fresh gateway bundle is picked up on the next cold setup / ETag refresh rather than by this version floor.\n🟡 (19:29-19:30) Traced the compose-bar path in `chat-app`: model selection goes through `apps/web/components/chat/compose-bar/primitives/compose-bar-model-selector.tsx` into `use-composer-options.ts`, then `updateSessionModel`/`setSessionModel` in `packages/backend/convex/domains/sandboxes/actions.ts`, which forwards the selected model to `GatewayClient.setModel`; if the gateway cannot resolve it, the runner falls back to its default.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_D4vPWlZgAD4C",
+    "createdAt": 1781032793231,
+    "lastUsedAt": 1781032793231,
+    "ageDays": 9.046715902777779,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "19:19",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"1a8fd4a108fe4661\" range=\"msg_user_1781032688027_1a60e894:msg_assistant_gen_01KTPX72ZDFYF3W6SEPBJYDBBB\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (2026-06-09 19:18) User re-approved shipping with “yes push” after the model-intelligence normalization work.\n✅ (2026-06-09 19:19) Pushed the chat-app model catalog change to `staging` as `d573c2fdb`; the commit normalized intelligence around Fable 5, disabled Gemini 3.1 Flash, and refreshed the related playground baselines.\n🟡 (2026-06-09 19:19) First push attempt failed in pre-commit because mobile type-checking broke after the host `node_modules` layout got clobbered by hoisted `markdown-to-jsx`; a `bun install` restored the package layout and the rerun passed typecheck, lint, and format before the successful push.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_6eBiBvsD9Zyo",
+    "createdAt": 1781032683422,
+    "lastUsedAt": 1781032683422,
+    "ageDays": 9.047986840277778,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "19:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"b37b41f3c0f4b4d8\" range=\"msg_user_1781032406234_b1d7276a:msg_assistant_gen_01KTPX3BH9D2NNC8EJ6YFTFQCW\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (19:13) User asked to normalize model intelligence for fable by dropping every other model's intelligence by 1.\n🟡 (19:15) User then requested `gemini-3.1` be set to intelligence 1, then clarified they actually want Gemini disabled too because they don't want too many models.\n✅ (19:16-19:17) Updated `packages/shared/src/types/ai-models.ts` in chat-app: reduced several model intelligence scores, set Google Gemini 3.1 Flash to `enabled: false`, and verified with 324 passing shared tests; refreshed visual baselines for the model selector / related screens so screenshots now reflect Gemini removed and the recalibrated dot ratings.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_e4206YvnLVKm",
+    "createdAt": 1781032366134,
+    "lastUsedAt": 1781032366134,
+    "ageDays": 9.051659155092592,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "19:12",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"0a8b5a07e5ada3cf\" range=\"msg_user_1781032350202_f8a2ddc2:msg_assistant_gen_01KTPWT4BG3572ZG0H0A046HQS\" cwd=\"/Users/david/dev/chat-app\">\n* 🟡 (19:12) User asked “can you push” in chat-app.\n* ✅ (19:12) Assistant checked git status/log and determined the repo is already pushed: working tree clean, `staging` is synced with `origin/staging`, with recent commits `3328ac442` (add Claude Fable 5 as `frontier:anthropic`) and `e83522149` (refresh visual baselines for Fable 5).\n* 🟢 (19:12) Assistant offered to run the deploy flow only if the user meant promoting staging to main/prod.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_vpH1CyzUVOiI",
+    "createdAt": 1781032264442,
+    "lastUsedAt": 1781032264442,
+    "ageDays": 9.052836145833334,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "19:11",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"8394fa8273ec82b2\" range=\"msg_user_1781031843019_7bbfa895:msg_assistant_gen_01KTPWPPMMXAY24ZGHBDRKBFD3\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (19:04) Investigated whether `/playground` visual baselines needed updates after the user asked about ui-playground screenshots; checked the ui-playground skill and visual entries that use `AI_MODELS`.\n🟡 (19:04-19:08) Narrowed the concern to `apps/web/components/playground/compose-bar/model-selector/model-selector-playground.tsx` and confirmed `compose-bar-model-selector` is the relevant screenshot target; `kanban-stage-model-popover` and search/session fixtures did not need changes.\n✅ (19:10) Refreshed and verified the `compose-bar-model-selector` baselines for both desktop and mobile with `bun ui:approve --force`; committed and pushed the screenshot update to `staging` as `e83522149`.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_Fs2-KvrVpYkB",
+    "createdAt": 1781031783588,
+    "lastUsedAt": 1781031783588,
+    "ageDays": 9.058401585648149,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "19:03",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"cd7fcbed1525e46b\" range=\"msg_user_1781031749315_876fffdd:msg_assistant_gen_01KTPW8BAMVSMR3Y0ZGDDBZPV4\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (2026-06-09 19:02) In chat-app, the assistant pushed a staged model-catalog change to `staging`: commit `3328ac442` (`feat(models): add Claude Fable 5 as frontier:anthropic`).\n-> Pre-commit `check-types`, `lint`, and `format` all passed; `git pull --rebase origin staging` found the branch already up to date, so the push went through cleanly with no rebase.\n-> The change added Claude Fable 5 as a frontier Anthropic option, mapping the mobile picker to the Anthropic icon and deriving the web label from the gateway slug.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_h6UTMr0yOUlr",
+    "createdAt": 1781031602174,
+    "lastUsedAt": 1781031602174,
+    "ageDays": 9.060501284722223,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "19:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"20d2e5ffb3136e7c\" range=\"msg_user_1781031499615_c12c48a0:msg_assistant_gen_01KTPW2JH4M3CS31N5QAPZY4JT\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (2026-06-09 18:58) User answered the Fable 5 pricing question by choosing the numbers from the Vercel AI Gateway page instead of a custom quote; this supplied the missing Anthropic Fable 5 pricing for duet-agent. \n✅ (2026-06-09 18:58) Updated `packages/shared/src/types/ai-models.ts` to add `frontier:anthropic` with `gatewayModelId: 'anthropic/claude-fable-5'` and pricing set from the linked gateway page, and updated `apps/mobile/src/components/messages/composer/models/index.tsx` to map the new model id to the Anthropic icon.\n🟡 (2026-06-09 18:59) Verification passed for the touched packages: `packages/shared` tests (324/324), `packages/shared` typecheck, `apps/mobile` typecheck, and linting completed with one pre-existing warning in `packages/shared/src/channels/utils.ts` about a combining character class; no new errors were introduced.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_bcF4kd2AB96r",
+    "createdAt": 1781030560595,
+    "lastUsedAt": 1781030560595,
+    "ageDays": 9.072556597222222,
+    "sessionId": "session_rUjMi_pUNzhB",
+    "kind": "observation",
+    "observedDate": "2026-06-09",
+    "timeOfDay": "18:42",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "<observation-group id=\"aecb3803bea78db0\" range=\"msg_user_1781030466937_1912f4f8:msg_tool_toolu_015hehLTC785K12NsRxTjSKN\" cwd=\"/Users/david/dev/chat-app\">\n🟡 (2026-06-09 18:41) User asked to add Claude Fable 5 support in chat-app by updating `AI_MODELS` and making it the frontier Anthropics model, while keeping Opus as the recommended model.\n🟡 (2026-06-09 18:41) In duet-agent, Fable 5 is already represented as a synthetic `anthropic/claude-fable-5` gateway id cloned from Opus 4.8 until pi-ai ships it directly; the catalog entry in `../duet-agent/src/model-resolution/catalog.ts` currently has no pricing, so chat-app’s `frontier:anthropic` mapping needs a pricing decision before the shared model types can be extended cleanly.\n🟢 (2026-06-09 18:42) The assistant paused for user input on Fable 5 pricing, offering either “same as Opus 4.8” or user-provided rates.\n</observation-group>",
+    "tags": ["observational-memory"]
+  },
+  {
+    "id": "mem_XR8x4XhFBCqB",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781004780409,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in the duet-agent repo, the prompt-routing/carry-forward work turned into a lesson about how much guardrail prose actually helps. After the user asked to keep pushing until satisfied but not to release without asking, the assistant narrowed carry-forward guidance to a wake-message reminder and a concise tool-description sentence, then later ablated a third `prompts.ts` reinforcement because batch testing showed it added little or no reliability gain. The durable lesson, later codified into the `write-eval` skill, is that prompt fixes should be ablated down to the shortest prompt that still passes, because extra wording can easily become token cost with no measurable benefit.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_M3cVnbFpvdBg",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1780992862265,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, the duplicate token-field cleanup advanced from backfill to field removal, but the change had to be gated by repository invariants. The assistant first made the flat `messages.tokenUsage` fields optional and added a guarded `stripMessageFlatTokensRow` migration, then later had to fix a TypeScript issue in `packages/backend/convex/migrations.ts` where `backfillMessageUsage260605` saw the optional flat fields as possibly undefined. The durable lesson is that once a migration starts mutating schema optionality, every backfill path that still reads the old fields has to be updated in lockstep; the migration itself is the compatibility bridge, so type safety will correctly fail if that bridge still assumes the old shape.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_jCwXKv2CwVob",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781807807239,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, a performance concern around slow runner responses led to a much smaller, safer streaming-redaction design. The first suspicion was that redacting every delta in `packages/agent-gateway/src/session-controller.ts` was re-running expensive scans over the accumulated buffer on every `text_delta`/`reasoning_delta`, so the refactor moved to line-based redaction and Convex write batching around a single flush threshold, then later to a throttled stream redaction model keyed by `STREAM_FLUSH_MIN_CHARS`. The lesson is that streaming safety features have to be budgeted like performance features: if the gateway re-processes the whole buffer on every tiny chunk, it can stall the event loop under concurrent runners, so the right unit of work is the smallest chunk that preserves the leak boundary and write cadence.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_5KtaJpekzmIt",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1780992862265,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in chat-app, the cost-attribution flow had to be untangled because the user asked how state-machine and relay executions are billed and whether front-end message cost could reflect the actual sub-agent model. The investigation split billing into two paths: the AI-gateway proxy and backend ledger already reconcile by `generationId` and authoritative per-generation cost, while the UI and monthly usage path still attributed a message to `session.runnerModelId`, which meant relay turns could be mis-labeled even when billing itself was correct. The resulting plan was to bring per-model cost data through duet-agent and then into chat-app rather than guessing in the UI, because the durable lesson is that presentation can only be as model-accurate as the payload it receives.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_SdMmgukY-DPX",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1780992862265,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, the agent-gateway review found that per-delta streaming redaction was too expensive and semantically too eager, so the final shape was to delay redaction until the canonical final `text`/`reasoning` step. The implementation was later tightened so `text_delta` and `reasoning_delta` chunks stay raw, redaction only happens once the end-of-turn canonical chunk arrives, and the integration test now asserts the final stored message is redacted rather than pretending mid-stream masking is a contract. The lesson is that when a system already has a canonical end-of-turn artifact, eager masking of every partial chunk may add cost without adding real safety; the right invariant is to protect the persisted record, not to overpromise mid-stream behavior.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_5xd2jdBDrqeP",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1780992862265,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in chat-app, the model-icon work had to reconcile a placeholder Z.ai asset with the user’s preferred visual shape. The user first asked for rounded corners on the downloaded logo, then clarified that the mobile icon should match web as the same `Z` on a transparent background rather than the white-Z-on-dark-tile version, so the asset was regenerated as a monochrome black `Z` glyph and pushed with the rest of the model-icon updates. The lesson is that icon work in this codebase is not just image conversion; the visual contract must match across web and mobile, and user clarification about silhouette/background can invalidate an otherwise “official-looking” asset.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_CoCnMn2Tgskg",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781033519120,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, the full per-turn usage payload finally got propagated through the gateway/backend/frontend stack after the duet-agent release and the user’s explicit `0.1.181` minimum-version bump. The gateway began forwarding raw `usage` plus `usageByModel`, the backend persisted the full raw payload while using a shared billable-cost helper to compute a free-aware `costUsd`, the web UI stopped using `isModelFree` and now labels Free only when stored billable cost is zero, and the mobile/web token-count displays switched to the shared `messageTokenCounts` helper. The higher-level lesson is that once the runner is versioned and published, the app can stop guessing from flattened fields and instead treat the new payload shape as the canonical source, while still keeping compatibility bridges and version-floor enforcement for older sandboxes.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_6PNjCU7BHhXF",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781033598583,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, the assistant discovered that a stale sandbox bundle can make a migration look wrong even when the backend and database are correct. A user record still showed flat token counts after the per-model payload work, which led to tracing the issue to an old agent-gateway bundle in the sandbox rather than the new deployed schema; the response was to raise the `@duetso/agent` floor to `0.1.181` and note that fresh sandboxes need the new bundle before the usage shape will match. The lesson is that version floors are not just packaging metadata in this repo — they are part of data correctness, because a cold sandbox must align runner version and schema migration before the observable payload can be trusted.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_jzWhG3oBqVFn",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781034166612,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in chat-app, a second liveness bug emerged after the heartbeat plan: a resumed state-machine session could run one more state and then disappear from recovery because recovery interrupted it into `state:'interrupted'` with `endedAt`, but the resumed reminder turn never re-marked it `running`. The analysis in `packages/agent-gateway/src/session-controller.ts` showed that `getRecoverableSessions` only scans `sleeping`, `running`, and `pending`, so interrupted-but-nonterminal state machines became invisible even when `stateMachineSession.currentState` was still active. The lesson is that session recovery must treat terminal status and state-machine progress as two separate axes; a row can look terminal to the session layer while still being alive at the orchestration layer.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_PaVrEGB0GEf6",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781517775861,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in chat-app, a more fundamental session-liveness bug surfaced while the assistant was investigating why long-running sub-agent turns were being misclassified as stuck. The investigation across `packages/backend/convex/domains/sandboxes/internal.ts`, `packages/backend/convex/domains/messages/mutations.ts`, and `packages/agent-gateway/src/session-controller.ts` found that the gateway dropped every event with an `origin` field before any Convex write, so sub-agent activity never refreshed `sandboxSessions.updatedAt`; later, the user corrected an earlier guess and made it clear this was a chat-app problem, not a duet-agent one. The fix became chat-app-only: add `lastHeartbeatAt` to `sandboxSessions`, record heartbeats on any agent-received event before the origin gate, and make stale-running recovery use `max(updatedAt,lastHeartbeatAt,startedAt)` so healthy sub-agent turns no longer get interrupted. The durable lesson is that liveness needs its own signal when the durable row is intentionally filtered by event origin; otherwise “activity” can disappear precisely in the cases that run longest.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_wtQkTcAOEpIf",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781208345188,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the user steered the evaluation flow to compare DeepSeek V4 Pro and GLM 4.7 against the Sonnet 4.6 baseline, with the eval harness defaulting to `sonnet-4.6` and the assistant creating an `eval-results/` directory for three separate runs. The DeepSeek run then surfaced a durable regression set: 133/150 passes, with failures around context overflow recovery, memory reflection preserving alternatives and user steers, global-prune convention retention, prompt cache, implicit recall triggers, `/relay` routing, multimodal RPC, source-of-truth-first file inspection, state-machine scope, and structured output. The lesson is not just that DeepSeek underperformed the baseline, but that several failures clustered around the same memory/reasoning themes that later became the main prompt-tuning targets, so the evals were revealing where the agent’s reflection and routing policies were still too brittle.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_muD_YJescaVd",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781003216537,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in the chat-app repo, the token-usage schema was deliberately widened to carry the full usage payload that duet-agent now emits, after the user asked for “all fields duet-agent sends back.” The investigation confirmed the runner’s `Usage` shape contains aggregate token counts plus nested `cost.{input,output,cacheRead,cacheWrite,total}`, and that the earlier backend schema had only persisted a flat summary while gateway code had been truncating per-model entries down to `{ model, costUsd }`; the fix was to persist full raw `usage` and `usageByModel` while preserving the existing flat summary and billable `costUsd` for compatibility. The lesson is that billing and attribution should be split: preserve the stable, free-aware billable amount for current readers, but keep the raw payload around so future consumers do not have to reconstruct lost detail from summary fields.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ytgMJODqtjQV",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1780992862265,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, the `/review` pass over the message billable-cost work surfaced a naming collision between the backend’s temporary `ModelUsageEntry` type and the published `@duetso/agent` type of the same name. The fix renamed the backend shape to `ModelCostEntry` and kept `billableCostUsd` as the single policy source, because the broader review found the WHY-focused comments, stored cost values, and monthly aggregate tests were all already aligned. The lesson is that when two packages share a boundary type, name collisions are not harmless style issues; they make it harder to tell which layer owns the semantics, so the local type should be renamed to reflect the narrower backend meaning.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_3WO8SR9lj-kF",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1780992862265,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in the duet-agent repo, the evaluation comparison work found that some states were trying to trust their own self-reported completion instead of verifying reality. One run ended with an orchestrator that kept re-selecting `run-sonnet` after the state had already executed, so the compare step had to be re-run against raw logs and only then written out to `eval-results/comparison.md`. The durable lesson is that state-machine eval orchestration should not believe a claimed terminal step without checking the artifact trail; when the machine is evaluating itself, verification has to be external and explicit.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ybNUsQLyw4Xe",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1780992862265,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in the duet-agent repo, an oversized script-state output problem surfaced when a long eval prompt loop caused the orchestrator to wedge near the end of `session_V_5GmfrlRyjF`. The investigation concluded that streaming full `bun test` stdout through the state machine made the next decision turn too large, so the fix was to cap script/poll output in `src/turn-runner/state-machine-controller.ts`, spill overflow to a temp file, and add Docker-gated regression coverage in `test/state-machine-output-cap.test.ts`. The lesson is that eval infrastructure needs bounded feedback loops: if the runner hands the orchestrator too much text, the control plane itself becomes the bottleneck, so bulk logs should live on disk and only summaries should re-enter the decision loop.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_WfiHfWEdX8V5",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1780999550250,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in the duet-agent repo, GLM-4.7 exposed a structural `firstState` bug that could not be papered over with prose. The failure showed that `createDefinitionSchema.firstState` had been nested incorrectly under `definition`, which made the runner fall back to `definition.states[0]`; the user then pushed for the simpler upstream fix and explicitly rejected mixed schema/usage prose, saying “we do NOT do this” and “the right solution is alawys upstream.” The final change made `firstState` required at the top level and removed the runner fallback, and the lesson is that some state-machine problems are schema problems, not prompt problems: if validation should fail, the schema should enforce it rather than the runtime guessing around it.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_sC3aFdIqJyxw",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781033573740,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in the duet-agent repo, the model-resolution catalog grew new shorthands for `deepseek-v4-pro` and `glm-4.7`, but the first pass included redundant and ungrounded aliases that review later stripped back. The user wanted the real gateway/provider spellings to stay canonical, so the cleanup removed the duplicate `deepseek-v4-pro` alias and the ungrounded `deepseek-v4pro`, leaving only grounded gateway/OpenRouter identifiers and a clamp for DeepSeek’s output limit when `max_tokens (384000)` exceeded the backend ceiling of `262144`. The durable lesson is that model catalogs need both semantic correctness and operational guardrails: alias convenience should not outgrow the provider IDs that actually work, and backend limits like DeepSeek’s max output tokens should be enforced in resolution before requests are sent.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_6owCjFjZ3vTh",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781033598583,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, the user explicitly resolved an earlier ambiguity by confirming that `costUsd` should stay stored while only the three flat token fields get migrated off. That turned the cleanup into a two-phase plan: add a shared `messageTokenCounts` helper that prefers nested `usage` and falls back to the flat fields, route backend and frontend readers through it, and backfill old rows so the flat fields can be removed later without breaking current readers. The durable lesson is that schema migrations here are staged, not all-at-once; when a field still has live readers or compatibility value, the repo prefers a helper-plus-backfill bridge before any deletion PR.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_AyFjq3mJEyE1",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1780992862265,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, the Slack-era profile cleanup established a migration pattern that later got reused for other dead schema fields. The user explicitly said “no deprecate the slack era stuff,” meaning they wanted the old user-profile fields actually stripped, so the repo added `stripSlackEraUserProfileFields260605`, regenerated the sandbox skill output from `users.md`, removed dead fixture fields, and later corrected a tooling mistake when the assistant briefly used Prettier instead of the repo’s formatter. The durable lesson is that these schema cleanups are not isolated: once the project has a strip-migration pattern, it becomes the standard way to deprecate legacy fields, and formatting/tooling must follow the repo’s established conventions (`oxfmt`, not Prettier).",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_9sIR5G0QeYWR",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781002760143,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, the user pushed the cleanup further by asking what about pinned app IDs and later clarifying that some channel fields were not actually user-settable. That led to a careful audit of which fields were dead versus live: `channels.pinnedAppIds` and `channels.aiAlwaysRespond` were stripped as deprecated, while `channelUsers.aiAlwaysRespond` and `channels.aiRespondInThread` were kept because code still reads them. The lesson is that schema removal here is evidence-driven, not aesthetic; a field must be traced through write paths and read paths before it is declared dead, otherwise a seemingly redundant cleanup can delete active behavior.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_vVVaOPSMQ81n",
+    "createdAt": 1780992862265,
+    "lastUsedAt": 1781215222438,
+    "ageDays": 9.508879861111112,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-05",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-05 in chat-app, the agent was forced to respect a new policy boundary after the user said the feature was already deployed, promoted to prod, and migrated in both environments, and that the assistant should stop pushing or committing without explicit approval. The assistant accepted that boundary and shifted to proposing only cleanup sequencing instead of proceeding autonomously. The durable lesson is that once a user calls the work “done” and asks for a hard stop on pushes, the default behavior changes from shipping to advisory cleanup; autonomy must yield to explicit approval in release-sensitive threads.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_TndFwm9nlMzQ",
+    "createdAt": 1780992862264,
+    "lastUsedAt": 1780992862264,
+    "ageDays": 9.508879872685185,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the chat-app repo, the thread began with a request to add DeepSeek V4 from Vercel AI Gateway, then immediately tightened the product rules: DeepSeek should become the bare `balanced` default, provider-pinned models like `balanced:xai` should fall back to the bare tier when their provider entry disappears, and DeepSeek should be marked as the new free model replacing the prior Grok/xAI promo. The work also picked up a UI asset constraint from `~/Downloads` and a test cleanup request to delete the obsolete `frontier` no-bare-entry fallback case while keeping the fallback behavior itself. The durable lesson is that the model catalog here is treated as policy, not just data: user-facing tier defaults, provider pinning, free-model promotion, and test coverage all move together, and the exact fallback semantics must stay aligned with the catalog’s eventual shape.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_IgFiqCKIdLH8",
+    "createdAt": 1780992862264,
+    "lastUsedAt": 1780992862264,
+    "ageDays": 9.508879872685185,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in chat-app, the first DeepSeek push had to be paused for review and tree-scope questions because the diff lived alongside unrelated pre-existing backend/codegen drift. After the assistant ran shared/web/mobile checks and found the DeepSeek model-catalogue changes clean aside from a stray blank line, the user chose to include the unrelated changes too, so the work was split into separate commits before rebasing onto `staging` and pushing. The durable lesson is that this repo can carry unrelated local drift, so the commit plan has to be made explicit before pushing; otherwise a good feature can be blocked by ambiguous tree scope rather than by the code itself.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_OI9w8uL9BTiS",
+    "createdAt": 1780992862264,
+    "lastUsedAt": 1780992862264,
+    "ageDays": 9.508879872685185,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in chat-app, the provider-locking design changed after the user insisted the lock belong on the model entry rather than in a separate proxy-side map. The fix moved the routing rule into `packages/shared/src/types/ai-models.ts` by adding `providerLock?: string[]` to `AiModelDefinition`, locking `zai/glm-4.7` to `['cerebras']`, and deriving the gateway override from the model catalogue so the proxy return shape stayed unchanged. The durable lesson is that routing policy belongs at the model-definition boundary when the user wants the catalogue to be the source of truth; that keeps routing logic discoverable and avoids a second hidden map that can drift.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_E14IDyoMXwkN",
+    "createdAt": 1780992862264,
+    "lastUsedAt": 1780992862264,
+    "ageDays": 9.508879872685185,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "08:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in chat-app, the first model-selection milestone was the addition of a new `fast` tier-default backed by `zai/glm-4.7`, after the user explicitly said “no do NOT remove fast:google.” The implementation had to preserve the existing Google-pinned variant while routing the bare `fast` tier through the AI-gateway proxy with a Cerebras-only lock, plus matching web/mobile icons and exhaustive provider maps. The lesson is that tier expansion here is additive and user-sensitive: a new bare default can coexist with an old provider-pinned variant, but the pinned route must remain intact until the user explicitly retires it.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_tlX3mtLORNcH",
+    "createdAt": 1780848865284,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511585648149,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the team also had to rework the release cadence multiple times because tags and remote branch heads moved underneath the work. A push for v0.1.173 initially succeeded as feature commit `be56158` plus release commit `29e0347`, but `git push origin main` was rejected when `origin/main` advanced, so the tag was deleted and recreated on the final rebased release commit `d17a918`; later an interrupted publish for v0.1.174 was redone from a clean `main` as `adef49f`, and a subsequent ask to “push and /release” produced v0.1.176 after a separate feature commit and release bump. The durable lesson is that release tags are only stable anchors if they sit on the final rebased commit, so a rejected push must be treated as a tag-management problem as much as a code problem.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_2uUtHGEAskvC",
+    "createdAt": 1780848865284,
+    "lastUsedAt": 1780848865284,
+    "ageDays": 11.175511585648149,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the chat-app repo, the user explicitly chose the deployment target for the version-bump work after a branch/push warning, answering “Push to staging” instead of production. That decision let the version bump commit land safely as `94338a8b6` on `origin/staging`, and later the same pattern repeated for `0.1.177`, where the branch had to be rebased onto the latest `origin/staging` before the push could succeed as `8f50b448e`; in both cases the pre-commit hooks (`check-types`, `lint`, `format`) passed. The durable lesson is that when deployment target is user-selected, the branch choice is part of the change itself, not an afterthought, and release automation should preserve that explicit intent instead of assuming production by default.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_-hO8cHkFjIka",
+    "createdAt": 1780848865284,
+    "lastUsedAt": 1780848865284,
+    "ageDays": 11.175511585648149,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the model override change was reviewed and simplified before release: `TurnRunner` now layers optional per-state `model` and `thinkingLevel` over inherited runner options when building agent state, and the implementation was trimmed to remove a one-off `baseOptions` variable and a duplicated comment. The associated release flow on `main` then created feature commit `600015a` (`feat: add UI-only per-state model and thinkingLevel overrides for agent states`) and release commit `706c76b` (`chore: release v0.1.176`), with pre-commit hooks passing before tag `v0.1.176` was created. The lesson is that once the behavior is pinned by evals, release hygiene should focus on removing incidental code churn so the final diff clearly expresses the intended contract.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_7rtBS8tjYZv8",
+    "createdAt": 1780848865284,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511585648149,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the acknowledgment-turn guidance around terminal was refined after the user objected that the prompt wording about starting follow-up work with `create_state_machine_definition` felt weird. The fix updated `src/turn-runner/tools.ts`, `src/turn-runner/prompts.ts`, and `src/turn-runner/turn-runner.ts` so the ack turn now summarizes and returns control instead of encouraging spontaneous follow-up work, while only explicit later user requests may create a new state machine or reactivate a finished one; the same pass updated comments/docs that still implied the ack turn should continue work. The lesson is that ack-turn semantics should be boring and conservative: if there is no good reason to continue, the model should stop and wait, because accidental continuation creates confusing behavior and muddles the meaning of “terminal acknowledged.”",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Rz1fb7SdZekG",
+    "createdAt": 1780848865284,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511585648149,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the state-machine model override work was driven by a user request for UI-only per-state control over the exact model and later thinking level, with the explicit constraint that the AI should not need the full model catalog and the field must not be exposed in the create tool or overrides. The implementation added optional `model` and `thinkingLevel` fields to `StateMachineAgentState` in `src/types/state-machine.ts`, threaded them into `TurnState.options` in `src/turn-runner/turn-runner.ts`, and kept `agentStateSchema` / `agentOverrideSchema` closed so only UI or programmatic state writes can set them; the runtime reused `resolveModelName` so invalid values fail like a bad CLI `--model`, and `evals/state-machine-agent-model.eval.ts` proved both override and fallback behavior. The durable lesson is that UI-only configuration should ride the existing runtime resolution path instead of inventing a second validation catalog, because that keeps bad values failing consistently and avoids exposing internal model taxonomy to the model itself.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_0nTemmpaD2IS",
+    "createdAt": 1780848865284,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511585648149,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the chat-app repo, the minimum supported Duet version had to keep chasing the agent releases, and the update path was always anchored in the sandbox setup plus both package consumers. First the floor moved from `0.1.171` to `0.1.174`, then to `0.1.176`, and finally to `0.1.177`, each time updating `packages/backend/registry/sandbox/setup.ts` (`MIN_DUET_VERSION`) and the `@duetso/agent` ranges in `packages/backend/package.json` and `packages/agent-gateway/package.json`, with `bun.lock` regenerated so the workspace resolved a single root version. The lesson is that version floors need to be updated everywhere the runtime and package graph can admit the agent, or the system ends up with inconsistent install-time and runtime expectations.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_tFXE8m6IyMnn",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the chat-app repo, the internal admin workspace details page needed a visible creation timestamp, and the fix landed in `apps/web/spa/internal-admin/route.tsx` by adding a Created row formatted from `org._creationTime` via `formatHumanReadableDate`. The work was deliberately kept UI-only because the data already existed; verification showed `apps/web` oxlint was clean and the only typecheck failures were pre-existing missing `@fingerprintjs/*` modules unrelated to the edit. The lesson is to prefer surfacing existing authoritative data in the admin UI rather than inventing backend plumbing when the underlying record already contains the needed signal.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_fBwDrro_KRuf",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the user later asked for a stronger scope guard so sub-agents would stay inside the current machine state even when given the full machine prompt and state list. The fix added a machine-context layer in `src/turn-runner/prompts.ts`, wired `src/turn-runner/turn-runner.ts` to pass `{ definition, currentState }` into sub-agent prompts, and paired that with `evals/state-machine-agent-stays-in-state-scope.eval.ts` plus `test/state-machine-agent-identity-layer.test.ts`; after the eval became flaky on sonnet-4.6, it was tuned into a 5-iteration loop that reliably reproduced over-reach on the unfixed code and passed with the fix. The lesson is that broader prompt context is useful only when paired with a strict “stay in state scope” invariant, otherwise smaller models can over-reach into implementation work that belongs to the parent.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_PIzfPbZqT6lx",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the chat-app repo, a stale client was mistaken for a backend regression around `domains/sandboxes/actions:runSandboxCommand`. The repo search showed the backend no longer exports `runSandboxCommand` from `packages/backend/convex/domains/sandboxes/actions.ts`; the only remaining command runner is `runOrgSandboxCommandAsInternalAdmin` in `domains/internalAdmin/actions.ts`, and the web app’s only live reference is the `terminal-viewer.tsx` prop alias left over from the user-facing terminal removal shipped in `8aad7dfb7`. The durable lesson is to validate API breakage reports against the current call graph before changing code, because stale clients can look like backend regressions when the real issue is a renamed or retired surface.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_W5NQ_gjmh7C-",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the chat-app repo, the team decided that `servicingStatus` should flip to `activated` when a verified card is added, not wait for the first successful payment. The reasoning came from tracing the billing state machine: `undefined` means trial/gateway-gated, `activated` means billing is set up, and `paused/canceled/banned` are lifecycle states; because the verification hold already proves chargeability, waiting for first payment would misroute the billing modal and conflate a revenue signal with serviceability. The durable lesson is to keep `servicingStatus` about whether the workspace can be serviced, and split any “has paid us” notion into a separate field or event instead of overloading the state machine.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Bcv252Y-WzkI",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the chat-app repo, a Stripe/email sanity check confirmed the environment was configured correctly but also exposed the limits of test mode. The investigation verified `apps/web/.env.local` had test-mode Stripe keys and webhook secrets, and that recent invoices/charges carried customer emails, yet Stripe test mode still does not actually deliver receipt/invoice emails; the practical conclusion was that live mode or a manual dashboard send is needed to verify real delivery, with a possible follow-up to audit live customer email addresses before relying on this in production. The durable lesson is that passing sandbox configuration checks is not the same as proving end-to-end email delivery, so production-readiness needs a live-path verification step.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_04pxXXc24SoA",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the chat-app repo, the user asked for an internal-admin pause control, and the code already had a recoverable `paused` state in backend gates and in the existing admin mutation. The fix in `apps/web/spa/internal-admin/route.tsx` added a “Pause org” button that calls the existing internal-admin mutation with `servicingStatus: 'paused'`, and the follow-up text was later corrected so the pause-confirm copy says a paused org unpauses automatically on its next successful charge rather than implying card updates alone re-enable it. The lesson is that UI copy for admin state controls must match the true recovery path in backend state machines, especially when `paused` is intentionally recoverable and distinct from `banned` lockouts.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_v1EnWcIjh_tx",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the chat-app repo, the user flagged a bug where adding a card did not always make it the default payment method. The fix traced through `packages/backend/convex/domains/organizations/actions.ts` and `packages/backend/convex/services/stripe.ts`, where `completeBillingSetupManual` already updates `invoice_settings.default_payment_method` and cancels the hold, but `completeBillingSetup` could return early for already-activated orgs before that logic ran; the chosen resolution was to split “promote newly added card + release hold” from first-activation-only effects so the default-PM update runs on every successful submission while activation analytics and `servicingStatus` gating stay tied to first-time setup. The lesson is that wallet/payment setup side effects that the user expects on every successful card submission should not be hidden behind lifecycle-only activation branches.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_V_6884LCnPQp",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the duet-agent repo, the user explicitly asked for an eval for the answered-ask transition case and allowed a fake history ending at an ask, with a broader request to run all relevant evals for regressions. That led to `evals/state-machine-answered-ask-enforces-transition.eval.ts`, seeded with a `TurnRunner` history that ended at `state_asked_user` and asserted the runner re-prompts into a real transition when the orchestrator withholds a tool call on the answer turn; a falsification pass temporarily removed the answered-ask guard from `src/turn-runner/turn-runner.ts` and the eval failed for the expected reason (`selectCalls.length` stayed 0). The important lesson is that for state-machine enforcement, a red/green eval is only convincing if it fails for the right causal reason, not merely because a counter happened to change.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_1SGtVD6Do2PY",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the chat-app repo, the team tightened secret redaction after realizing streamed messages could leak API keys if the redactor only ran on final text. The fix landed in `packages/agent-gateway/src/session-controller.ts`, where `redactText` now re-runs on accumulated streamed text/reasoning so secrets split across `text_delta` and `reasoning_delta` chunks stay masked before Convex updates, and a regression test in `packages/agent-gateway/src/session-controller.integration.test.ts` split a `sk-proj-...` secret across token boundaries to prove both streamed and completed messages are redacted. The durable lesson is that token-boundary streaming is a first-class attack surface, so redaction must operate incrementally, not only on fully assembled messages.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_rd3GWXjPTWCY",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the user made the reactivation policy explicit: selecting terminal should stop the auto-drive loop and hand control back to the user, and the only way to reactivate a finished machine is an explicit user prompt like “this is wrong, do this again,” not a separate flag. The implementation added a `state_machine_reactivated` event to `src/types/state-machine.ts`, a `recordStateMachineReactivated()` helper in `src/turn-runner/state-machine-session.ts` to clear `terminal` and `terminalAcknowledged`, and `runDecision` in `src/turn-runner/state-machine-controller.ts` now reactivates when a non-terminal state is selected on a terminal session; `evals/state-machine-terminal-reactivation.eval.ts` proved both terminal stop and explicit-user reactivation, and a falsification pass disabling the reactivation path turned the eval red for the right reason. The durable lesson is that terminal should mean “stop autonomous progression” rather than “destroy the machine,” but re-entry must be explicit so downstream state consumers can treat reactivation as a deliberate user action.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ZkkdZNa9-Ujr",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the chat-app repo, the user asked to include the media-creation skill’s recommended models in the gateway whitelist so trial users would not be auto-paused for using them. The fix expanded `WHITELISTED_GATEWAY_MODEL_IDS` in `packages/shared/src/types/ai-models.ts` to include the image/video model set (`openai/gpt-image-2`, `openai/gpt-image-1.5`, `google/gemini-3.1-flash-image-preview`, `bytedance/seedance-2.0-fast`, `bytedance/seedance-2.0`, `google/veo-3.0-generate-001`, `klingai/kling-v3.0-t2v`, `klingai/kling-v3.0-i2v`) and later that change was committed and pushed as `6653730b5`. The lesson is that payment-gate policy must follow the models the product explicitly recommends, otherwise the system punishes users for using the blessed defaults.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_7ZWDgJdwGe9Z",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, a second identity drift issue surfaced when state-machine sub-agents started behaving like chat assistants on empty-thread fixtures. The user prioritized fixing the sub-agent first because wasted tokens there hurt even if the parent was correct, so the investigation built a red eval at `evals/state-machine-agent-keeps-task-identity.eval.ts`, discovered Sonnet was too compliant, then strengthened the fixture with an explicit empty trailing user-message transcript and stronger persona pressure before proving the fix in Docker; the actual code change introduced `createStateAgentSystemPromptLayer()` in `src/turn-runner/prompts.ts` and wired `createStateAgentHandle` in `src/turn-runner/turn-runner.ts` to prepend it ahead of any per-state `systemPrompt`, with a separate offline guard in `test/state-machine-agent-identity-layer.test.ts`. The durable lesson is that sub-agent identity needs an explicit system-level guard when the runtime may otherwise confuse fixture metadata for live conversation state, and model-tendency evals may require carefully tuned bait before they become reliable regressions.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_i6HwXmi0XmLh",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the chat-app repo, a separate redaction review expanded protection from plaintext secrets to base64-encoded blobs. The work started by mapping `REDACTION_RULES` in `packages/shared/src/constants/redaction.ts` to the gateway redactor, then chose a Tier 2 prefix-anchored base64 strategy: redact both standard and URL-safe base64 for known secret prefixes like `duet_gt_`, `sk-svcacct-`, `sk-proj-`, and `sk-ant-api03-`, while intentionally excluding `ghp_` because it is too short to anchor safely; tests covered all three alignments, URL-safe encoding, and an innocent base64 string, and the later explanation clarified the output becomes `leading base64 + [REDACTED]` rather than a full re-encoding. The lesson is that encoded-secret redaction needs alignment-aware matching and a consciously limited scope, because overclaiming coverage is worse than masking the remainder of a run once a stable anchor is found.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_p7IUPKbbkgDM",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the user asked whether terminal behavior should be hard-blocked or reactivatable, and the investigation found terminal was not actually enforced by code. `select_state_machine_state` validation in `src/turn-runner/tools.ts` does not check `session.terminal`, `StateMachineController.runDecision` in `src/turn-runner/state-machine-controller.ts` has no terminal gate, and state-machine tools are still exposed on non-`agent` turns, so the apparent restriction came from prompt/tool wording that described terminal as final; the follow-up decision was to keep terminal as a durable user-visible end state and make any reactivation explicit rather than silent. The lesson is that prompts can describe a policy, but if the code does not enforce it then the real design constraint is social and UI-facing, not technical.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_CAlFsAJ2tKDM",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the duet-agent repo, a review of the answered-ask guard surfaced two consistency bugs: the retry budget in `src/turn-runner/turn-runner.ts` was duplicated in prose and logic, and the `isAwaitingUserAnswer` JSDoc in `src/turn-runner/state-machine-session.ts` contradicted itself about which lifecycle events end the wait. The fix was to extract `PARENT_TRANSITION_RETRY_BUDGET = 3` so the loop bound and retry text could never drift apart, then rewrite the JSDoc to match the actual answered-ask lifecycle. The durable lesson is that guard behavior is fragile when constants and comments can diverge, so enforce the contract once and keep the narrative aligned with the implementation.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_eJ5rjTfl2ABD",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the duet-agent repo, the team initially treated `evals/state-machine-executed-state-not-no-op.eval.ts` as a regression during the answered-ask work, but repeated baseline/branch comparisons showed the apparent failure was `gpt-5.5` variance rather than a deterministic code break. The investigation mattered because the new answered-ask branch is a no-op in an eval that never asks the user, so the shared post-completion loop was left unchanged after checking prompt/loop logic and seeing 3/3 branch passes alongside later baseline passes. The durable lesson is to distinguish model-judgment flakiness from real behavioral regressions before widening a fix, especially when the observed change is outside the eval’s path.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Iqu2tCmu1edx",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780984874420,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the chat-app repo, the billing modal behavior was clarified twice: first for the split between `BillingPopupReason = 'first-activation' | 'topup-failed'`, and then for the manual `?activate` path when a card was already present. The investigation traced `useBillingActivated`, `activate-billing-modal.tsx`, and `packages/backend/convex/services/stripe.ts` to show that `first-activation` only occurs when `servicingStatus === undefined`, while an already-activated org should normally be on the `topup-failed`/portal path; the manual flow reuses the Stripe customer and only had a small inefficiency in creating a fresh verification-hold PaymentIntent before the no-op guard. The durable lesson is that activation and payment-method update are related but not identical concerns, so modal copy and backend side effects should be split along that boundary instead of overloading one state.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_8r1fl9BcIIYE",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-04",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the project codified a testing rule for these prompt-layer behaviors by updating `/.agents/skills/write-eval/SKILL.md`. The trigger was the realization that deterministic wiring tests and model-tendency evals need different falsification strategies: a single-run red/green is enough for wiring bugs, but prompt-layer fixes change probabilities rather than guarantees, so the skill now says to calibrate against broken code first, then loop N times with fresh cwd/runner and clean runs, lock the eval once it reproduces, and keep comments honest about tuned bait instead of claiming verbatim prompts. The durable lesson is that eval-writing guidance must match the kind of bug being tested, or the team will either overtrust flaky single runs or dismiss useful regressions as randomness.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_lETWl-G6F3Eb",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780848865283,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the chat-app repo, the user asked when a subscription pauses, and the billing flow was traced through Stripe webhook handling to separate recoverable pauses from terminal lockouts. The answer established that an org pauses either after `invoice.payment_failed` on `credit_topup` / `credit_topup_manual` invoices hits `CONSECUTIVE_TOPUP_FAILURE_PAUSE_THRESHOLD = 3`, or when `invoice.marked_uncollectible` sets `servicingStatus` to `paused` directly; a later successful `invoice.paid` clears top-up errors and unpauses back to `activated`, while `banned` remains reserved for admin/terminal lockouts. The durable takeaway is that `paused` is a recoverable serviceability state, not a permanent punishment, and the code should keep that distinction sharp so billing recovery paths remain predictable.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_zuWI8p1QDGWz",
+    "createdAt": 1780848865283,
+    "lastUsedAt": 1780982490608,
+    "ageDays": 11.175511597222222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:14",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-04 in the duet-agent repo, the user first challenged the sub-agent architecture by asking whether the `prompt` property should be sent as a user message rather than treated as system-level context. The investigation traced `src/types/config.ts` and `src/turn-runner/turn-runner.ts` to confirm `state.prompt` already enters the sub-agent via `await agent.prompt(expandedPrompt)` as a user turn, so the real decision was about how much host persona to inherit; after a user choice of “Precedence fix: lead with worker identity,” the code added a `prepend` layer in `src/turn-runner/prompts.ts` and threaded `prependSystemPrompt` through `src/turn-runner/skill-context.ts` and `src/turn-runner/turn-runner.ts` so state sub-agents lead with worker identity while per-state `systemPrompt` stays appended. The lesson is that prompt architecture should make worker identity precede host context when the model is acting as a sub-agent, because that reduces persona bleed without removing the useful task instructions already passed as user input.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Qa9qRnI117Gq",
+    "createdAt": 1780762732133,
+    "lastUsedAt": 1780762732133,
+    "ageDays": 12.172423055555555,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the `duet-agent` repo, the user tightened the state-machine tooling contract so `select_state_machine_state` should immediately reject invalid overrides and impossible cwd values instead of silently ignoring them. The implementation was pushed into `src/turn-runner/tools.ts`, where selection-time validation now checks both kind mismatches and missing directories at call time, and the tool description was updated so the behavior is documented rather than implicit. Creation-time validation was also tightened: `create_state_machine_definition` now verifies each state cwd against the runner base cwd and tells authors to omit `cwd` until a runtime-created directory exists, then set it later via `override.cwd`. The durable lesson is that silent ignore paths are dangerous in orchestration code; if a state override cannot be applied, failing fast makes the bug obvious and keeps the prompt/tool contract honest.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_-9YSYGqzww0n",
+    "createdAt": 1780762732133,
+    "lastUsedAt": 1780762732133,
+    "ageDays": 12.172423055555555,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:18",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the `duet-agent` repo, a review uncovered that the relative-state-cwd logic had drifted across `tools.ts`, `state-machine-controller.ts`, and `turn-runner.ts`, creating a risk that validators and runtime would stop agreeing. Rather than leave duplicated copies in place, the code was simplified by extracting a shared `resolveStateCwd(cwd, baseCwd)` helper in `src/turn-runner/tools.ts` and moving the controller onto it, with a small cleanup that collapsed a terminal-state guard to a single-line return. This was a classic case where the bug was not a visible failure but a maintenance hazard: duplicated path resolution is easy to get almost right until a future change updates one copy and not the others. The lesson is that orchestration code benefits from shared normalization helpers even when the behavior seems trivial, because path semantics are exactly the sort of detail that diverges under pressure.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_x26tLucOKeJh",
+    "createdAt": 1780762732133,
+    "lastUsedAt": 1780762732133,
+    "ageDays": 12.172423055555555,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the `duet-agent` repo, the cwd work was stress-tested with a real `duet --rpc` eval because the user wanted confidence that the runner resolves relative workdirs against `--workDir` rather than the launch process cwd. The new `evals/state-machine-workdir-cwd-rpc.eval.ts` used a temporary workdir with a sentinel-only `probe/` directory so the run would fail with `ENOENT` if the wrong base was used; the eval was deliberately falsified by reverting the runtime resolution and then restored once the failure reproduced exactly as expected. This pattern was repeated later in the release flow, where the change was committed, tagged, and then rechecked after additional prompt-related edits, but the functional behavior stayed the same. The lesson is that a good regression eval should prove the bug path, not just assert the happy path, and the best sign it is wired correctly is that it turns red the moment the old implementation comes back.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_OZGj5FCT8X0P",
+    "createdAt": 1780762732132,
+    "lastUsedAt": 1780762732132,
+    "ageDays": 12.17242306712963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:18",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the `duet-agent` repo, the user asked whether interrupting a turn parked on `ask_user_question` would mark the terminal as `interrupted`, and the investigation showed that it should not. Reading `src/turn-runner/state-machine-controller.ts` and `src/turn-runner/state-machine-session.ts` confirmed that asking clears `activeRun` and records a `state_asked_user` event, while `interrupt()` is a no-op when nothing is actively running, so already-asked states do not get reclassified. The answer that followed was that only in-flight work becomes interrupted; once the machine is waiting on a user answer, interruption should not rewrite that terminal state. The broader lesson is to be careful about retroactively changing terminal semantics after the runner has already yielded control, because the “waiting for user” boundary is materially different from “running code right now.”",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_PGdDHVa7u8yq",
+    "createdAt": 1780762732132,
+    "lastUsedAt": 1780762732132,
+    "ageDays": 12.17242306712963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:18",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the `duet-agent` repo, the state-machine prompt was refactored because the user noticed wording that made it sound like the sub-agent should be doing routing, when in fact the parent/orchestrator owns all routing and the child should only report back results. The prompt was condensed substantially, the UI wording was split so user-facing replies still call state machines “relays,” and an explicit prohibition was added against writing state prompts that tell a sub-agent to “route to X,” which had been called out as a footgun in a prior video-pipeline precedent. One eval briefly failed after the condensation and had to be strengthened by restoring more explicit guidance, which reinforced that prompt simplification is only safe when the invariant still survives targeted regression checks. The lesson is that prompt refactors should preserve ownership boundaries first and style second; if a shorter prompt blurs who controls routing, it is too short.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_6J3QuI4tyx9v",
+    "createdAt": 1780762732132,
+    "lastUsedAt": 1780762732132,
+    "ageDays": 12.17242306712963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-03 in the `duet-agent` repo, the user wanted the answered-ask path to be guarded symmetrically with the existing post-completion transition guard, because a later user response should not silently skip the next state transition. The fix added `isAwaitingUserAnswer(session)` in `src/turn-runner/state-machine-session.ts`, then routed answer turns with no control action into the same bounded retry/error-terminal enforcement path that already existed for completed states; a dedicated test was temporarily falsified by reverting the guard to prove the bug was real before restoring it. The resulting implementation reused the 3-attempt parent-transition retry logic as a shared helper, which kept the behavior consistent across completed states and answered asks. The lesson is that every point where the worker regains control after a wait needs the same transition enforcement, or else one path will drift into silent no-op completion while another still blocks correctly.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_09B5_VqsilFl",
+    "createdAt": 1780762732132,
+    "lastUsedAt": 1780762732132,
+    "ageDays": 12.17242306712963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the `chat-app` and `duet-agent` repos, the agent-gateway contract was deliberately simplified after a user and assistant agreed that only true turn-level failures should surface as chat errors. Earlier attempts had chat-app infer runtime state-machine failures from history or special flags, but that was judged too brittle, so the gateway was rewritten to stop treating state-machine terminal failures as visible chat errors and instead rely on `stateMachine.terminal.reason` when the parent agent actually needs the detail. The durable lesson is that the gateway should expose only the envelope-level failure boundary; state-machine semantics belong to the parent-agent relay path, not to a second error channel in the chat UI.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_isuKyNdLEEt4",
+    "createdAt": 1780762732132,
+    "lastUsedAt": 1780762732132,
+    "ageDays": 12.17242306712963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the `duet-agent` repo, the team first tried to make create-while-active recoverable in-turn with a bounded reprompt loop, but the user pointed out that `create_state_machine_definition` and `set_state` both terminate the worker prompt loop, so the worker cannot both finish the old machine and start a new one inside the same turn. That constraint forced a pivot away from retry scaffolding and toward explicit reset semantics: `create_state_machine_definition` gained a `replaceActive?: true` escape hatch, the runner supersedes the old session as `cancelled`, and the guard message was made explicit enough to name the active machine and state so an unaware agent does not blindly create over the top of it. The lesson is that recovery logic has to match the control-flow contract of the tool model; if a tool is terminal by design, then “retry until success” is often the wrong abstraction and a deliberate reset flag is safer and clearer.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_KOnn-EcbKe5z",
+    "createdAt": 1780762732132,
+    "lastUsedAt": 1780762732132,
+    "ageDays": 12.17242306712963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-03",
+    "timeOfDay": "16:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 and 2026-06-03 in the `duet-agent` repo, relative state `cwd` handling was chased end-to-end because the user said the `--workDir` option had to work correctly and that there were “lots of errors / inconsistencies with how we do cwd.” The fix was to resolve relative per-state cwd against the runner base cwd (`config.cwd`, set by `--workDir`) instead of the launch process cwd, then to codify that rule in both creation-time and selection-time validation so bad paths fail early with messages that point authors toward `override.cwd` for directories that do not exist yet. The code was then cleaned up by extracting a shared `resolveStateCwd(cwd, baseCwd)` helper to avoid validator/runtime drift, and the change was backed by a red/green eval over the real `duet --rpc --workdir <tmp>` path. The durable lesson is that cwd semantics must be defined once and reused everywhere; if validators, runtime, and prompts each interpret the base differently, the system will appear to work until a worktree or alternate launch cwd exposes the mismatch.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_CwwB5ueHB9-n",
+    "createdAt": 1780762732132,
+    "lastUsedAt": 1780762732132,
+    "ageDays": 12.17242306712963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the `duet-agent` repo, a long turn-runner protocol refactor began because state-machine failures were leaking through the wrong channel and downstream consumers were seeing ambiguous or spurious errors. The work moved from an initial attempt to store protocol-violation details only on the turn event, through several rounds of redesign, to a cleaner split where terminal state-machine outcomes live on `stateMachine.terminal` and the turn envelope stays `status: \"completed\"` for legitimate machine outcomes. The key decisions were to add bounded recovery only where the worker actually could self-correct, to preserve `event.error` for true runtime/infra failures, and to keep the parent-agent acknowledgment path responsible for interpreting machine outcomes. The durable lesson is that turn completion and state-machine outcome are separate layers: if they are conflated, chat-gateway code ends up fabricating user-visible failures like `Error: cancelled` or `Error: failed` from state names that were never meant to be transport errors.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_J6oKphX0Dnt5",
+    "createdAt": 1780762732132,
+    "lastUsedAt": 1780762732132,
+    "ageDays": 12.17242306712963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the `duet-agent` repo, the runtime-failure contract was narrowed after the user rejected overloading `failed` and asked for a distinct `error` status to represent only runtime errors that should fail the turn runner. The implementation then separated authored terminal outcomes (`completed` / `failed` / `cancelled`) from machine/runtime failures, with `recordStateFailed` persisting `status: \"error\"`, `controllerResultToTerminal` mapping that into a failed turn event with `event.error`, and protocol/misconfigured-gate tests updated to assert the new shape. The rationale was to preserve a clean distinction between business outcomes and infrastructure/runtime failures so future consumers can reason from status names instead of reverse-engineering them from history entries or turn envelopes.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_o2PYUGbTyEuw",
+    "createdAt": 1780762732132,
+    "lastUsedAt": 1780762732132,
+    "ageDays": 12.17242306712963,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:18",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the `duet-agent` repo, the team spent several iterations proving how state-machine `cwd` should behave because the user wanted the child agent to work in the right tree without being told to `cd` in prompts. The work started by strengthening prompt guidance and validators, then moved into a production-faithful eval where one state created a worktree and later states had to pass its path forward via `override.cwd`; that eval initially timed out because the sub-agents tried to do too much real work, so it was trimmed to one-line markers and made reliable. When falsification showed the guidance could be stripped without changing behavior on the tested models, the non-load-bearing guidance was eventually restored and treated as a guardrail rather than a behavior shaper. The lesson is that cwd instructions are only worth keeping if they are either enforceable or at least document the runtime contract clearly; otherwise a green-but-unbreakable eval can become noise instead of protection.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Adz76xCbCcA2",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the duet-agent repo, the user asked to reproduce the “create while active” issue with an eval before any implementation, and the response followed that ordering explicitly. Using the existing `write-eval` skill and nearby state-machine evals as a pattern, the team created `evals/state-machine-create-while-active-self-correct.eval.ts` to cover the recovery case and confirmed that the bug reproduces in Docker: the deliberate create-while-active violation happens, but the follow-up `select_state_machine_state(\"done\")` never occurs, so `recoverSelectIndex === -1` and the eval fails for the expected reason. The lesson is that evaluation-first is the right discipline for protocol bugs, because it proves the exact missing recovery behavior before any code is changed and gives a stable regression target for the eventual bounded 3-attempt self-correction fix.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Sv9KQJYh8c5y",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the chat-app `packages/agent-gateway` path, the user hit the “max 16 agents running concurrently” error while starting a kanban task, and the debugging work traced the cap to `packages/backend/convex/domains/sandboxes/internal.ts`. The investigation distinguished the system/cron bucket from the normal user bucket: `MAX_CONCURRENT_SYSTEM_SESSIONS_PER_SANDBOX = 16` is enforced only when `userId === undefined`, while user sessions have a separate cap of 100, and the non-terminal session count is computed from `pending`, `running`, `waiting-for-input`, and `sleeping` records. The durable lesson is that a 16-slot saturation is usually a symptom of stuck or crash-looped system-scoped work before `turn_started`, so the right next diagnostic step is to inspect or clear non-terminal system sessions rather than assuming the user path is at fault.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Y_cORLKOsNbl",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the chat-app repo, the user asked for the kanban/session-scoping bug to be reproduced with a test first, but then later deferred testing and said to “just do the fix and I’ll test it live,” which changed the implementation strategy. The work first identified the relevant seams (`packages/backend/tests/convex/kanban.test.ts`, `packages/backend/convex/workflows/chat/chime.ts`, `packages/backend/convex/workflows/chat/workflow.ts`, `packages/backend/convex/model/threads.ts`, and `packages/backend/convex/domains/sandboxes/actions.ts`) and initially planned a regression test around the workflow boundary, but `convex-test` could not execute workflows end-to-end. The eventual fix was to rely on the already-threaded `actingUserId` through `packages/backend/convex/workflows/chat/workflow.ts` into `packages/backend/convex/workflows/chat/chime.ts`, then patch the call-site in `threads.ts` so the session uses the initiating user instead of the AI placeholder; the lesson is that when the harness cannot simulate the full workflow stack, it is better to test the seam you can actually drive than to force an unrealistic end-to-end repro.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Ff91Bh-NGU6q",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "low",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-06-02 in the chat-app repo, that sidebar-state fix was pushed to `staging` as `bc603c6b8`, which made the migration test repair live on the remote branch. The trigger was the same stale assertion problem after `5fa6e487c`; the decision was to repair the test harness and expectations rather than treat the failure as a product bug, because the underlying code change was intentional and the tests simply had not been taught about the new field. The broader lesson is that remote pushes should preserve the convention of adjusting fixtures and migration snapshots whenever state schema evolves, otherwise later debugging gets polluted by outdated expectations.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_BskxftB58E_B",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the duet-agent repo, the user asked whether the parent agent sees a state’s `when` field when selecting a state in a state machine, and the answer came from following the prompt serialization path rather than guessing about selector behavior. The investigation found that `when` is defined as optional routing guidance on state definitions in `src/turn-runner/tools.ts`, and the entire active definition is serialized into the parent prompt in `src/turn-runner/prompts.ts` via `JSON.stringify(definition, null, 2)` with no selective projection that would drop `when`. The durable lesson is that routing confusion is more likely a prompt-comprehension problem than a data-plumbing problem here, so a future improvement should be a prompt nudge telling the parent to consult each state’s `when` field rather than changing the underlying serialization.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem__cz9Cp35dj8h",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780747312993,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Still on 2026-06-02 in the duet-agent repo, the user’s follow-up about handling runner complete errors exposed a gap in the gateway logic rather than the turn runner itself. Inspecting `packages/agent-gateway/src/session-controller.ts` showed that the `complete` branch logs `[runner complete error]`, creates an `ai-system` placeholder, and passes `error` into `completeSession` only when `event.status !== 'completed'`; that means genuine state-machine failures that now arrive as `status: 'completed'` with an `event.error` can be swallowed unless the gateway checks the terminal state separately. The durable lesson is that once the turn envelope is normalized, downstream error handling must switch from status-only gates to a combined status-plus-error or state-machine-terminal check, or the gateway will silently erase real failures.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_l-Xv_GNe37sD",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780748224656,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-06-02 in the chat-app `packages/agent-gateway` work, the kanban failure path turned out not to be a user-cap problem at all but a scoping bug: a kanban child-channel chime post surfaced an `ai-system` error even though no `sandboxSessions` row existed because `packages/backend/convex/workflows/chat/chime.ts` throws before insert when the cap is hit. Tracing through `packages/backend/convex/model/messages.ts` and `threads.ts` showed that kanban thread seeds are authored as AI placeholders (`origin: 'ai'`, text like “Starting new thread with Duet”) and passed into `processMessageSent` → `processChimeIn` without author injection, so `chime` fell back to `message.authorId` and classified the session into the system/cron bucket. The fix in `packages/backend/convex/model/threads.ts` was to forward `actingUserId: userId` into the `chimeIn` payload for author-less thread/kanban seeds so the initiating human owns the session; the broader lesson is that session routing should key off the acting human, not the seed message’s missing author, whenever AI placeholders originate a user-visible workflow.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ORY39sViLm3R",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in the duet-agent repo, the user asked whether state-machine prompts and docs fully described template handling, and the investigation showed a subtle documentation gap rather than a runtime bug: the system prompt and `create_state_machine_definition` already explained `{{ input.foo }}` plus the need for matching `inputSchema` and `input`, but the poll-state schema never mentioned templates even though `src/turn-runner/state-machine-controller.ts` also renders `state.command` before shell execution. The durable lesson was that poll commands already support `{{ input.foo }}` expansion through the shared helper, with `src/turn-runner/shell-state-handle.ts` only expanding `input.`-prefixed placeholders, allowing nested paths and turning missing values into empty strings; that behavior is important enough to document explicitly so future changes do not assume poll states are template-free.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_vbNe87ewJc1k",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the duet-agent repo, the follow-up to that terminal-status review confirmed that `get_current_state_machine_state` still returns the live session snapshot’s `terminal`, and that `terminal.status` remains the authoritative machine outcome even after the turn-envelope change. The verification showed the tool path now exposes `currentState`, `currentInput`, `terminal`, `progress`, and recent history, so resume or interruption checks should continue to read the terminal snapshot for the actual machine result. The lesson is that the public turn protocol can be normalized for transport while the session snapshot keeps the semantic truth about whether the machine actually completed, failed, or was cancelled.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_BJxIIqHM1BsM",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Later on 2026-06-02 in the chat-app `packages/agent-gateway` wake-path work, the user and assistant traced why a sleeping runner does not pick up a newly edited kanban or state-machine definition when it resumes. The investigation showed that a `wake` event does not re-read the channel’s latest definition; instead, it boots from the persisted session metadata (`metadata.mode`) that was last written by the prompt/answer path, while the path that refreshes kanban/state-machine definition from the channel is `buildTurnChannelContext` → `resolveKanbanDefinition` during prompt/answer turns. The user favored the safer alternative of doing nothing on wake to avoid orphaning a parked `currentState`, especially for timer or poll states that resume by state name, and the suggested follow-up was to add a comment at `wakeSession`/`wakeSandboxSession` explaining why wake intentionally does not refresh `mode`; the lesson is that resume-time state must stay pinned to the suspended definition until the next prompt/answer reconciliation point.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_40__DZCsT0mB",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-06-02 in the duet-agent repo, the team explored whether state-machine terminal state could be fully separated from the turn runner’s terminal event so that a completed state would not emit a turn-level error. The investigation found that most state-machine failures already live on `stateMachine.terminal.reason`, but two protocol-violation paths in `src/turn-runner/turn-runner.ts` still return inline terminal errors only on the turn event and would lose their messages if the event error were simply dropped. The plan, which the user explicitly told the assistant to draft before implementing, was to make the turn event always `completed` for terminal acknowledgement, move all machine outcome detail onto `stateMachine.terminal`, and then migrate those two inline protocol errors into session state before removing the event-level error field. The durable lesson is that protocol errors must be relocated carefully, not just deleted, or else the one place that still carries the human-readable explanation will disappear.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Pz1KMZc14sR-",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the chat-app repo, that gateway gap was fixed in `packages/agent-gateway/src/session-controller.ts` by treating a completed turn as failed when `event.status !== 'completed' || event.error != null`. The motivation was to preserve real state-machine/runtime failures such as poll timeouts, unknown state, agent failure, or missing `select_state_machine_state` while still not reclassifying deliberate cancelled or failed terminals as turn failures just because the state machine ended that way. The fix was backed by integration coverage in `packages/agent-gateway/src/session-controller.integration.test.ts` for both a completed envelope carrying `error: 'Poll state \"poll_email_reply\" timed out'` and a deliberate cancelled terminal with no error, and the team verified the result by running the gateway integration suite, typecheck, and lint; the lesson is that error propagation has to distinguish semantic machine failures from intentional terminal statuses.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_r53L7SXfajo1",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the duet-agent repo, a code review of commit `3c562a6` for PR #65 (`fix(runner): report completed turn status on state-machine terminal`) surfaced an important contract split: turn completion status should always be `completed` for any state-machine terminal, while the actual machine outcome still belongs on `stateMachine.terminal.status`. The underlying bug had been that `cancelled` and `failed` terminals were indistinguishable from a genuine user abort, which caused the backend to log a spurious `[runner complete error] status=cancelled` and inject an unnecessary “Error: cancelled — try again” system message after an otherwise-successful turn. The review also noted that downstream consumers must read the true outcome from the terminal snapshot, not from the public turn status alone, and flagged `drainQueuedTurnCommands` in `src/turn-runner/turn-runner.ts` as a behavior to double-check because it used to stop on `complete && status ===",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Fl3Aa-McKeXO",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-06-02 in the duet-agent repo, the user challenged the assumption that poll states had a prompt field and described a `pr + review` poll as if a prompt plus command combination was causing a tight loop. The investigation checked `src/turn-runner/tools.ts` and `src/turn-runner/state-machine-controller.ts` and concluded that poll states do not have a `prompt` field at all; accepted keys are `command`, `intervalMs`, `successCodes`, `timeoutMs`, `cwd`, `inputSchema`, `name`, `kind`, and `when`, and any `poll`-adjacent prompt data is silently ignored on the poll path. The lesson is that when a loop looks wrong, the likely causes are command and exit-code semantics or orchestrator re-selection, not hidden prompt behavior in the poll schema.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Ew4jVgjdi--I",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the duet-agent repo, the user reported a broken poll-state behavior from a prior commit: a poll meant to run every 12 hours had been miswritten as `echo`, so it falsely counted as success and the orchestrator re-selected it up to roughly 100 times. The response was to write `evals/state-machine-poll-misconfigured-gate.eval.ts` against the real `TurnRunner`, verify that the eval passed on the fixed code, then deliberately remove the poll-gate guard in `src/turn-runner/state-machine-controller.ts` to confirm the eval turned red and timed out at 150 seconds before restoring the guard and re-verifying green. The durable lesson is that poll loops must be defended at the execution gate, not merely documented, and a good regression should prove both the normal success path and the failure when the guard disappears.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_XC9A2agAzXV1",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Later on 2026-06-02 in the chat-app `packages/agent-gateway` area, a review found duplicate scoping rationale scattered across the kanban-thread seed path, and the cleanup effort was about preserving one canonical explanation rather than changing behavior. The fix consolidated the rationale onto the `actingUserId` handling in `packages/backend/convex/workflows/chat/chime.ts`, trimmed the transparent forwarder in `workflow.ts`, and reduced the `threads.ts` call-site note to the bare fact that the seed message is author-less. That refinement was then pushed to `staging` as commit `1a6ab86f0` with the subject `fix(kanban): scope thread-seed sessions to the initiating user`; the durable lesson is that once the runtime contract is correct, the explanation should live in one obvious place so future edits do not have to reconcile multiple half-duplicate comments.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_jj6au69TCO0_",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the chat-app repo, a user was worried about signup abuse from people repeatedly creating accounts on the same computer to farm free credits, and they explicitly rejected simple client storage tricks like cookies or localStorage because incognito and cache-clearing bypass them. The investigation response was architectural rather than code-specific: the assistant recommended a layered anti-abuse design built around derived device fingerprinting as the strongest client-side signal, combined with IP/network heuristics, disposable-email blocking, higher-friction verification before granting valuable credits, and server-side risk scoring or shadow-limiting instead of a blunt hard block. The lesson is that this kind of abuse needs multiple weak signals plus server enforcement, because any single browser-local identifier is easy to reset.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_D2i3nxPVdKbV",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780821844285,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the duet-agent repo, the user asked to run the most recent commit’s evals and, if they passed, perform a release; the response was a clean release workflow rather than an ad hoc push. The evals `promised-wait-needs-state-machine.eval.ts` and `state-machine-routing.eval.ts` both passed, `bun run check-types` and `bun run lint` were clean, and the package version was bumped from `0.1.168` to `0.1.169` before committing `chore: release v0.1.169` as `88b30d2`, creating annotated tag `v0.1.169`, and pushing both `main` and the tag to `origin`. The lesson is that a release should be anchored by passing evals plus the standard type/lint gate, and the version/tag pair is the stable cross-session identifier worth preserving.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_DKzZ-kSH4w36",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the duet-agent repo, the user later clarified the semantics around `create_state_machine_definition` by asking whether the current active-state-machine guard ends the turn automatically and whether a terminal state machine would let the agent self-correct in the same turn. The investigation into `src/turn-runner/turn-runner.ts` showed that the active-state-machine guard currently returns a terminal failed result immediately, ending the turn rather than allowing recovery, while the existing `select_state_machine_state` miscall path already uses a bounded re-prompt loop via `selectNextStateAfterCompletion`. The plan was refined to keep the active-state-machine error as recoverable re-prompt logic rather than a terminal failure and to leave the separate “didn’t call select” violation on its own bounded retry or terminal path; the lesson is that recoverability should mirror the existing bounded self-correction pattern, not invent a new one-off retry mechanism.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_nUfU0tgxaBcc",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780676822231,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the duet-agent repo, another investigation asked whether a `poll` key is ignored when passed in, and the answer confirmed that it is silently dropped because the poll executor never reads `state.prompt` or any `poll`-adjacent prompt field. The path through `src/turn-runner/tools.ts` and `src/turn-runner/state-machine-controller.ts` showed that the schema is permissive about unknown keys, which means the runtime behavior is governed only by the poll command and exit-code contract. The durable takeaway is that any real polling bug has to be debugged at execution time, because extra config keys may compile or parse cleanly while having no effect whatsoever.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_gogP80_E6_BK",
+    "createdAt": 1780676822231,
+    "lastUsedAt": 1780749646416,
+    "ageDays": 13.166750625,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-02",
+    "timeOfDay": "16:27",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-02 in the chat-app repo, a post-commit test failure surfaced in `apps/web/hooks/use-channel-sidebar-state.test.ts` after `lastVisibleDesktopStateByChannel` had been added in commit `5fa6e487c`, and the migration assertions were still expecting the old shape. The fix was to add `lastVisibleDesktopStateByChannel` to `resetStore` so test state cleared the new field between cases, then update the two migration assertions so the full web suite passed again at 100 files and 857 tests, with `oxlint` clean on the touched test file. The lesson is that when store shape changes are introduced, reset helpers and migration expectations must be updated together or tests will keep failing against stale state assumptions.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_o8orPI3SUx2a",
+    "createdAt": 1780612540593,
+    "lastUsedAt": 1780612540593,
+    "ageDays": 13.910751064814814,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "22:35",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in `chat-app`, the user’s request to simplify snapshot regeneration revealed a subtle Playwright behavior that needed to be documented, not just worked around. A stale org-sidebar PNG had appeared because `bun ui:approve` used `--update-snapshots=changed`, so a render change that stayed under the diff threshold could leave the baseline untouched even though the UI was different; deleting the old desktop and mobile PNGs first forced Playwright to rewrite them as brand-new baselines, and the later `/ui-playground` skill update captured that reality. When the user pushed back that “update snapshots of all” sounded like it would run the whole suite and they explicitly wanted to avoid the 5+ minute full run, the doc clarified the distinction between `bun ui:approve --force <id>` and the separate `--all` flag, with `--force` mapped to `--update-snapshots=all` for the matched item only. The durable lesson is that snapshot tooling needs precise operator semantics in the docs, because “approve” can appear to succeed while still leaving stale PNGs unless the team knows when to delete baselines or use the force path.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem__VdtXUAY7Qx1",
+    "createdAt": 1780612540593,
+    "lastUsedAt": 1780612540593,
+    "ageDays": 13.910751064814814,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "22:35",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in `chat-app`, the user’s request to make the pinned-app hover interaction feel stable turned into a small but layered layout cleanup in `apps/web/components/layout/unified-org-sidebar.tsx`. The first bug report was that the pinned-app hover cut off at the top and failed to unhover when the mouse left; the fix replaced the earlier framer-motion lift from commit `630f09478` with CSS `:hover/:active` transforms, added more top headroom, and hardened tooltip z-index/positioning, then a second pass tightened the resting gap under the `PINNED APPS` label with `-mt-2` so the extra headroom did not make the dock feel loose. A third pass changed the icon treatment so custom-icon tiles fill the tile without border/tray/background while selected state still keeps the brand ring, and icon-less tiles keep the higher-contrast white `bg-background` surface the user preferred. The durable lesson is that visual polish often needs separate fixes for interaction physics, spacing, and fallback appearance, and the right way to preserve intent is to approve the screenshots only after the code and baselines agree—sometimes by deleting stale PNGs and regenerating them when `bun ui:approve` appears to do nothing.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_IBt8KSg_Tffs",
+    "createdAt": 1780612540593,
+    "lastUsedAt": 1780696750162,
+    "ageDays": 13.910751064814814,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "22:35",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in `chat-app`, the agent-gateway and sandbox runner relationship was hardened after the user asked whether the runner could be prevented from killing the gateway process itself. The investigation found the runner was a direct child under inherited root privileges, so it could signal the gateway today; smaller ideas like plain uid/gid dropping were rejected because the gateway already runs as an unprivileged user, and userns-only isolation was rejected because it broke sudo-based package installs. The chosen fix was fail-hard PID-namespace isolation in `packages/agent-gateway/src/runner-isolation.ts`, wired through `runner-manager.ts` and `session-controller.ts`, using `sudo -n -E unshare --pid --fork --mount-proc setpriv --reuid <uid> --regid <gid> --init-groups -- ...` so the runner cannot see or kill the gateway PID while still preserving the environment and file ownership; the implementation was verified live in an E2B sandbox, then packaged as PR #1626 on `david/runner-pid-isolation`. The lesson is that when a child process must remain interactive but untrusted, PID namespace isolation is a cleaner boundary than privilege trimming alone, and the design should fail hard if the namespace cannot be created rather than silently falling back to a weaker mode.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_klNBcEkucXQA",
+    "createdAt": 1780612540593,
+    "lastUsedAt": 1780660618871,
+    "ageDays": 13.910751064814814,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "22:35",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in `chat-app`, a later kanban bug showed that prompt-time metadata changes were not taking effect consistently on subsequent runs, which forced the agent to synchronize session context on both prompt and answer paths. The user first reported that editing the kanban definition did not update child channel sessions because the definition was only set when the session started; the first fix added an optional `mode?: TurnMode` to `PromptSessionRequest`, forwarded `body.mode` through `/session/prompt`, persisted it in `session-controller.ts`, and passed `kanbanDefinition` as `mode` on every prompt. When the user then asked whether the answer path should be wired too and explicitly approved disabling support, the implementation expanded to a shared per-turn channel-context builder, `appendSystemPrompt` and `mode` threading through `/session/answer`, and session-store logic that clears `mode` when `null` is sent so a respawn actually drops the old board context. The durable lesson is that prompt and answer turns must be kept in lockstep for any session metadata that affects execution, because fixing only one turn type creates a subtle drift that will reappear the moment a session resumes from the other path.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_fmDkFBn4BU4E",
+    "createdAt": 1780612540593,
+    "lastUsedAt": 1780654985357,
+    "ageDays": 13.910751064814814,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "22:35",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in the `chat-app` repo, the AI-gateway policy changed several times in response to user steers, and the durable lesson is that the gate should track product intent rather than a fixed security shape. It started as an allow-list that rejected explicit non-`AI_MODELS` requests and even scheduled an org ban, then was simplified into a small denylist seeded with `anthropic/claude-opus-4.6` and `anthropic/claude-opus-4.7` when the user said those models were no longer used and should be the signal, then was revised again to restore the allow-list while letting previously-paid orgs through and returning `402 model_requires_payment` with a billing URL, and finally a whitelist was added so infrastructure models like `openai/gpt-5.4-mini` and `google/gemini-embedding-2` could bypass payment checks. Across those turns, the shared helper in `packages/shared/src/types/ai-models.ts`, the gateway route at `apps/web/app/api/v1/ai-gateway/[...path]/route.ts`, and related backend actions/analytics were repeatedly reshaped to match the latest policy. The lasting principle is to keep the model gate explicit and centralized, but to treat product exceptions—paid orgs, infra models, and ban/analytics side effects—as first-class policy inputs rather than one-off route hacks.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_nCpakGaEZIoZ",
+    "createdAt": 1780612540593,
+    "lastUsedAt": 1780675233422,
+    "ageDays": 13.910751064814814,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "22:35",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in `duet-agent`, a prompt clarification and release workflow became a durable precedent for how sub-agent results should be communicated. The user wanted the state-machine prompt to say that sub-agent output is not visible to the user, so `src/turn-runner/prompts.ts` was updated to tell the parent agent that results, files, values, and findings stay in parent context and any user-facing summary must be restated in plain text rather than referenced as “the sub-agent’s output.” After that change, the release path for `v0.1.168` bumped `package.json`, ran `bun run check-types` and `bun run lint`, created the annotated tag, and pushed `main` plus the tag; the follow-up eval suite in Docker passed the relay-output, acknowledgment, transition-carry-forward, trust-user-over-sub-agent, promised-wait, and real-session carry-forward tests, with one routing test flake rerun cleanly. The lesson is that agent prompts should encode the user-visible communication contract explicitly, and that a prompt change is only durable when the release and eval suite both confirm it did not break turn routing or state carry-forward semantics.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Au_ljMTU1Gwd",
+    "createdAt": 1780612540593,
+    "lastUsedAt": 1780659319912,
+    "ageDays": 13.910751064814814,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "22:35",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in `chat-app`, a review of the kanban “Created by” filter uncovered that the underlying data source did not mean what the UI label implied. The filter options came from `apps/web/components/kanban/kanban-created-by-filter.tsx`, which queried `api.domains.kanban.queries.getKanbanCreators`; that backend query in `packages/backend/convex/domains/kanban/queries.ts` originally derived names from authors of seeding parent messages on active non-archived cards, so a kicked-out org member could still appear if their old cards remained on the board. The user wanted the stale member gone, so the implementation was simplified to use live channel membership via `ChannelUsers.getChannelUsers(kanbanChannelId)` and the client comments were rewritten to say “member” rather than “creator,” with the existing stale-selection recovery still resetting invalid picks back to `everyone`. The lesson is that filter UIs should be sourced from the authority that matches the business meaning users expect; if the requirement is “who is in the channel now,” then scanning historical card authors is the wrong abstraction even if it is technically convenient.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_RrDL1myNWi6T",
+    "createdAt": 1780612540593,
+    "lastUsedAt": 1780739056956,
+    "ageDays": 13.910751064814814,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "22:35",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in `chat-app`, the sandbox security work followed a clear trigger: the user showed that `runSandboxCommand` could be abused to exfiltrate `/home/user/.duet/credentials.json` by base64-encoding the file, bypassing output redaction. Investigation confirmed two distinct paths: the command runner only redacted by matching known secret strings in stdout/stderr, which encoding avoids, and `packages/backend/convex/domains/sandboxes/actions.ts` had a `readSandboxFile` base64 path that intentionally skipped redaction for binary-safe reads. The response was to remove the generic arbitrary-command surface entirely for org members, keep arbitrary execution only behind the staff-gated `runOrgSandboxCommandAsInternalAdmin`, replace the former command path with dedicated `getSandboxSkills` and `getSandboxStats` actions, and drop the orphaned `sandbox_command_run` analytics event; the user also approved keeping the admin terminal, but only behind the internal-admin gate. The durable lesson is that redaction is not a sufficient security boundary when encodings can transform the payload, so sensitive files and arbitrary execution must be denied at the command/file layer rather than merely filtered at output time.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_n6s1X94RI8BH",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780676162112,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in chat-app, the product analytics surface was extended only after the assistant confirmed there were no existing events for sending a terminal command or viewing a file. Inspection of `packages/backend/convex/services/analytics.ts` showed the event pipeline was server-side through `internal.services.analytics.event` calling `posthog.capture`, and the only existing file events were create/delete/rename/copy, so adding file-view and terminal-command instrumentation required a deliberate payload design that avoided raw command contents. The shipped change added typed `file_viewed` and `sandbox_command_run` events, threaded the exact resolved file path into `file_viewed` from `packages/backend/convex/domains/sandboxes/actions.ts`, and emitted `sandbox_command_run` with the exact command from `runSandboxCommand`; then, when the user requested all file analytics to include the file path, the payloads were normalized so created/deleted now log `path`, rename/copy log `source` plus target `path`, and view already logs `path`. The durable lesson is that analytics schema should carry just enough context to be useful and debuggable, but the instrumentation point must be chosen carefully so sensitive data is consciously exposed rather than accidentally captured.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_zsPkko5_iYp3",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "11:16",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in chat-app, the team discovered a subtle public-API documentation gap after noticing that `GET /api/v1/channels/{channelId}` was already exposing a channel’s `kanbanDefinition` through `api.domains.publicApi.queries.getChannel`, because `getChannelPublicMetadata` returns the raw channel doc as `data.channel` with no pick/omit. The user asked to document that field and review the other public API skill files, so `packages/backend/registry/sandbox/default-skills/duet/reference/channels.md` was updated to mention `data.channel.kanbanDefinition`, `packages/backend/registry/sandbox/default-skills/kanban/SKILL.md` added reuse guidance, and `generated.ts` was regenerated. The broader doc audit confirmed `actorEmail` usage was consistent, `messages.md` matched the no-actor delete behavior, `channels.md` matched the viewer-free read path, and other docs like `organization.md`, `search.md`, `usage.md`, `mentions.md`, and `files.md` had no kanban or actor-email drift. The lesson is that undocumented but live fields are still part of the contract, so once the API shape is discovered in code it should be surfaced in the skill docs to prevent future agents from treating it as accidental.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_XrjnQjxpK5AA",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "11:16",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in the duet-agent repo, the user asked how large local observations can get after seeing a context bar around 108k/200k and noting reflections are size-limited. The assistant inspected `src/memory/observational.ts` and explained the trigger and condensation math: local observations are capped by the reflection trigger at 0.325×effectiveContext, which is 65k at the default 200k window, reflections condense them toward 0.4×that trigger (~26k), and because the observer can add up to about 8k tokens before the next check, the theoretical worst-case local-pack size is roughly 73k tokens or about 36% of a 200k window. The durable lesson for future memory work is that apparent “context bar” headroom is not the same as durable local-memory capacity; the real limit is governed by the observation trigger and how much can accumulate between reflection passes.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_iIZ3dEsQZHYd",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in chat-app, the spam cleanup escalated from analysis to production deletion after the user asked to find users created in the past hour by a spammer and then approved removal with “yes go for it.” The assistant first separated legitimate recent users from the spam pattern by reviewing WorkOS org/user creation times, then deleted the 18 recent spam-base users from `/tmp/del_recent_users.txt`, correcting a trailing-newline straggler on the second pass and verifying that zero spam-base users remained while two legitimate recent users were left untouched. Earlier in the same burst, a larger WorkOS sweep found 436 orgs across six high-volume `+` alias bases in a tight creation window, with a smaller probe wave on 2026-05-31 afternoon UTC preceding the main 2026-06-01 burst; the assistant explicitly avoided deleting until scope was clarified because the action was irreversible. The lesson is that production cleanup should be staged by evidence and confirmation, especially when some accounts may be legitimate test/dev traffic mixed in with obvious alias-farm spam.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_lijUY_IKjXwb",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-31",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-31 in the duet-agent repo, the user wanted a more reliable eval-writing workflow and asked for a new `.agents` skill that codified their preferred red/green TDD plus a falsification check. The assistant modeled `.agents/skills/write-eval/SKILL.md` on the repo’s existing skill style and the `evals/state-machine-slash-skill-expansion.eval.ts` reference, instructing writers to use the outermost entry point, make the assertion only-if the behavior exists, run it green, then intentionally break the production path to verify the eval goes red for the right reason before restoring. A verification pass found a reference mismatch (`test/helpers/docker-only.js` versus the actual `test/helpers/docker-only.ts`), which is a useful reminder that skill docs need to stay aligned with the exact file layout they describe or they become misleading operational guidance.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_e3zcHvGvPgsX",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "11:16",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in chat-app, the user asked whether any `/ui-playground` updates were needed after the terminal-removal changes, and the answer was no after running `bun ui:check channel-files-panel` in the Playwright Docker image. Both desktop and mobile passed with no baseline diff because the removed Terminal item lives in a closed options dropdown and the stripped `terminal` content type is not part of the default rendered snapshot, so the UI change was visually inert in the regression suite. The durable lesson is that not every behavioral cleanup requires screenshot churn; if the affected control is not part of the rendered baseline, the correct proof is a targeted UI check rather than a blanket baseline regeneration.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_goIAcSsYwT3O",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in chat-app, the deploy-to-prod path was interrupted by a stale generated file problem: `packages/backend/registry/sandbox/default-skills/generated.ts` had drifted because `bun run format` reflowed markdown before codegen. The deployment was stopped, the generated file was regenerated, and the fix was pushed to `staging` before the promotion could continue; that same day the user also found `apps/web/spa/files/components/editors/hooks/use-markdown-editor.test.tsx` reformatting on every run because the `oxfmt-ignore` comment was malformed. The root cause was that oxfmt 0.35.0 only honors a bare `// oxfmt-ignore`, so the existing `// oxfmt-ignore -- ...` was inert; the comment was split into a plain explanation line plus a bare directive, `oxfmt --check` passed, the test passed, and the fix was pushed to `staging` as `d6bc0da28`. The durable lesson is that generated artifacts and formatter directives are part of the release contract: if formatting changes them or a linter directive is syntactically wrong, the deployment pipeline should stop until the generated state and the comment semantics are both restored.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_qryrUaJcVQjI",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in chat-app, the user explicitly pushed back on the earlier identity model by saying `getFirstOrganizationUserId(org)` was a red flag and should “never” be needed because the system should not randomly choose users; they also corrected the assumption that the sandbox `userId` is the actor, clarifying it is only the creator of the sandbox and that every public API needing a creator should take an explicit `userId`. After the assistant audited `packages/backend/convex/domains/publicApi/*` and found multiple first-user call sites, the user changed the contract again: actor resolution should be email-based instead of `userId`, because every message already includes sender email and the exact email is known. This led to a broad refactor plan across nine sites, covering creator, channel-actor, viewer, and analytics paths, and the durable lesson is that standing API identity rules came from user correction, not from implementation convenience: actor selection must be explicit, deterministic, and traceable to the caller’s known email rather than inferred from org membership heuristics.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_eC3olQx3i-es",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in chat-app review mode, the assistant was asked to inspect the public-API cleanup under the repo’s review skill rules, which required checking naming, stale references, unnecessary complexity, and comment quality and then applying safe simplifications before reporting. The review found a real duplication: a new viewer-free public-channel listing had reimplemented the same public-plus-external merge/sort/slice policy already used by `getVisiblePublicOrganizationChannels`. Rather than leaving two subtly diverging implementations, the fix extracted shared selectors in `packages/backend/convex/model/channels.ts` — `selectVisiblePublicOrganizationChannels` and `selectJoinableOrganizationChannels` — so both viewer-aware and viewer-free paths share the same page selection and only differ in final enrichment. The lesson is that review should not just approve or reject code; it should collapse accidental forks back into a single policy source when the same selection logic is being duplicated for different call sites.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_2uGBq2UHuj5D",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-31",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-31 in chat-app, the kanban empty-column layout was tightened because the user wanted the columns to shrink a lot and the title to rotate sideways for maximum compression, then refined the direction with “rotate it the other way, so I can read it looking at it from the left.” The final change in `apps/web/components/kanban/kanban.tsx` removed the 180° flip, leaving vertical text readable from the left side, and the later commit `655a4482f` shipped the collapse behavior on `staging` as `feat(kanban): collapse empty columns to a vertical-title rail`. The visual change deliberately left populated columns and Inbox alone, because Inbox’s leading new-task affordance prevents collapse, and visual baselines were deferred since the kanban playground still crashed on a pre-existing Router/useNavigate coupling in the fixtures. The durable lesson is that layout compression work should preserve the user’s reading orientation as specified, and when screenshot baselines cannot be regenerated safely, the blocker should be fixed in the harness rather than papered over.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_B3V9OCZFsnCY",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in chat-app, the kanban review uncovered a subtle scalability bug in `packages/backend/convex/domains/publicApi/internal.ts`: `listSearchableOrganizationChannelIds` was doing an unbounded `.collect()` over organization public/joinable channels even though the only consumer was `searchOrganizationMessages` and it only needed IDs. The fix changed the query to `.order('desc').take(1000)` per type, preserving the most recently active channels if an org exceeds the cap and avoiding unnecessary reads; that same pass confirmed the actor-email refactor had removed all `getFirstOrganizationUserId` references and kept `organizationId` auth-derived while resolving caller-supplied `actorEmail` to a real member. The broader lesson is that search surfaces should bias toward bounded, activity-ordered candidate sets and that cleanup work is worth reviewing for hidden asymptotic costs, not just correctness.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_OA_Gn0zQjT9o",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in the chat-app repo, a real staging bug surfaced when the public-API board-task flow for channel `jh707yemyksv8918aq0fj7wb0n87p8fr` could enable a board via `/kanban` but then fail task creation with `Channel user record not found`. Investigation traced the failure to `packages/backend/convex/domains/publicApi/mutations.ts#createBoardTask`, which had been selecting a creator with `getFirstOrganizationUserId` even though `model/kanban.createKanbanTask` and `model/messages.upsertChannelUser` require the author to already be a member of private channels. The fix introduced `getFirstChannelMemberUserId` in `packages/backend/convex/domains/publicApi/internal.ts` and changed `createBoardTask` to prefer an org user only if they were actually a channel member, otherwise falling back to an existing channel member; a regression test in `packages/backend/tests/convex/kanban.test.ts` locked in the private-group-board case where the admin is not a member. The durable lesson is that public-channel defaults can be tolerant, but private-channel writes must choose an author from real membership rather than “first org user” shortcuts, because random user selection violates the model contract.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_vbUU79bKFa-F",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in chat-app, the public API refactor removed arbitrary actor fallback by threading explicit `actorEmail` through actor-bearing endpoints and deleting the random/first-member selection path in `packages/backend/convex/domains/publicApi/internal.ts`. The work split the surface into actor-aware and actor-free paths: `resolveOrganizationActor` and `resolveChannelActor` now validate org membership and, for channel-scoped operations, channel membership, while org-wide search was reworked to enumerate channel IDs without per-user metadata so it no longer needed viewer selection at all. The follow-up review on 2026-05-30 caught an unbounded `.collect()` in `listSearchableOrganizationChannelIds`, which was capped with `.take(MAX_SEARCHABLE_CHANNELS_PER_TYPE)` at 1000 per type, and later the user tightened the API again by insisting `get`/`list` channels and `deleteMessage` should drop `actorEmail` entirely because it was bad query-param design. The final outcome was a viewer-free `getChannelPublicMetadata` path plus explicit actor-only helpers where needed, which teaches that the cleanest API is the one that keeps caller identity only where it is semantically required and removes it from read paths that can be derived from intrinsic resource data.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_tyPtNhz9hXJI",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780606774677,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in chat-app, the request to remove the terminal feature was not satisfied by deleting backend endpoints, because the investigation showed `runSandboxCommand` was still used by `packages/shared/src/hooks/queries/use-sandbox-skills.ts` and `apps/web/spa/files/lib/use-sandbox-stats.ts`, and the internal-admin terminal still depended on `runOrgSandboxCommandAsInternalAdmin`. The actual decision was to decouple the user-facing UI instead: `apps/web/spa/files/components/viewers/terminal-viewer.tsx` dropped the dead `runSandboxCommand` fallback and required an explicit command-runner prop, while the terminal was removed from `/files`, the chat right-rail inline viewer, and the sidebar options menu, leaving the internal-admin Terminal tab as the sole command runner. The broader result was shipped as `8aad7dfb7` (`feat(files): remove user-facing terminal; track file views + sandbox commands`) alongside the analytics changes, and the follow-up Playwright check showed `channel-files-panel` still had no baseline diff, meaning the UI removal was visually inert in the regression suite. The lesson is that feature removal should target the actual user-facing surface when shared backend plumbing still exists elsewhere, and regression suites only need regeneration when the removed affordance changes the rendered snapshot rather than a closed menu path.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_XoOoG2MoH-zL",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780675233422,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-31",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-31 in the duet-agent repo, the `/skill` slash-command expansion change was reviewed after pulling `origin/main`, and the working tree was already clean with `src/turn-runner/skill-context.ts` and `src/turn-runner/turn-runner.ts` behaving correctly under `tsc`, `oxlint`, and the targeted docker test. To make the behavior durable, the assistant added `evals/state-machine-slash-skill-expansion.eval.ts` so the real `TurnRunner` state-machine path could be exercised end-to-end: the eval uses a skill whose body contains a unique token absent from metadata, asserts the sub-agent reaches that token without tool calls, and then was falsified by temporarily bypassing `expandedPrompt` to confirm the eval fails for the right reason before the implementation was restored. The release then shipped as `v0.1.167`, bumping `package.json` to `0.1.167`, tagging `v0.1.167`, and pushing `main` plus the tag. The lesson is that evals are only trustworthy when they can be broken on purpose against the same outermost execution path they are meant to guard.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_-uEg41qMs5yo",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-31",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-31 in chat-app, the next kanban task was not the layout itself but the playground harness: the `/playground` kanban fixture crash came from components like `new-chat-dialog.tsx` and `home-compose-bar.tsx` throwing outside a react-router `<Router>`. The fix introduced `apps/web/hooks/use-optional-router.ts` with `useOptionalNavigate` and `useOptionalSearchParams`, then wired those components through router-safe fallbacks so they no longer require a live router to render; this followed the existing `useInRouterContext` gating pattern already used in the repo. After the change, the assistant regenerated kanban visual baselines, confirmed all four kanban playground fixtures rendered correctly in desktop and mobile screenshots, and committed `9115fa3f6` (`fix(kanban): gate compose-bar router hooks so playground fixtures render`). The lesson is that fixture stability should come from making components tolerate the absence of a router, not from wrapping everything in `MemoryRouter` just to silence hook crashes.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_bJh0yj3fyqpU",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-06-01",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-06-01 in chat-app, the signup-credit system became the target of abuse analysis after a user asked how to stop the attack and explicitly wanted to increase the grant amount. Investigation in `packages/backend/convex/domains/channels/mutations.ts` and the shared credits constants showed the attacker was exploiting email-alias farming rather than defeating the org-level trial-credit reduction, so the assistant proposed canonical-email dedupe before any larger grant increase. When the user approved the direction and asked for no migration, the fix was shipped as `d8dc2c3de` (`feat(credits): dedupe signup grant per canonical email`) and moved the canonicalization logic into `packages/shared/src/users/canonical-email.ts` with tests, while `channels/mutations.ts` keyed the first-org grant on `signup_grant:canonical:<canonicalEmail>` so Gmail dot/`+tag` aliases collapse through `by_reference` idempotency but additional-server grants still remain per-org. The durable lesson is that abuse prevention should be tied to a deterministic canonical identity and an idempotent ledger key, because fuzzy “similar email” matching would be brittle and unnecessary when the real problem is alias reuse.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_R5ZQHwbAlllz",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-31",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-31 in chat-app, the kanban subsystem surfaced a pagination crash in `packages/backend/convex/domains/kanban/queries.ts` because the `orphans` path was draining multiple raw pages with `.paginate()` inside a loop, which Convex rejects since a function may run only one paginated query. The fix replaced the multi-page drain with a single paginated scan over a bounded look-ahead window and then post-filtered orphan cards so `continueCursor` still works, which preserved the user-facing pagination contract while staying within Convex’s execution rule. In the same review, `disableChannelBoard` in `packages/backend/convex/domains/publicApi/mutations.ts` was hardened to reject child/non-board channels instead of silently returning success, and `packages/backend/registry/sandbox/default-skills/kanban/SKILL.md` was updated to say the disable `channelId` must be the parent board, not a child thread. The lesson is that correctness here is not just “make the UI do something,” but “respect Convex’s pagination model and make the API fail loudly when a caller targets the wrong channel shape,” because silent success hides misroutes and wastes debugging time.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_igOchicFUnv6",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in chat-app, the first public-API cleanup exposed a second design problem: `packages/backend/convex/domains/publicApi/internal.ts` still had `listOrganizationChannels` pulling viewer metadata via `viewerUserId` even though the org-wide message search caller only needed raw channel IDs. The assistant separated that concern into `listSearchableOrganizationChannelIds`, dropped dead `updatedAfter`/`updatedBefore`/`sort`/`limit` options, and replaced the metadata-heavy flow with a viewer-free ID enumeration because the public `queries.listChannels` endpoint was a different surface and not the consumer. A later review then refined the search ordering per the user’s request: searchable channel IDs should be sorted by last activity so, if the 1k cap is reached, the results are the 1k most recent channels, implemented as `.order('desc').take(1000)` per type with a comment explaining the cap. The durable lesson is that internal helpers should be narrowed to the smallest data shape the caller actually needs, and when a safety cap exists it should preserve the most recently active records rather than arbitrarily truncating by insertion order.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_PDbw1DX9pImi",
+    "createdAt": 1780571811776,
+    "lastUsedAt": 1780571811776,
+    "ageDays": 14.382149409722222,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "11:16",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in chat-app, a user change request turned into an API cleanup that removed `actorEmail` from `getChannel`/`listChannels` and `deleteMessage`, because they wanted `actorEmail` used only when absolutely necessary and never as a query param. The assistant answered by splitting channel reads into a viewer-free `getChannelPublicMetadata` in `packages/backend/convex/model/channels.ts`, delegating `getChannelMetadata` to it, and leaving `channelUser` only on the authenticated viewer-aware path so shared `ChannelWithMetadata` types did not ripple across every caller. `deleteMessage` also changed to attribute AI-message deletion to the message’s own `authorId` rather than a supplied actor email, and a new `packages/backend/tests/convex/channel-metadata.test.ts` locked in that `getChannelMetadata` delegates to the public builder while the public builder omits viewer-only fields. The durable lesson is that public endpoints should expose intrinsic channel facts separately from viewer state, because mixing them forces caller identity into read APIs that do not truly need it and makes later simplification harder.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_sbvM4Hb7XFi9",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Later on 2026-05-30 in the chat-app repo, the kanban skill itself was rewritten after the user explained that it should emphasize long-running workflows — triage, action request, waiting for response, and eventually resolved/not relevant/cannot resolve — because kanban behaves like a state machine that can run for days or months while polling for external events such as customer replies. The update to `packages/backend/registry/sandbox/default-skills/kanban/SKILL.md` replaced the example with a customer-support lifecycle, highlighted multiple terminal outcomes and waiting steps, and then regenerated `packages/backend/registry/sandbox/default-skills/generated.ts` while verifying the generated skill stayed `target: sandbox`. The lesson is that the kanban skill should teach lifecycle management and patience, not just card creation, because its value comes from tracking work across asynchronous terminal states.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_qAfrrvCYeMC0",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in the chat-app repo, the org-scoping bug review for child-channel metadata started from a PR comment about child-channel `orgId` inheritance and led to tracing three creation paths instead of assuming the issue was isolated. The investigation found one path in `packages/backend/convex/domains/externalChannelMetadata/internal.ts` inserting `type: 'child'` without `organizationId`, while `emailInbox/internal.ts` and `model/threads.ts` did include or inherit orgId; the canonical URL resolver in `packages/backend/convex/model/channels.ts` also showed that child URLs normally resolve through the parent channel and only fall back to `/app/dm/...` when the parent lacks org context. That combination made the missing org on the child insert look accidental rather than intentional, especially because `args.organizationId` was already in scope and used for the metadata row right after. The lesson is that routing bugs often hide in a newer record path even when a canonical resolver still works, so it is worth tracing all related insert paths before deciding which row needs the fix.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_sAzGgFMyHe_s",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in the chat-app repo, the user asked the review skill to explicitly document the Zustand persistence pattern, not just safe localStorage access, so the guidance would steer reviewers toward the preferred implementation pattern. In response, `.agents/skills/review/SKILL.md` §24 was updated to say persisted React state should use Zustand `persist` with `createSafePersistStorage<T>()`, prefer selector hooks and stable setters for per-entity preferences, and call out the manual `useState` + `useEffect` + raw-storage pattern as the anti-pattern to replace. The lesson is that review docs should encode both the storage safety mechanism and the state-management shape, because safer persistence is only fully captured when the state container pattern is specified too.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_RNW-zDXy65km",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780519266011,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Still on 2026-05-30 in the chat-app repo, the child-channel `orgId` issue was resolved by explicitly adding `organizationId: args.organizationId` to the child-channel insert in `packages/backend/convex/domains/externalChannelMetadata/internal.ts` after the user approved with “yes add it.” The follow-up check identified the production call sites in `packages/backend/convex/domains/connections/internal.ts` and `packages/backend/convex/domains/telegram/internal.ts`, plus the test call site in `packages/backend/tests/convex/external-private-channel.test.ts`, and then `bunx tsc --noEmit` surfaced only an unrelated pre-existing `instanceof` type error in `tests/convex/telegram-external-sync.test.ts:47`. The assistant also called out a residual risk: historical child channels created before the fix still lack `organizationId`, so any consumer that reads org directly from the child row may need to resolve from the parent or backfill. The durable lesson is that adding the missing foreign key to the new write path is the correct fix, but old rows remain a migration concern whenever the application starts relying on that field for routing or authorization.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_hMLoUwT73t9k",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Still on 2026-05-30 in the chat-app repo, the removal of the kanban demo/default path exposed test and type-safety fallout that had to be cleaned up rather than papered over. The backend kanban test file was rewritten around a local `TEST_KANBAN_DEFINITION` plus a real membership helper so surviving create-task coverage still had a channel-user row, and `packages/backend/convex/domains/kanban/definitions.ts` needed its `StateMachineDefinition` import restored to satisfy `KanbanChannel`. After those fixes, backend and web `tsc` passed, oxlint was clean, `packages/backend/tests/convex/kanban.test.ts` passed 13/13, `apps/web/app/api/v1/_lib/state-machine-definition-schema.test.ts` passed 10/10, `apps/web/tests/i18n/messages-parity.test.ts` passed 2/2, and `packages/backend/registry/sandbox/default-skills/generated.ts` was regenerated via `bun run codegen:skills`. The lesson is that deleting a default path in a cross-surface feature usually requires re-seeding tests with explicit fixtures and then proving the generated registry still matches the new contract.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_RNgc8gJqQfIg",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-05-30 in the chat-app repo, the user clarified a behavior rule that kanban should not be enabled proactively: it should only be turned on if the user explicitly asks or confirms after it is proposed, and it should be used only when there will be multiple tasks of the same type with a shared lifecycle; for one-off work, a normal state machine is the right tool. That guidance was reinforced by checking the child-thread behavior in the codebase and confirming that the ordinary AI-response plus start-thread flow does not automatically create kanban cards, because kanban membership is opt-in through the kanban task path while ordinary child threads remain ordinary threads. The lesson is to reserve kanban for repeated, lifecycle-driven work rather than using it as a default thread type, and to make opt-in explicit so the user stays in control of the abstraction.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_HywTLegImrmI",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780421527452,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in the chat-app repo, the scope of the skill-target change was deliberately narrowed when the user chose to keep the adjustment limited to `duet` plus `kanban` and leave the six proxy/gateway skills (`ai-gateway`, `media-creation`, `firecrawl`, `go-to-market`, `branded-content`, `composio-credentials`) as `target: both`. That boundary mattered because the branch already had the duets/kanban flip, the kanban rewrite, and validation passing, so widening the change would have created unnecessary churn in unrelated gateway skills. The durable lesson is to treat user scope limits as hard constraints: even when a registry pattern seems broadly applicable, do not expand it to neighboring skills unless the user explicitly asks.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_BWJk7zLhDQYP",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in the chat-app repo, the kanban work started from a user request to make `/kanban` easy to reference by creating a separate default `kanban` skill that the `duet` skill could point at. The first pass created the standalone skill, wired it into the duet docs, and regenerated code successfully, but that immediately exposed a design question in `packages/backend/convex/domains/sandboxes/actions.ts`: whether the temporary `const mode = kanbanDefinition` indirection was worth keeping. The decision was to drop the one-use alias and inline the runner payload as `{ mode: kanbanDefinition }` because the only wire-level need was at `gateway.startSession`, while `kanbanDefinition` remained the domain term. The broader lesson is to keep semantic names at the domain boundary and avoid extra indirection when a value only exists to satisfy one payload field.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_YI_FlxTXj0Tw",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "After the first kanban cleanup on 2026-05-30 in the chat-app repo, a review pass surfaced stale references that would have kept the old story alive even though the behavior had already changed. The follow-up work removed an orphaned `channel-sidebar.tsx` comment about the deleted internal-only “New kanban” gate, trimmed `packages/backend/convex/domains/kanban/mutations.ts` docs to drop the obsolete `createKanbanChannel` comparison, tightened the `mode` comment in `packages/backend/convex/domains/sandboxes/actions.ts` so it only described the runner wire field, moved `FIXTURE_KANBAN_DEFINITION` below imports in `apps/web/components/playground/kanban/kanban-playground.tsx`, and fixed the “kanban kanban” typo in `packages/backend/tests/convex/kanban.test.ts`. Re-running checks showed backend and web `tsc` still clean, oxlint at 0 warnings/0 errors, tests still passing, and a repo-wide grep confirming no remaining `DEFAULT_KANBAN_DEFINITION` or `createKanbanChannel` references. The lesson is that after a feature deletion, stale comments and docs are a real form of dead code and should be removed in the same review turn as the implementation cleanup.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_7e2AstFF1XmS",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in the chat-app repo, a kanban message-list toggle was requested so kanban channels could switch between board and message view while persisting the preference per channel in localStorage, with an explicit request for a safe localStorage utility. The implementation added `apps/web`’s `use-kanban-view-preference.ts` with Zustand `persist` plus `createSafePersistStorage`, introduced `KanbanViewToggle`, added a `trailing` slot on `ChannelHeader`, and wired `chat-layout.tsx` so kanban channels switch between board and message list while the composer hides only in board mode. Verification used the web typecheck, oxlint on touched files, and 6/6 header visual tests, and the review note explicitly contrasted the new preference pattern with the older files-tab setting in `apps/web/spa/files/hooks/use-files-context.tsx`, which still used raw `window.localStorage` plus `useState`/`useEffect`. The durable lesson is that per-channel UI preferences should follow the repo’s safer Zustand persistence pattern, not ad hoc storage code, because the safe helper centralizes resilience while keeping the UI behavior predictable.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_2tubbJpTiWfd",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in the chat-app repo, the user clarified the kanban/public-API boundary by saying the kanban target should be sandbox-only because only sandbox has access to the public API, and that the same rule should apply to other public-API methods. In response, `packages/backend/registry/sandbox/default-skills/duet/SKILL.md` and `packages/backend/registry/sandbox/default-skills/kanban/SKILL.md` were both updated to `target: sandbox`, and `packages/backend/registry/sandbox/default-skills/generated.ts` was regenerated so the embedded registry reflected the new targets. The durable lesson is that target selection follows capability boundaries, not just feature names: if only sandbox can call the public API, the skill registry should encode that explicitly instead of leaving the surface ambiguous.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_IXpfaLZYIVbz",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780518730790,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-05-30 in the chat-app repo, the user clarified that the kanban board should have no built-in default and that `definition` must be required because the earlier fallback was demo-only; they then explicitly asked to remove the demo path and delete the deprecated “New Kanban” UI entry point. That steer drove a larger cleanup across backend and web: `DEFAULT_KANBAN_DEFINITION` and `createKanbanChannel` were removed, `enableChannelBoard` and `/api/v1/channels/[channelId]/board` were changed to require `definition`, the sidebar button/dialog were deleted, locale keys were removed, and the kanban playground was switched to a local fixture definition. The durable lesson is that when a feature is demo-only and the user wants it gone, the cleanup has to remove both the fallback data and every UI affordance that keeps the old path alive.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_rhjA0D51x0-0",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780421527452,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-30 in the chat-app repo, after the kanban API and docs changes were pushed as commit `5100b8a8d` on `david/kanban-enable-via-api`, the work shifted to clarifying the actual board/task entry points so the new “sandbox-only public API” rule would not be misread as the only creation path. Investigation showed kanban tasks can still be created from the web board’s Inbox-column `NewTaskCard` through authenticated `api.domains.kanban.mutations.createKanbanTask`, and also through the sandbox-only public API `POST /channels/{id}/tasks` / `publicApi/mutations.createBoardTask`; meanwhile the earlier UI affordance for enabling/disabling kanban boards had already been removed. The lesson is that a transport or visibility constraint on one creation path does not eliminate other valid entry points, so the docs and registry need to distinguish “sandbox-only public API” from “all possible task creation.”",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_BebhiHjLVazJ",
+    "createdAt": 1780421527452,
+    "lastUsedAt": 1780421527452,
+    "ageDays": 16.12155130787037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-30",
+    "timeOfDay": "17:32",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "After the kanban toggle landed on 2026-05-30 in the chat-app repo, a merge from `origin/staging` into `david/kanban-enable-via-api` revealed a consistency issue that was bigger than the toggle itself. The branch had been 18 behind / 4 ahead, local work was stashed and restored around the merge, and post-merge inspection showed `apps/web/spa/files/hooks/use-files-context.tsx` still driving `showHiddenFiles` through `useState`/`useEffect` with stringified booleans even though `apps/web/lib/storage/safe-local-storage.ts` now provided defensive safe-storage helpers. That mismatch motivated a docs-level correction rather than a code fix in the same turn, because the right durable outcome was to update the review guidance to prefer the safer persisted-state pattern. The lesson is that merge conflicts can surface architecture drift: when the codebase already has a standard safe-storage helper, review rules should teach people to use it consistently instead of leaving older raw-localStorage patterns as accidental precedent.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_V2zVgASrZp4O",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780343976172,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-27",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-27 in `chat-app`, a schema-push failure revealed that existing `sandboxSessions.stateMachineSession.definition` rows still carried a `firstState` field that the validator did not allow, so the team had to choose between strict schema purity and operational compatibility. The fix was to add optional `firstState` to `StateMachineDefinitionValidator` and document that the persisted relay shape differs from the upstream TypeScript interface, while keeping `StateMachineSessionValidator` itself aligned with the runner-owned session interface. The lesson is that Convex schema validation has to account for live rows, not just the ideal model; for externally-versioned runner-owned objects, strictness is good until it blocks deployment on data that is already being produced in the wild.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_1cQOLxv0lQcp",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780415397996,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-29",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-27 in `chat-app`, the kanban/public-API work moved from a narrow board-creation feature into a broader enablement API after the user decided the board should be an upgrade that a normal channel can gain, and then later asked for a route-based `/board` and `/tasks` surface. That led to a new public API path under `apps/web/app/api/v1/channels/[channelId]/...`, a shared kanban helper in `packages/backend/convex/model/kanban.ts`, and a prompt/skills update so the board definition is injected into the system prompt and documented for external callers. The durable lesson is that once kanban becomes a first-class capability rather than a bespoke project type, the API should expose explicit enable/disable/task endpoints and keep the board as a projection over the same channel source of truth, instead of inventing a separate channel lifecycle.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_J8PyW8GHXF0o",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780399076247,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-28",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-26 in `chat-app`, the kanban UI work became a layout-debugging loop driven by concrete visual regressions: the board overflowed horizontally, the new task button disappeared off-screen, and thread headers truncated too aggressively when relay pills were present. The path taken was iterative and evidence-based: first constraining the frame width, then adding `overflow-hidden`, then ultimately moving to an `absolute inset-0` frame contract that mirrors the messages layout so the wide `w-max` columns row cannot affect ancestor sizing; after that, the title/relay balance was tuned in `apps/web/constants/ui.ts` and a `/playground/thread-header` scenario was added to reproduce the truncation reliably. The durable lesson is that complex web layouts should be debugged with purpose-built playgrounds and explicit container contracts, because trying to patch ancestor flex behavior ad hoc just shifts the overflow bug around instead of eliminating it.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_EMPSZGgQZCl1",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780339671187,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-28",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-28 in `duet-agent`, the model-resolution path for `opus-4.8` was initially handled as a temporary `anthropic/claude-opus-4.7` clone because the upstream catalog did not yet expose the new model, but the user challenged that fallback as a smell and asked why the workaround existed at all. The response first narrowed the fallback to an explicit special case, then the upstream packages were upgraded to `pi-ai ^0.77.0`, the temporary duet-gateway workaround was removed, and `opus-4.8` became the default-facing shorthand in the catalog and CLI docs. The lesson is that transport hacks are acceptable only as short-lived compatibility shims; once the upstream catalog supports the real model, the fallback should be deleted so the code reflects the actual product surface and does not hide typos or stale costs/context windows.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_8AThgB-IgkH_",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780415796986,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-26 in the `duet-agent` monorepo, a user request to make parent-agent `run` persist prompt and parameter edits by default led to a new override flow in `select_state_machine_state`, but a review immediately exposed wording mismatches in the tool description and TUI labels. The fix was not to change the underlying behavior again, but to make the opt-out explicit with `persistOverride: false` / `(one-shot)` wording and to rerun targeted tests and evals before pushing. The lesson is that state-machine protocol work in `duet-agent` is fragile when the UX text lags the runtime semantics, so review needs to treat prompt copy and tool labels as part of the contract, not as decoration.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_T5slA3HhfHRz",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780554131853,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-29",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-29 in `chat-app`, the sandbox setup path was changed so cold starts can self-heal an outdated duet runner binary before serving turns, after the user asked for a minimum CLI version floor and then clarified that the check should be a dedicated always-run verification step rather than an `INIT_VERSIONS` entry. The solution was to add `MIN_DUET_VERSION` in `packages/backend/registry/sandbox/setup.ts`, probe `duet --version`, compare it with a shared semver helper, and force an upgrade through the existing gateway `/admin/runner-upgrade` path when the binary is below floor, while leaving the init script itself alone. The lesson is that version floors belong at the place where the system can safely recover, not in a raw install hook: the setup phase already has the gateway lock, the upgrade path, and the ability to decide whether a broken or old binary should be repaired before work begins.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Uh8maCz-1kIW",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780339671187,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-26 in the `chat-app` repo, the first major thread was a full project-channel refactor driven by a request to stop treating project channels as a separate `channel:project` type and instead make them ordinary channels carrying project state. The work moved from a dedicated type to a `mode`/definition-based shape, then immediately tightened again when the user insisted the definition itself should live directly on the channel record and later that the field should be renamed to `mode` to match runner protocol. The durable lesson is that the system should keep a single source of truth for board intent on the channel row, while the runner/session layer owns only runtime state; special cases like kanban detection should be expressed by the presence of that field rather than by parallel channel types or duplicate snapshot shapes.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_nWraN4an9JXZ",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780399076247,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-26 in `chat-app`, the user pushed the channel/project design toward minimal special cases: first asking that project threads behave like normal threads, then approving a refactor where the only kanban-specific exception lived at the kanban entry point, and later insisting that kanban logic stay isolated from message/thread machinery. This caused the backend to shed bespoke `createProjectChildChannel` paths, then later to move kanban state stamping into `createKanbanTask` alone, with message helpers returning richer message docs or IDs as needed so kanban code would not pollute the general send path. The durable lesson is that kanban should be a thin consumer of existing channel and message flows, not a parallel transport; when the feature needs an exception, the exception should sit at the UX entry point rather than inside the generic messaging pipeline.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_aT65Yhx47eUE",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780339671187,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-27",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-27 in `chat-app`, stale-session pruning and sandbox shutdown were rethought after the user reported that auto-pausing was too eager and could interfere with quick follow-up work or in-flight writes. The original immediate-stop fan-out through `maybeStopSandbox` was removed, the keep-alive cron was made more aggressive at one-third of the timeout, and then the helper `hasActiveSessions` was restored when the user pointed out it could still be useful later. The lesson is that lifecycle code should distinguish between “safe to keep around for a bit” and “actually dead,” because pausing too early is worse than leaving a sandbox idle; it can break the user’s mental model and increase the chance of data-lossy races.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_AjqyFvRuD5Dc",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780339671187,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-26 in `duet-agent`, a release/tag workflow exposed GitHub Actions drift: the release tag `v0.1.159` existed locally and remotely, but CI and release workflows had silently dropped runs for the last pushes. The investigation went through `gh run list`, workflow triggers, and a manual tag re-push, and then the team discovered CI was still failing for a different reason — `oven-sh/setup-bun@v2` could not be downloaded from codeload, while the release itself had already published `@duetso/agent@0.1.159`. The lasting lesson is that release success and CI success are separate axes: a green tag publish does not imply the workflow matrix is healthy, and if a tool download is flaky the more robust long-term fix is to remove that dependency rather than keep retriggering.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_4th4MU7Fl6Hm",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780518965067,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-28",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-28 in `duet-agent`, the `-v` CLI path looked slow enough that it was investigated as if it might be doing network work, but timing and code tracing showed the real cost was eager module loading before the version branch could exit. The fix was to add a thin `src/cli-entry.ts` that intercepts `-v/--version` before importing the heavy CLI graph, and then simplify that entrypoint so it only checks the first token instead of duplicating the whole subcommand list. The durable lesson is that “fast version” should be solved by moving the entry boundary, not by making the dispatcher smarter; if the version path still loads the world, the bottleneck is architecture, not comparison logic.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_wPb_P8l3Oibe",
+    "createdAt": 1780339671187,
+    "lastUsedAt": 1780398696758,
+    "ageDays": 17.068961782407406,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "18:47",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-26 in the `chat-app` repo, the project-channel implementation was repeatedly simplified by deleting duplication rather than layering new helpers: `createProjectChannel` started delegating to `Channels.createOrganizationChannel`, `getProjectKanban` reused `ChannelUsers.isChannelMember`, and later the kanban domain was extracted out of channels entirely into `packages/backend/convex/domains/kanban/`. The user then made the naming rule explicit — “let's also just commit to calling this kanban instead of project” — and the repo-wide rename followed, including API surfaces, comments, tests, and i18n. The lesson is that once a feature’s real shape is understood, naming and placement should be collapsed to that shape quickly; keeping old “project” wording or channel-domain ownership would only preserve ambiguity and make future refactors harder to reason about.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_jgrVnAaQS7a6",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780397311389,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In chat-app on 2026-05-26, the project-kanban query phase landed after the backend needed a way to render the new board without leaking state-machine internals. The implementation in `packages/backend/convex/domains/channels/queries.ts` created `getProjectKanban(projectChannelId)` plus `ProjectKanbanResult` / `ProjectKanbanChild` / `ProjectKanbanChildStatus`, validated that the channel exists and is `type: 'channel:project'`, and pulled children via the `by_parent_channel_updated_at_desc` index; it deliberately read `child.channel.sandboxSessionId` and fetched `sandboxSessions` directly instead of reusing `getChannelStateMachine`, because the board needed the snapshot even for terminal children and the existing query would have hidden those rows. The associated tests in `packages/backend/tests/convex/project-channel.test.ts` and the `afterEach` fix around `t.finishInProgressScheduledFunctions()` show the durable principle: query helpers should be chosen for the data shape the UI actually needs, not for abstract reuse, when reuse would filter away the very state the new surface must display.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_3aMotmN2oTRm",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780052823757,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The same duet-agent memory-reflect work on 2026-05-26 also produced a useful fixture lesson: the old `STRATEGIC_DECISION_SLICE` in `evals/fixtures/global-reflect/sandbox-memories.ts` was misgrounded because it tried to preserve `Plan mode removed`, `Hyperframes`, and `duet-gateway` facts that were not actually present in the redacted `sandbox-memories.json`, so the test was demanding hallucination. Replacing that slice with three real durable decisions from the dump—`Web Push` intentionally deferred for Convex/VAPID/fan-out reasons, the bottom-tab crossfade being removed so peer-tab navigation stays plain while drill-ins animate, and the `/use-cases` nav bundle being split from the long-form persona spec—made the strategic-decision assertions meaningful again. The lesson is that reflector evals must be grounded in the exact evidence corpus they feed on; if the slice does not contain the named facts, the right fix is to re-slice the fixture, not to ask the model to infer them from elsewhere.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_N89E7oQbGryw",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780056663608,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo on 2026-05-25 and 2026-05-26, a failing `memory-reflect` eval uncovered two separate memory-system issues: first, `src/core/structured-output.ts` was sending `gpt-5.4-mini` through pi-ai’s `openai-responses` provider where `options.toolChoice` was being ignored, and second, the reflector prompt and fixture slice were not preserving the right kinds of durable facts. The fix forced `tool_choice` through pi-ai’s `onPayload` hook using the Responses API’s flat function shape, which restored the required `reflectObservations` tool call and moved the eval from 11/5 to 13/3 and then 14/2 failing/passing as the prompt was tightened. The prompt work in `src/memory/observational-prompts.ts` was then adjusted to preserve chronology separately from identifiers and to explicitly call out durable user rules and strategic decisions; the key lesson is that structured-output failures can masquerade as prompt failures, so the first step is to restore the actual tool invocation path before tuning content quality.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_6WwUU7sCMwdB",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780052823757,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "11:07",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "When the user later asked whether `terminateStaleSessions` was covered, the answer in chat-app was already in the repo’s tests: `packages/backend/tests/convex/terminate-stale-sessions.test.ts` exercises stale `running` rows, interrupt rejection/timeouts, terminalization races, multi-row draining, the new stuck-`pending` reaping path, and the exemption for state-machine-driven `pending` rows, while `packages/backend/tests/convex/sm-recovery.test.ts` covers selection/query behavior and deduping of inactive/non-primary rows. The notable gap was not a missing suite but a missing edge assertion: the new pending-reaping branch still lacked an explicit recency-cutoff test for fresh pending rows, so the right follow-up would be to prove the 30-minute boundary still protects recently created sessions.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_YB5hszXDdh5f",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780052823757,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also in chat-app on 2026-05-26, the final `channel:project` v1 polish turned into a reminder that even a “small” visual feature needs testable presentation seams. The kanban view was refactored so `apps/web/components/project-kanban/project-kanban.tsx` exposes a presentational `ProjectKanbanView({ result, basePath, defaultComposerOpen })`, the playground mounts hand-built `ProjectKanbanResult` fixtures, `KanbanCard` now checks `useInRouterContext` before navigating so app-router playgrounds degrade instead of crashing, and deterministic `Date.now()` offsets were chosen for fixture ages to keep `date-fns` bucket rounding stable. The broader lesson is that visual-regression fixtures are much easier to keep honest when the component tree can be rendered without live query dependencies and navigation side effects.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_sSh9-jKF4UFQ",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780216728470,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "As `channel:project` v1 progressed in chat-app on 2026-05-26, the first phase exposed a wave of integration points the plan had to absorb: adding `ChannelType` for the new project surface forced exhaustive-switch updates in `packages/backend/convex/model/channelUsers.ts`, `packages/shared/src/channels/utils.ts`, `packages/shared/src/hooks/sync-engine/adapters/convex-network-adapter.ts`, and `apps/web/components/channels/channel-info-dialog.tsx`, while `packages/backend/convex/domains/sandboxes/internal.ts` gained an optional `stateMachineSession` parameter on `createSandboxSession` so the resolved definition could be seeded through the existing snapshot path instead of inventing runner plumbing. That phase mattered because it showed the project-channel architecture was really a cross-cutting data-flow change, not just a new query or UI component, and the right precedent was to thread the same state-machine definition through existing persistence seams until the system could render and replay it consistently.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_sqB1TW48DVSm",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780052823757,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-26 in duet-agent, a separate trust regression tightened that lesson further: the user rejected a literal follow-up phrasing, narrowed the pushback to “file doesn’t exist,” and asked to reproduce the default failure before fixing it again, which led to reworking `evals/state-machine-trust-user-over-sub-agent.eval.ts` around a mocked `createStateAgentHandle` path. The corrected eval makes `do_work` claim success without creating `/tmp/workflow-output.txt`, then requires the parent to trust the user’s contradiction and drive a fresh state-machine transition via `override.state.prompt` instead of merely apologizing or narrating failure. This is a durable pattern for agent orchestration: the evaluation should simulate the exact false-claim shape you need to defend against, otherwise the prompt can pass for the wrong reason and you will optimize the wrong behavior.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_nOs2BEslFVuB",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780216728470,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "During duet-agent review on 2026-05-26, the compaction path shifted from a larger architectural experiment to a simpler invariant after the user said they did not need the last user message preserved, that the fix could be made by editing the fixture instead of special-casing recovery, and that the result should be net less code. The final branch consolidated `/compact` and the automated context-overflow path around a shared best-effort drain helper, removed the separate `noopEnsureCoverage` plumbing, made `findEvictionHorizon` synchronous again, and deleted the extra async transform test because the complexity did not justify itself once the invariant was spelled out as “drain if you can, warn and continue if you can’t.” The lesson is that user steers about simplicity are not just preference—they can invalidate an earlier technically elegant design and force the implementation back toward explicit, caller-owned behavior.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_aPRdgUL5u_2-",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780052823757,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-26 in the chat-app repo, the project-kanban branch picked up a final cleanup pass after review found a dead `sandboxSessionId` existence check, a duplicated literal union for child status, and placeholder channel-info copy that the user did not want to leave as technical debt. The branch in `packages/backend/convex/domains/channels/queries.ts` now derives `ProjectKanbanChildStatus` terminal values from `ProjectChannelTerminalStatus` and drops the redundant `'sandboxSessionId' in childChannel` guard, while `apps/web/components/channels/channel-info-dialog.tsx` uses dedicated `typeProjectLabel` / `typeProjectDesc` keys with matching `en` and `es-419` translations. The lesson is that v1 polish matters when it codifies the real model rather than carrying temporary branches forward, especially when the user explicitly says they want no tech debt even in the first ship.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_RNiEtaWxmm09",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780052823757,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The same duet-agent compaction review also surfaced a trust/ownership principle that got baked into the prompt stack: the user wanted the parent orchestrator to review sub-agent responses and not treat them as truth, so `src/turn-runner/prompts.ts` and `src/turn-runner/turn-runner.ts` were updated to frame sub-agent output as a claim that must be spot-checked before being propagated or transitioned on. A later refinement moved the retry instruction and everything after it into a `<system-reminder>`, and the state-machine trust eval was eventually rewritten to mock the worker so the parent had to choose corrective state-machine action when the user contradicted the child’s claim. The durable lesson is that when an orchestrator delegates work, the parent’s job is verification and correction, not transcription; the prompt must make that explicit or the control flow will drift into trusting the delegate by default.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_l_QU5ZWBWpKq",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780052823757,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "On 2026-05-25 in the chat-app repo, a stuck-pending sandbox-session report led to tracing a crash window between `prepareCronTaskSession` and `startSession`: older gateway builds could insert a `pending` row and die before flipping it to `running`, which left non-state-machine sessions counted as active forever and even blocked concurrency by consuming `MAX_CONCURRENT_SYSTEM_SESSIONS_PER_SANDBOX`. The fix widened `getStaleSessions` in `packages/backend/convex/domains/sandboxes/internal.ts` to include non-SM `pending` rows older than the 30-minute cutoff, and `terminateStaleSessions` in `packages/backend/convex/domains/sandboxes/actions.ts` was taught to accept `pending` for the `inactivity` reason, re-read before failing, and persist `Session never started: gateway likely crashed before runner launch`. The durable lesson is that stale-session reaping has to reason about crash-before-start as a first-class terminal path, not just a running-session timeout, because the same state can otherwise silently poison capacity accounting.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Cnmwak7Gwcqw",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780052823757,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "By 2026-05-26, the chat-app `channel:project` work had reached a terminal, almost-shippable state around PR #1552, and the open-time checks made the release posture clear: local typecheck/lint/tests were green, `Vercel Preview Comments` and `Vercel – chat-app-sandbox-gateway` passed, but `build-and-test` and the main chat-app Vercel deploy were still pending, so merge was intentionally deferred. The branch summary captured a six-commit stack covering the hardcoded v1 state machine, `getProjectKanban`, seed plumbing through session metadata and runner `mode`, the kanban UI, and visual fixtures/baselines, with the remaining follow-ups explicitly left for later: card metadata, inline editor/version bump, template picker, drag-to-transition, and archive view. The durable lesson is that a feature can be functionally complete enough for review while still being intentionally not merged if CI and outstanding product questions remain; those pending gates are part of the decision, not noise.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_eFU4crCnGrMK",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780052823757,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "11:07",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Also on 2026-05-25 in chat-app, review cleaned up the first stale-session fix by removing a small per-candidate allocation in `terminateStaleSessions` and replacing it with a direct boolean invariant, because the real rule was simpler than the temporary helper suggested: non-primary sessions may only be reaped from `running`, while the `inactivity` path may also accept `pending`. The review deliberately kept the split stale-session filters in `getStaleSessions`, since the reference-time logic genuinely differs (`updatedAt ?? startedAt` versus `startedAt`), and it reinforced a useful practice: comments should explain why the filter split exists, not merely narrate the code shape.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_gjFPdDTZt0ML",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780216728470,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Later on 2026-05-26 in chat-app, the project-channel seed path was audited and the bug was found in the seam between backend actions and the gateway: the state-machine seed had been stored on `sandboxSessions.stateMachineSession` but never forwarded into the gateway→runner start path, so resumed turns could lose the project definition. The fix threaded that seed through `packages/backend/convex/domains/sandboxes/actions.ts`, `packages/agent-gateway/src/types.ts`, `packages/agent-gateway/src/routes/admin.ts`, `packages/agent-gateway/src/session-controller.ts`, and `packages/agent-gateway/src/session-store.ts`, so the runner now replays the definition as `mode` on every start. The lesson is that persistence alone is not enough for resume semantics; anything that should survive restart has to be carried all the way through the control plane, or the system will quietly forget the mode that was written correctly in storage.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_WCuOjnCrmVYV",
+    "createdAt": 1780052823757,
+    "lastUsedAt": 1780395293927,
+    "ageDays": 20.388955185185186,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-26",
+    "timeOfDay": "11:07",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the chat-app repo on 2026-05-26, the user started a much larger `channel:project` feature by asking for a project-channel surface where every request starts a new thread, AI always responds, the UI becomes a kanban board, and v1 should be fully specified before implementation. The design questions surfaced two important constraints: the channel should use a single hardcoded default state machine with no picker/editor, and project behavior should be backend-first rather than a separate shared package, so the implementation was planned as a fresh PR/branch off `staging` that would keep the state-machine definition server-side and embed it into the kanban response and runner seed payload. The durable lesson is that when a product surface spans backend, gateway, and UI, the cleanest v1 may be to centralize the definition on the server and keep the client presentational, especially when the user explicitly wants the thread-creation contract to stay simple.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_SiIKczO2dKRZ",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779998095412,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the user wanted explicit safety around concurrent access to `~/.duet/memory.db`, and that request ended up shaping both auto-upgrade and manual upgrade behavior. I first added a skip path in `src/cli/auto-upgrade.ts` using `peekOpenLockHolderPid()` from `src/memory/pglite.ts` so auto-upgrade now emits `skipped: memory-in-use` before registry probing when another duet process holds the lock; then I mirrored that same gate in `src/cli/upgrade.ts`, with `--dry-run` staying ahead of the check and `--force` as the explicit override. The user also asked for the same protection on explicit `duet upgrade`, so I documented the new flag in `src/cli/help.ts` and covered the gate, `--force`, and dry-run bypass in `test/upgrade-command.test.ts`. The durable lesson is that destructive or side-effecting maintenance commands should fail fast on shared-state contention unless the user deliberately opts into the risk, and the data-dir path should come from one canonical source rather than being rederived in each command.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_NV0bUELeBnwE",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, a review of `packages/agent-gateway/src/ensure-runner-binary.ts` found a race in the runner upgrade/install path that only appears when stale staging directories are cleaned before the coalescing install lock is held. I checked out the PR branch, rebased it onto `origin/staging`, and traced the failure path through the staged install code until it was clear that `cleanStaleStagingDirs(scopeDir)` could race a concurrent rename mid-install. The fix moved the stale-dir sweep inside `runNpmInstall` so the lock owns cleanup too, and the review passed after `bun --filter @repo/agent-gateway check-types` plus the focused `ensure-runner-binary` test run. The lesson is that cleanup and installation are not separable concerns when they touch the same staging area; if the lock does not cover both, the “maintenance” step can become the race that breaks the install.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_gRmtx78g-ZaX",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-24",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, a review of the reflector’s behavior showed that the system was buffering and re-feeding far more memory than the user expected, so I inspected `src/memory/observational.ts`, `src/memory/observational-prompts.ts`, `src/types/memory.ts`, and the memory budget tests to understand the actual trigger and limit. The key finding was that the reflector receives the whole observation log concatenated without a separate input cap, while the active bound is the reflection trigger (`reflection.observationTokens`), so the earlier idea of “40% of original size” was implemented as `REFLECTION_BUFFER_RATIO = 0.4` plus a test update to `reflection.bufferActivation: 26_000`. Later, when the user asked for an even safer compaction fix, I changed `findEvictionHorizon` to await an async coverage hook and made `ensureMemoryCoverageForCompaction` retry once before evicting anyway, because the user explicitly preferred “retry and evict anyways” over stalling compaction. The durable lesson is that memory protection should keep the budget invariant hard, but coverage/observer hooks are best-effort and should never block the system from making forward progress.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_9YHXhwhWChql",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the user asked for the reflector to be more aggressive, and that request eventually clarified how compaction should behave under budget pressure. I first learned that `reflectObservations` in `src/memory/observational.ts` takes the full observation log as context and that the real bound is the reflection trigger, not a separate input cap, so I introduced `REFLECTION_BUFFER_RATIO = 0.4` and updated the memory budget tests to match a 40% reflector buffer. Later, when compaction itself became the focus, the user specified that if the observer hook errors or times out we should “retry and evict anyways,” so I made `findEvictionHorizon` async, added `ensureMemoryCoverageForCompaction`, and kept budget compliance hard while allowing coverage failures to degrade to a warning instead of a stall. The durable lesson is that observability hooks are best-effort, but budget enforcement is not: the system should make room first, then try to preserve context, rather than letting preservation logic block forward progress.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_YBGsE-csA62U",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the user repeatedly steered the sandbox-session cleanup flow away from passive background recovery and toward explicit user-facing behavior for cap and credit failures. After `createSandboxSession` began rejecting over-cap work with `ConvexError`, I wrapped `processChimeIn` in `packages/backend/convex/workflows/chat/chime.ts` so a cap hit now posts an `ai-system` channel message and returns `shouldChimeIn: false`, instead of silently failing in a background workflow step. When the user asked what would happen if a channel had no sandbox and the cap was hit, the answer was that the message would post but the reply could otherwise vanish; the system-message path exists specifically to surface the failure in-band, matching the earlier paused/canceled/banned behavior. The durable lesson is that invisible workflow failures are a bad fit for chat UX: if the user is waiting on a reply, business-rule failures should become channel-visible system messages rather than only log entries.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_bSiA9VDXav5Q",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-24",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the sandbox keep-alive and wake/terminate flows all started from the same symptom class: cron loops were too slow and too fragile for the new timeout policy, so I inspected `packages/backend/convex/domains/sandboxes/actions.ts` and found sequential processing and noisy failure semantics. I first replaced hand-rolled chunking with `p-all` for `processDueWakePlans`, `keepAliveSandboxes`, and later `terminateStaleSessions`, keeping bounded concurrency but switching to `stopOnError: false` where the user explicitly said “for both - a thrown error shouldn't stop it”; I also added the `process-due-wake-plans` regression test file to pin down stale-plan skipping, billing-gated skips, failure recording, and mixed-branch draining. When a review found stale comment wording and redundant budget commentary, I tightened the comments rather than changing behavior, because the important durable fact was the cron budget and not the historical incident narrative. The lesson in `chat-app` is that system cron paths should be designed for throughput and partial failure tolerance first; once the behavior is correct, comments and tests should be pared back to the reusable invariants rather than the debugging trail.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Ir9jttNxwjHY",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the same memory-debug effort exposed a second failure mode: auto-upgrade could corrupt `~/.duet/memory.db` if another duet process was still holding the database open. The user reported that one CLI auto-upgraded while another was active, so I first captured the fresh quarantined copy as the best source of truth, then added `peekOpenLockHolderPid()` in `src/memory/pglite.ts` and wired `runAutoUpgrade()` in `src/cli/auto-upgrade.ts` to skip with `skipped: memory-in-use` before any registry probing. The user then asked for the same gate on explicit `duet upgrade`, so I added it in `src/cli/upgrade.ts` with a `--force` escape hatch, preserved `--dry-run` ahead of the gate, and covered the behavior in `test/upgrade-command.test.ts`. The durable lesson is that upgrade paths touching shared local state need to respect the lock as a hard precondition, and any override must be explicit enough that the operator understands they are choosing risk over safety.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_cYs26hlmp-d-",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, a release and review pass around model resolution revealed that Duet-hosted OpenAI-prefixed models were being routed through the Anthropic-compatible gateway path, which would strip OpenAI reasoning/thinking-trace behavior. I reproduced that with a red eval at `evals/openai-thinking-tracks.eval.ts`, then patched `src/model-resolution/duet-gateway.ts` so `gpt-5.5` and similar OpenAI-prefixed models resolve to the OpenAI-compatible API path while Anthropic models continue on the Anthropic path. I also locked the behavior down in `test/cli.test.ts`, asserting the exact `duet-gateway` / `openai/gpt-5.5` / `api:",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_D5Ui42aL0KE4",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779997672391,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, a Convex warning about `updateSandboxSession` reading 31,756 documents surfaced a less obvious hot-path problem: the active-session probe was scanning the entire `by_sandbox` index and filtering for `running|pending`, which made terminal rows expensive even when only one live session mattered. I checked whether `maybeStopSandbox` already performed the same check, confirmed the probe was redundant, and then removed the duplicate stop gate from `updateSandboxSession` while moving the real active-session lookup to a new `by_sandbox_state` index in `packages/backend/convex/schema.ts` and `packages/backend/convex/domains/sandboxes/internal.ts`. The same index-first pattern was then reused for other callers like `getActiveChannelSessionStates`, and dead code such as `getActiveSandboxSessions` was deleted rather than optimized because it had no callers left after PR #1017. The lesson is that when a read path is only asking “is anything active?”, the schema should let you answer that question directly; otherwise the cost of older terminal history quietly becomes the bottleneck.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_XYppKgK4LyWm",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1780053237431,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, a prod incident with many sandbox sessions stuck `running` and almost no messages turned into a root-cause hunt across gateway startup, Convex session reaping, and E2B sandbox lifecycle. The first pass found that the leaking rows were system-originated sessions (`userId: undefined`) created by `prepareCronTaskSession`, while `getNonPrimaryRunningSessions` and related reaper logic intentionally skipped those rows, so they could accumulate until much later stale-session cleanup; subsequent investigation tied the spike to a May 20 reaper change (`c73291df1`) that widened that exemption and to a crash-loop in old gateway builds where missing `duet` binaries caused repeated startup failures. The fix path then layered several protections: the gateway was hardened to treat async child-process spawn failures as normal exits, `prepareCronTaskSession` gained a preflight-credits gate so it skips creation when the org can’t pay, `wakeSandboxSession` was taught to bail before provisioning when credits are low, and the backend gained per-sandbox caps plus a migration-based drain for stuck system rows. The durable lesson is that this flow needs source-side prevention, not just reaping: if the gateway, credit gate, and cleanup all rely on later recovery, a small runtime failure can become a large, expensive backlog.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_3xRaZpbwFvKy",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779998632999,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the internal admin servicing-status override UI started as a narrow restoration flow, but the user pushed it toward a more general “restore to activated” action that matched the backend validator’s full state set. I first confirmed the mutation already accepted `activated`, `paused`, `canceled`, and `banned`, then updated `apps/web/spa/internal-admin/route.tsx` so non-activated orgs can be restored to `activated` from the panel with a confirm dialog that distinguishes clearing a ban from restoring other statuses. When the user later said “just do the refactor,” I consolidated the servicing-status literals into a single shared validator/type in `packages/backend/convex/schema.ts`, removed the duplicate inline unions from the backend and UI, and then moved the model type into schema because that is where canonical schema definitions belong. The durable lesson is that status enums used across admin UI and backend validators should have one authoritative definition; otherwise the drift surface is small but inevitable, and the UI will eventually encode a different truth than the API.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_9Jk4fecPiaNQ",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-24",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the user wanted live eval guidance after adding a `wakeAfterMs` timer eval, so I first verified that the new eval was typechecked and linted but had not yet run against a model. Running it exposed a chain of environment and assertion issues: one attempt failed with a 401 from Vercel AI Gateway because Docker was forwarding stale `AI_GATEWAY_API_KEY`, then the eval passed only after switching the container wiring to `DUET_API_KEY`, and the assertion had to be relaxed because the relay correctly enters `sleep` immediately when `firstState` is used. I also added `evals/timer-wake-after.eval.ts` and documented the pattern in `AGENTS.md` under a new “Writing Live Evals” section so future evals remember the container auth, first-state, and single-file execution constraints. The lesson is that live evals are mostly plumbing-sensitive; the model behavior may be correct even when the first run looks like a failure, so the harness and environment need to be treated as part of the test design.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ZvHtWwZHmEgR",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the “thinking traces” regression was initially easy to misread as a model-routing bug, but the user’s pushback forced a deeper look at the wire-shaping path and the local observation store. I traced `TurnState.wireGuardHorizon` through `src/session/session.ts`, `src/turn-runner/turn-runner.ts`, and `src/turn-runner/wire-shaping.ts`, then exported `~/.duet/memory.db` into `evals/fixtures/session_VO5yjfS1vV6_/memory-dump.json` and built `evals/helpers/capture-wire-payload.ts` to reproduce the exact dispatched `AgentMessage[]`. That harness showed the real problem was not “no raw history exists” but “local pack lag plus aggressive eviction”: the transform can evict the transcript before the reflector writes a fresh local observation, leaving the model with stale memory plus a continuation hint and no intervening user context. The durable lesson is that memory failures often come from timing and retention boundaries interacting, so the right repro tool is an exact wire-payload harness, not just a fixture of the visible transcript.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_NwOkEsaxK8-3",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the user’s question about when the runner upgrade happens led to a useful clarification that the upgrade is cron-driven rather than tied to every spawn. I checked `packages/agent-gateway/src/cron-config.ts` and confirmed `upgrade-runner` runs every six hours on an epoch-aligned grid, then noticed the user’s pushback that it should stay separate from heartbeat and memory jobs; that prompted an `anchorMs: hours(1)` shift so the upgrade lands at 01:00/07:00/13:00/19:00 UTC instead of colliding with the midnight heartbeat slot. I also updated the scheduler test to pin the new anchor, because the important invariant is not just the period but the slot separation from other cron families. The durable lesson is that cron systems need both cadence and phase management; if jobs share the same anchor they can create hidden resource contention even when the periods look harmless on paper.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_AB3nvq3R_A6t",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, a follow-up memory-debug pass showed that the apparent context-loss bug was really about the interaction between raw-message eviction, local-pack lag, and the in-session reflector. The user asked whether the harness should dump all observations from the failing session, so I loaded the live `~/.duet/memory.db` into `evals/fixtures/session_VO5yjfS1vV6_/memory-dump.json`, built `evals/helpers/capture-wire-payload.ts` to replay the exact production memory/wire-shaping path, and then wrote `evals/session-compaction-wire-starvation.eval.ts` to reproduce the starvation shape. That work showed the dispatched payload was dominated by two synthetic `<system-reminder>` messages while `retainedMessageCount` was zero and the model saw no real user intent, so I also updated `.agents/skills/debug-memory/SKILL.md` to explain how to reproduce a wire payload from a session dump. The durable lesson is that memory bugs are often only reproducible when you include the full store, not just the visible transcript; the replay tool must mirror the production transform exactly or you will diagnose the wrong layer.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Sz-Sgx9ntYXg",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-24",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, a question about whether answering pending questions should “reset” the list turned into a useful distinction between terminal-event payloads and persistent session state. I traced `Session.answer()` and `TurnRunner.answer()` in `src/session/session.ts` and `src/turn-runner/turn-runner.ts`, then checked `src/tui/question-picker.ts` and `src/tui/session-subscription.ts` to see where questions are actually rendered. The outcome was that `ask` questions live on the terminal event, while the picker’s local `pendingQuestions` state is cleared when the picker hides; the user later backed away from collapsing that into a generic `TurnState` field, saying it was “a terminal event” and that the simpler hidden-state path was the right shape. The durable lesson is that some data should reset by being replaced at the next turn boundary, not by adding new persistent state that would blur event semantics.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_F703dFrx1Mf5",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779991429412,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-24",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, lowering the sandbox idle timeout from five minutes to one minute initially seemed like a simple constant change, but measuring `keepAliveSandboxes` showed the action took about 141.6s and was already far too slow for the new budget. I traced the runtime to a fully sequential loop over sandboxes, then reverted `DEFAULT_SANDBOX_TIMEOUT_MS` back to five minutes at the user’s request and parallelized the keep-alive path with bounded concurrency, first with a hand-rolled worker pool and then with `p-all` when the user said they prefer existing concurrency libraries. The same pattern later applied to `processDueWakePlans` and `terminateStaleSessions`, and I kept the cron interval tied to the timeout only as long as it remained comfortably below the measured runtime. The durable lesson is that timeout policy must be driven by measured p95/p99 execution time, not intuition; if the maintenance loop can’t comfortably stay under half the timeout, concurrency or the interval itself has to change before the timeout can be reduced.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_aQPe4UAs7AQL",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779995123731,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-25",
+    "timeOfDay": "15:09",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the incident around `sandboxSessions` stuck in `pending` revealed that “no used session should stop on its own” is not a useful assumption for the current lifecycle logic. I checked `packages/backend/convex/domains/sandboxes/actions.ts` and `internal.ts` and found that `maybeStopSandbox` only pauses sandboxes after sessions become terminal, `keepAliveSandboxes` only refreshes sessions that are already running, and `getStaleSessions` only reaps old running rows, which leaves stale `pending` system rows in a gray zone. The user then asked whether an unused sandbox will ever stop on its own, and the answer was that E2B may pause the sandbox eventually, but Convex session rows can still remain pending indefinitely and keep the sandbox counted as active. The durable lesson is that lifecycle cleanup must account for every non-terminal state, not just the obvious running ones; otherwise “stuck pending” rows can prevent reaping logic from ever seeing the sandbox as idle.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_31jAJNOJo9sx",
+    "createdAt": 1779980975982,
+    "lastUsedAt": 1779980975982,
+    "ageDays": 21.22052665509259,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-24",
+    "timeOfDay": "15:09",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, a backup sandbox failure reported as bare `CommandExitError: exit status 1` exposed a mismatch between the E2B client API and the backup action’s assumptions. I traced the failure to `packages/backend/convex/domains/backup/actions.ts:391`, where the code used `sandbox.runCommand(...)` for the Python export script and then tried to inspect `zipResult.exitCode`, even though `packages/services/src/e2b-sandbox/client.ts` throws `CommandExitError` on non-zero exits. The fix was to switch to `runCommandNoThrow` and rethrow a detailed error that includes the exit code and stderr (`Failed to create sandbox backup archive (exit N): ...`), so the next failure will reveal the actual Python cause instead of an opaque transport-level exit status. The durable lesson is that if a caller wants to inspect stderr or branch on failure semantics, it must opt into a no-throw command API; otherwise the exception boundary hides the very debugging data the user needs.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_AzjG8vlM0xW-",
+    "createdAt": 1779811408464,
+    "lastUsedAt": 1779811408464,
+    "ageDays": 23.18311366898148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-23",
+    "timeOfDay": "16:03",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` workspace, the user was not asking for a product change but testing post-compaction behavior by asking what was still in the assistant’s current context window. The response deliberately summarized the visible session state — including sandbox-path work in `chat-app`, recent `chat-app`/backend changes, and the fact that the raw pre-compaction transcript is not retained verbatim — rather than pretending to recover full lost history. The decision to answer at the level of what remained observable, instead of overclaiming exact pre-compaction text, reflects the constraint of compacted context: once the transcript is gone, only the retained summary and current session state can be reported honestly. The durable lesson is that post-compaction queries should be answered with explicit bounds on what is still visible, because precision about the limit is more useful than confident reconstruction of erased details.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_S1twSOsTbTzH",
+    "createdAt": 1779811408464,
+    "lastUsedAt": 1779811408464,
+    "ageDays": 23.18311366898148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-23",
+    "timeOfDay": "16:03",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` repo, a question about whether `/compact` was actually pruning observation blocks surfaced a subtle but important distinction between wire history and memory history. By tracing `src/turn-runner/state-compaction.ts`, `src/turn-runner/turn-runner.ts`, and `src/tui/slash-commands.ts`, the work established that compaction is a wire-horizon operation: it drains observations first, refreshes the memory context pack, and then selects a new `evictionHorizon` from the surviving wire-tail token target. The key decision was not to treat observations as ordinary messages to be deleted for budget pressure; instead, observational-context messages are stripped when the cut is searched, while the memory-pack budget handles them separately and compact only refreshes that prefix once. The durable lesson is that compaction in `duet-agent` is about re-anchoring the conversation boundary, not erasing memory blocks, so future fixes should reason about the wire budget and the memory budget as separate mechanisms rather than assuming one controls the other.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_uvQ5wdYMVjxS",
+    "createdAt": 1779811408464,
+    "lastUsedAt": 1779811408464,
+    "ageDays": 23.18311366898148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-23",
+    "timeOfDay": "16:03",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` repo, concern that long conversations might keep inflating context led to a direct check of the local-observation retention rules rather than guessing from the compaction flow. The investigation landed in `src/memory/observational.ts`, where local observations are capped by `MEMORY_BUDGET_RATIOS.observationTokens = 0.325` of effective context and a reflector compacts them once that ceiling is exceeded, while `GLOBAL_CONTEXT_TOKEN_BUDGET = 8_000` keeps cross-session memory on a separate fixed budget. The decision embodied there was to rely on explicit budget ratios and a dedicated reflector instead of letting observation growth ride on the main turn-compaction path, because that keeps local accumulation bounded even in very long sessions. The lesson is that the memory system already has two independent guardrails — one for local observations and one for global context — so the right debugging instinct is to check which budget is being exercised before assuming unbounded bloat.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_20CdH94ByfSj",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` TUI dino refactor also needed a comment cleanup because the old prose still described the pre-refactor “while-you-wait” behavior. The review updated `src/tui/dino/index.ts`, `src/tui/layout.ts`, and `src/tui/key-handlers.ts` so the comments now match the current always-Ctrl-G mount point contract instead of the old busy/expanded lifecycle. The lesson is that when a UI feature is re-scoped, stale lifecycle prose can be as misleading as stale code, so the comments should move with the behavior or they become a second source of bugs.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_fpBJSWPK-oW7",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` `/compact` feature was initially introduced as a protocol command with a byte limit, but the user pushed back that if the goal is to reduce context usage by half, the command should not accept a caller-supplied ceiling. That prompted a redesign to a parameterless `compact` command with token-based compaction helpers, then another refinement when the user pointed out that the runner already shapes context by transforming agent messages rather than deleting them. The final design advances the wire-shaping eviction horizon, drains observations before moving the horizon, persists `wireGuardHorizon` across TUI exit/resume, and keeps `compact` separate from `turn()` so a non-model side effect does not masquerade as a turn. The lesson is that compaction is a wire-shaping concern, not a transcript-editing one: preserve the durable transcript, shrink only the next wire-visible tail, and keep the turn chain contract intact.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_9vwoKg_GKO-s",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` judge-model issue was not a model-quality bug so much as an environment mismatch: the shared judge helper had hardcoded `anthropic:claude-opus-4-7`, which broke Docker evals with auth-resolution errors. Switching the judge to the shorthand `opus-4.7` let provider resolution route through whichever credentials were actually available in the environment—gateway when `DUET_API_KEY` is present, Anthropic direct on a laptop—without changing the eval semantics. The lesson is that eval infrastructure should use provider-agnostic shorthand when the transport is meant to float across local and Docker environments, otherwise the judge itself becomes the thing under test.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_lW1TLNNdmEm6",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `chat-app` migration cleanup was not about behavior change but about keeping the codebase honest after a long-running staging branch accumulated dead migration exports. The review confirmed that none of the removed migration names were referenced anywhere, so `packages/backend/convex/migrations.ts` was pruned down to three example migrations and the old exports/imports were removed, with a header comment telling future readers to use git history for deleted migrations. The lesson is that migration files can become a museum of completed work unless the repository periodically trims them back to the few examples that still teach something.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_g10Nv-ClPxuW",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779980026760,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The right-bar panel then evolved from a static Memories surface into a Timeline/Relay shell because the user wanted the tab bar nudged upward, the header renamed to “Timeline,” and Relay made the default when available. The first implementation caused a flash of Memories before Relay because `useChannelStateMachine` was null on the initial render, so the fix changed `channel-actions-panel.tsx` / `channel-actions-panel-view.tsx` to render optimistically while relay data loaded and preselect Relay until the absence of a relay was confirmed. The lesson is that default-tab logic in a loading UI has to be monotonic from the user's perspective: it is better to snap once than to flash the wrong state and then correct it.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_QJDOk7W3YxIk",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779979284421,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The same right-bar work later produced a regression where Relay auto-selection stopped working, and the repair in `apps/web/spa/chats/components/channel-actions-panel-view.tsx` restored a two-direction effect keyed only on `hasRelay` / `relayLoading`: snap `memories -> relay` when Relay appears, and `relay -> memories` only after loading resolves and Relay disappears. That small asymmetry matters because it prevents the optimistic loading state from fighting the real data arrival while still letting the UI recover when Relay truly does not exist. The durable pattern is to keep loading-state transitions directional and to separate “data appeared” from “data disappeared” so the interface feels deterministic instead of sticky.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_xhx3XP66y3rR",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The model-selection sweep in `duet-agent` was useful because it showed that upgrading the judge or model family does not automatically solve recall behavior. Comparing `sonnet-4.6` to `opus-4.7` on the recall evals showed Opus doing worse overall even though it remained good on negatives, and the analysis pointed to tool-call eagerness rather than raw reasoning quality as the bottleneck. That led to the recommendation that the next productive steps are a proper-noun classifier or active recall on send, not just another model bump; the lesson is to distinguish “can think” from “can decide to call the tool” before changing the model tier.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_8wMtcZa9WR2L",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779798329512,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The memory recovery work in `duet-agent` ended up adding operational tooling because the user needed a way to restore a quarantined database without losing the fresh replacement file. A helper script, `scripts/restore-memory.sh`, was added to refuse restoration while a live process still held the DB, preserve the displaced fresh DB as `memory.db.fresh-pre-restore-<stamp>`, and swap the newest `memory.db.corrupted-*` or `.backup-*` directory back into place. The lesson is that once the app starts quarantining local state, the recovery story itself becomes part of the product and needs a scriptable, audited path rather than an ad hoc manual rename.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_MV9hXYv2u4Dg",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779798329512,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` memory backup policy then grew more conservative after a user objected that taking snapshots before a successful open could poison the backup pool with a WAL-corrupted cluster. The implementation was moved so backups are only taken after a successful `openAndProbe` plus best-effort `CHECKPOINT`, and the pool rotates to the five newest verified-readable copies instead of keeping unbounded history. The higher-level lesson is that backup rotation is only useful if each snapshot is proven readable; otherwise you are just preserving corruption more efficiently.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_kwF0I_r2N9ZP",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In `duet-agent`, the first major state-machine work came from a real model-behavior bug: `select_state_machine_state` was emitting invalid `decision.kind` values like `Select`, `State`, and `Continue`, and the runner's generic union validation only produced a vague `Expected union value` error. The fix path was to make the schema itself spell out the allowed literals (`run_state | terminal | fail`) and reject invalid kinds with a clear tool-result error, which the eval `evals/state-machine-decision-kind.eval.ts` proved by going green after the change. The higher-level lesson is that if the model is guessing between near-synonymous verbs, the schema and error text need to tell it the exact accepted vocabulary; otherwise the model will keep probing the same dead branch.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_zr5m9UppJQHW",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779977431007,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "A later eval sweep in `duet-agent` found that `evals/cli-paths.eval.ts` was failing because judge calls to `opus-4.7` were mutating the parent process's auth state, and the spawned CLI inherited a Duet token it should not have seen. The fix was to clear both `DUET_API_KEY` and `AI_GATEWAY_API_KEY` in the eval spawn env, then later to standardize on `--no-skill-sync` instead of env hacks so the CLI-spawning evals still exercised gateway auth without syncing skills as a side effect. The durable lesson is that CLI evals should isolate the behavior under test from ambient auth mutations and side-effectful startup syncs; otherwise an eval can fail for the wrong reason and teach the wrong workaround.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Exp-c2s3TKSq",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779823496907,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` eval sweep also exposed content regressions in `memory-reflect-units.eval.ts`, which meant the prompt engineering for reflection rows was underfitting the user's requested memory shape. The failures called out missing user-steer coverage, insufficient alternatives-considered coverage, and duplicate insight pairs, which is exactly the kind of drift that happens when a reflection prompt is optimized only for passing tests rather than for atomic narrative quality. The lesson is that memory reflections need content-level evals that punish shallow paraphrase and duplicated insights, because structural correctness alone does not guarantee durable memory usefulness.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_2cB2mRnzWm48",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779798329512,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The retry/restore path for E2B sandboxes in `chat-app` was then tuned more carefully once the user pointed out that snapshot restore itself can be slow and should not be confused with a normal create. The fix gave `restoreSandboxSnapshot` a longer 180s ready budget while normal create/setup stayed at 30s, and the same codebase now treats a restore as a distinct, slower lifecycle that may need more time to bring the gateway externally ready. The lesson is that restore-only flows deserve separate time budgets from cold starts, because a restore can be slower even when everything is healthy and a too-short budget would turn a recoverable state into an unnecessary failure.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_twDgqn0lYSpX",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779954560555,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The same state-machine investigation in `duet-agent` then went further and removed the free-form `decision.kind` field entirely because it turned out to be mostly redundant. Inspection of `src/turn-runner/state-machine-controller.ts` showed dispatch already keys off the selected state's own kind, so `run_state` was the only branch with unique semantics and `terminal`/`fail` were just alternate ways of finishing the chain. The refactor changed the protocol to accept only `{ state, reason?, override?, input? }`, updated formatter/tests/evals, and kept the invalid-state failure path generic; the lesson is that a field should only survive if it encodes an invariant that the downstream dispatcher cannot already derive, otherwise it just gives the model another knob to guess wrong.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ctOs6CN0RMvB",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` CLI gained home-directory expansion because the user discovered `--workdir` accepted `~/xyz` only when the shell expanded it first, which is fragile for RPC and direct invocation. The fix introduced `expandHomeDir(path)` in `src/cli/shared.ts`, applied it to `run.ts`, `rpc.ts`, and `skills.ts`, and added tests for tilde, absolute, relative, empty, and unsupported `~user` forms so the behavior stayed consistent across entry points. The durable lesson is that path normalization belongs in shared CLI code, not in per-command parsing, especially when the same workdir value is used by multiple front doors.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_9gyxewmDi4Y2",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "A separate `duet-agent` eval (`evals/state-machine-relay-output-to-user.eval.ts`) was added after the user complained that the parent prompt was suppressing normal replies and only surfacing tool calls and thinking blocks. The investigation confirmed `turn-runner.ts` still told the agent “Do not answer normally,” which meant background state-machine work could finish without relaying the visible artifact back to the user; the fix loosened the prompt so status questions from a finished state are answered in plain text while still requiring the `select_state_machine_state` tool call to end the turn. The lesson is that a runner can still enforce tool completion without silencing user-facing status; the user should see the output of the work, not just the protocol bookkeeping.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_nEKUJIDm_EJb",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779977783060,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` workdir handling eventually led to a clearer invariant in the web app: `supportsAgentWorkDir` was deleted because the user objected that it was overcomplicated and said every non-child channel should support workdir. The investigation showed the real rule was just `!isChildChannel(channel.type)` for the visible workdir UI, with child threads inheriting their parent context while other channels can still have their own workdir. The lesson is that a named allow-list helper is only worth keeping if it captures a non-obvious policy; once the policy collapses to a simple predicate, the helper is dead weight and the code should say the invariant directly.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_fz1xJrA4BLzx",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In `chat-app`, the visual-regression pipeline was intentionally trimmed to stay reviewable after the user objected that `ui:approve` was rewriting every PNG baseline. The fix changed `packages/web` so `visual:approve` uses `--update-snapshots=changed` instead of `--update-snapshots=all`, and later the team inspected the actual stale screenshots to distinguish real output drift from noise. That investigation showed the changed PNGs were genuine—some came from the reset-session copy change, others from agent-id and share-dialog rendering—and the baselines were refreshed only after that inspection, with a clean `0 modified PNGs` rerun. The durable lesson is that snapshot tools should update only the images that truly moved, because reviewability beats blanket regeneration.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Zi2HdkR7r9qb",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The compaction work also surfaced a concurrency edge that had to be solved explicitly: the user asked whether `/compact` followed immediately by a prompt was handled safely, and the answer was no at first because TUI compaction was effectively fire-and-forget. The fix introduced `compactInFlight` so `turn()` waits behind an active compaction, and the tests proved the race by asserting that a turn arriving mid-compact sees the compacted horizon instead of stale state; a new eval (`evals/compact.eval.ts`) locked that in. The lesson is that even runner-private maintenance commands need their own in-flight serialization if they mutate shared turn state, because “between turns” is still a race window when the UI can dispatch immediately.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_7cPqoutMyQ4S",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779964411780,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-23",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The restore flow also revealed why a cached sandbox can appear to “wipe itself” later: if `connectExistingSandbox` times out, `getAndSetupSandbox` can fall through and overwrite the org's `e2bSandboxId` with a fresh sandbox, effectively orphaning the old VM. The final comment in `packages/backend/convex/domains/sandboxes/actions.ts` makes the blast radius explicit and explains why transient failures should be surfaced instead of turned into silent recreation. The lesson is that any recreate path should be treated as destructive by default; if the caller cannot prove that the old VM is truly dead, the safest action is to fail loudly rather than silently replace state.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_UFXDwY41HRkB",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "A related `chat-app` regression was the dead auto-redirect on `/sign-in`: the user observed the page loaded and showed an already-signed-in user, but did not redirect to `/app`. Investigation showed that `[locale]/sign-in` no longer sat under `authkitMiddleware`, so `useConvexAuth` always resolved as no user there; invite flows still worked because `invitationToken` bypassed the redirect branch. Rather than keep a misleading redirect, `apps/web/app/sign-in-page-client.tsx` was simplified to remove the `isAuthenticated` effect and router plumbing, and the README was updated to explain that `[locale]/*` routes intentionally cannot read the WorkOS session. The durable lesson is that if a route cannot reliably see the auth signal, the right fix is often to remove client-side auth-dependent behavior instead of fighting the middleware boundary.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_eHsYOlGZMRdb",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779873815153,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` memory quarantine logic was repeatedly tightened after real-world startup problems showed that not all ENOENTs mean the user's database is corrupted. The first pass added `isExternalAssetError` so failures pointing outside the user's `dataDir`—like a missing bundled `pglite.data` during self-update—would be rethrown instead of quarantining a healthy `memory.db`; later, when the user reported that `duet upgrade` could still trigger quarantine, the code was refined again with `looksLikeIntactPGliteDirectory(path)` and then with a 15s polling window, later reduced to 10s, so an intact-looking cluster gets time to recover before quarantine. The key lesson is that PGlite corruption detection should be based on persistence and retryability, not a single exception shape: valid clusters can look broken mid-update, and quarantine should only fire once the on-disk evidence and timing both point to real data loss.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Vna5HpanI3Le",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The TUI dino panel in `duet-agent` was another case where the observed symptom and the code invariant had drifted apart: the user reported Ctrl-G did nothing, while the placeholder already advertised it at rest. The red/green test showed `src/tui/dino/index.ts` was still gating toggle visibility on `agentBusy`, so the fix removed that dependency, let `src/tui/app.ts` stop setting busy state for the panel, and rewired visibility to depend only on `expanded`. The durable lesson is that if a feature is presented as an always-available mini-game or panel, the implementation should not hide it behind unrelated busy-state gating, or the UI promise becomes a lie.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_alEdNVlzNBjr",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `chat-app` right-bar rewrite began with a screenshot/report that the Memories tab showed an empty gap under the header and a missing connector above the first item. Investigation traced the shell through `channel-actions-panel.tsx`, `channel-actions-panel-view.tsx`, `channel-timeline-tab.tsx`, and `channel-timeline-item-card.tsx`, and the first fix moved `LayoutHeaderScrollUnderPad` out of the inner scroll area and into the panel root so the frosted-strip offset was owned once instead of being doubled. After the user asked to “get rid of this border,” a second local cleanup removed the tab-header `border-b`, showing the design principle that these shell-layout problems are usually ownership/padding issues before they are rendering bugs.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_4EEIISiD86Jl",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The state-machine /compact review also revealed why the gate against active work existed: the code was intentionally blocking compaction while any model-driving work was in flight, because state-machine sub-agents can be active even while the parent agent seems idle. The user questioned whether `compact` should just be part of the turn chain, and the reply argued it should stay a runner-private side effect because folding it into `turn()` would either fake a terminal or weaken the single-terminal-per-chain contract. The lesson is that not every maintenance action belongs on the same concurrency path as a model turn; if it does not drive the model, it should not inherit the model's turn semantics.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_i8I8k1QfN-OJ",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The user then asked for harder recall-memory evals and explicitly wanted the work optimized for `opus-4.7`, with the expected failures documented so another agent could pick it up cold. That led to `evals/recall-memory-implicit-triggers.eval.ts`, extensive top-of-file commentary, and several prompt-tuning passes that found a local optimum: explicit cross-session cases stayed green, but a handful of implicit named-referent prompts such as pet names, codenamed artifacts, and advice questions still failed. The key lesson was not that the prompt is perfect, but that additional wording changes started regressing neighboring cases; once the Pareto frontier is reached, the next lever is better harnessing or a different intervention, not more prompt text.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_0-lnyiuVpyHX",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-23",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The restore path in `chat-app` also revealed that a snapshot restore is not just about sandbox creation—it is a two-stage recovery with its own lifecycle hazards. The code creates a fresh sandbox from the snapshot, then rebinds the org row and runs setup with a longer ready budget, and the user later surfaced that the restore could still be wiped if a later connect timed out and the code fell through to `createAndSetupSandbox`. The fix track therefore separated concerns: cached sandbox ids must never auto-recreate on transient connect failures, while explicit snapshot restore can have a longer timeout because it is already doing a destructive replacement on purpose. The broader lesson is that restore-time guarantees should be narrower and more explicit than normal steady-state guarantees, because the same timeout can mean “slow but healthy” or “dead and should be replaced.”",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_gq9RLFmb2ImJ",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "A follow-up review in `chat-app` caught a subtle race in the same SM-recovery work: after deleting `markSessionForRecoveryWake`, the code no longer performed the second-phase recheck between incrementing the recovery attempt and sending the reminder, so reminders could be injected into healed or terminal sessions. The fix re-read session state inside `nudgeStuckSession` and bailed when the state no longer matched the recovery reason, which made Codex's PR comment valid even though the helper looked dead from the call graph alone. The lesson is that recovery paths often need a state revalidation step right before side effects, because “dead code” around the helper can actually encode a load-bearing race guard.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_696luNY8kv9e",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In `chat-app`, the SM-recovery redesign started from the user's clarification that the reminder body should **not** be written to Convex as a chat message, while the agent's reply still had to remain visible; they also insisted to “do interrupt before nudging” and make the nudge a queued follow-up when the parent was mid-turn. That steer led to a new admin gateway endpoint (`POST /admin/session/system-reminder` in `packages/agent-gateway/src/routes/admin.ts`), a Convex-side `nudgeStuckSession` flow, and `recoverStuckSessions` routing `stuck_running` / `stuck_pending` through the nudge path rather than treating them as wakes. The durable lesson is that recovery UX can preserve user visibility without persisting the reminder itself, but only if the interrupt/queue ordering is explicit and tested at both the gateway and Convex boundaries.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_fsvcHHfUF41p",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779967267693,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-23",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent`/`chat-app` shared sandbox work eventually uncovered another brittle boundary: `getAndSetupSandbox` was trying to connect to an existing E2B sandbox, and a 500 / `Failed to place sandbox` style failure could leave the org pointing at a dead `e2bSandboxId` while `createAndSetupSandbox` was never reached. The initial attempt to auto-recreate on connect timeout was later walked back after the user clarified that a cached `existingE2BSandboxId` should never silently recreate, because that risks instant data loss; the final policy is that cached-connect failures should surface for debugging, while explicit snapshot restore is the only path that intentionally replaces the sandbox. The durable lesson is that a “connect failed, create new one” fallback is only acceptable for explicitly disposable state, not for a live sandbox that may still contain user work.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_126Ad4JtMJAT",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The later `/review` pass on `duet-agent` memory recovery found small but meaningful cleanup opportunities that reinforced the same principle of single source of truth. The doc comment still said the retry loop could wait 15s even after the budget had changed, the restore helper carried an unused `_cause` parameter, and the restore path had duplicated the quarantine path string instead of calling `quarantineDataDirectory(path)`. Cleaning those up made the code more honest: the comments matched the budget, the helper surface matched actual usage, and the quarantine path was shared rather than recomputed ad hoc. The lesson is that recovery code accrues folk history quickly, so review passes should aggressively trim stale comments and duplicated path logic before they become alternate realities.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_nZa9go2wDzPo",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "After `/compact` was made horizon-based, the user asked whether `MIN_HISTORY_TAIL` was still honored and whether evicted messages would be replaced by observations on later resume. The investigation showed the existing compaction logic only preserved observations already in the store, so the fix made `compact()` async, drained memory updates before moving the horizon, and persisted the horizon so the trimmed tail survives TUI exit and restart. The lesson is that a compaction command that changes what future turns can see must not run before the memory side effects it is supposed to preserve, or else you silently lose the very context you intended to condense.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_2RjapP3LApro",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779874173230,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` state-machine prompt/workflow later hit a user-visible regression where the parent prompt was too strict about not talking to the user, so turns with visible output only surfaced tool calls and thinking blocks. The fix relaxed the prompt: status questions during state-machine work should be answered as normal user-facing replies, and the model should still call `select_state_machine_state` to end the turn. That change reinforced a broader lesson from the earlier state-machine work: a protocol tool can remain mandatory without forcing the assistant to hide all user-facing information inside the protocol itself.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_ZBrYCHoYqSMO",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The reset-session copy in `chat-app` was simplified because the user explicitly asked that it say only “drops any in-flight work” and stop mentioning state machines, and they wanted the wording updated in both English and Spanish. That led to edits in `apps/web/messages/en/app.json` and `apps/web/messages/es-419/app.json`, and the later visual-baseline refresh confirmed the copy change had real UI impact. The lesson is that user-facing warning text should be kept narrow and operational: if the user wants less jargon, the copy should preserve the safety warning but drop internal implementation terms that leak across locales.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_DcE9S9tjO_AN",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The `duet-agent` release workflow showed a recurring pattern: the repo is releaseable directly from `main` only when the tree is clean and the target tag does not already exist. Releases `v0.1.145`, `v0.1.146`, `v0.1.147`, `v0.1.149`, `v0.1.150`, `v0.1.151`, and `v0.1.152` all followed the same shape—check status, verify the next tag is unused, run typecheck/lint, commit a version bump, tag, and push both `origin/main` and the tag—while also occasionally absorbing adjacent edits when the branch was dirty. The durable lesson is that release automation only stays trustworthy if the version and tag existence checks remain explicit, because otherwise a clean-looking release can silently collide with an existing tag or stale working tree.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_RDTYdHBG0Lyn",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "When the user asked for a red/green regression in `chat-app`, the SM-recovery bug was turned into a focused backend test (`packages/backend/tests/convex/sm-recovery-nudge-race.test.ts`) that drives `nudgeStuckSession` directly with `t.action(...)` and mocks the E2B client so it never touches the network. The test was made red by reverting the recheck guard in `packages/backend/convex/domains/sandboxes/actions.ts`, which caused the action to call `gateway.sendSystemReminder` against a healed row; restoring the guard made the test green again. The durable lesson is that a regression is only real once you can force it to fail in isolation, and here the isolated action-level harness was the right boundary because the bug was a timing/race issue rather than a UI one.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_B06aftJtxAU8",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The user later discovered a much deeper auth issue in `chat-app`: `/` was throwing `withAuth` errors only in dev, because `AuthKitProvider` still mounted from the root `<Providers>` while the marketing branch no longer ran `authkitMiddleware`. The user explicitly rejected the bigger refactor as “too high risk,” so the chosen path was a surgical middleware adjustment that routes only Next.js server-action POSTs carrying `Next-Action` through authkit while keeping anonymous GETs on the intl branch CDN-cacheable. The comment in `apps/web/middleware.ts` was expanded to record the root cause, which is the durable lesson here: when a framework provider leaks auth calls into an unauthenticated tree, the safest fix is often to narrow the middleware to the failing request class rather than moving the whole provider graph.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_wJIepHN5RmHC",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "Another dev-only `chat-app` failure turned out to be self-inflicted by asset placement rather than locale logic: the runtime was receiving `locale = \"favicon-dev.ico\"`, which traced back to `app/layout.tsx` / `hooks/use-unread-favicon.ts` pointing at `/favicon-dev.ico` while the file lived under `apps/web/app/favicon-dev.ico`. Because Next treated that path as a route segment, the favicon name was being matched by `[locale]` and poisoning the locale render. Moving the icon to `apps/web/public/favicon-dev.ico` fixed the problem without changing the dev/prod favicon behavior, and the lesson is that a path that is meant to be a static asset must live where the framework will never reinterpret it as a route.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_nEkUACK0U8Be",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The channel `workDir` feature in `chat-app` was introduced because the user wanted channels to be able to create and update a work directory through the public API, not just through internal sandbox plumbing. The implementation added a shared `normalizeChannelWorkDir(input)` helper in `packages/backend/convex/model/channels.ts` and threaded `workDir` through both Convex mutations and the REST routes in `apps/web/app/api/v1/channels/route.ts` and `[channelId]/route.ts`, then documented the field in the embedded duet skill reference. A review later trimmed the comments down to the one non-obvious guarantee that matters locally—`null` means clear, `undefined` means no change—which is a good reminder that normalization rules belong in code, while comments should only capture the edge cases a future maintainer cannot infer.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_L2dYkl2sKBN9",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-21",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In `duet-agent`, the `recall_memory` feature was split into a system-prompt layer after the user objected to stuffing trigger guidance into the tool description and said it should be “like how we did state machine.” The work began with a cross-session eval that initially failed because the model made zero recall calls on some prompts; then the guidance was moved out of `src/turn-runner/tools.ts` into `createRecallMemorySystemPromptLayer()` in `src/turn-runner/prompts.ts`, and `turn-runner.ts` was updated to append that layer only when `memoryDbPath` is set. The durable lesson is that tools should explain how to use themselves, while trigger policy belongs in the system prompt layer that is already responsible for behavioral routing.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_3vUumNwQiLPB",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In `chat-app`, the invite-link and sign-in flow turned out to hinge on a middleware split rather than a simple auth bug: the user reported `/invite/<id>` 404s after an i18n change, and investigation found `next-intl` was rewriting unprefixed routes to `/en/*` even for top-level routes like `/invite/[invite-id]`. The fix expanded `apps/web/lib/i18n/path-classification.ts` so `shouldBypassI18n` skips non-localized routes while leaving locale-prefixed `/sign-in` alone, and the later README update documented the invariant that new top-level routes must be added to `shouldBypassI18n` and wrapped in `RuntimeIntlProvider`. The lesson is that route ownership matters: marketing/localized pages and auth/workflow pages can live in the same app, but they need explicit carve-outs or they will silently rewrite each other.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_UA33Bt44YxvG",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-22",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "After channel workdir support shipped, the user hit a workdir-sensitive auth bug: child-thread sessions started failing with `Error: No API key for provider: vercel-ai-gateway`, but only when a channel workdir was set. The investigation traced the path through `packages/agent-gateway/src/session-controller.ts`, `runner-manager.ts`, and the CLI's dotenv loader, and the important discovery was that the gateway process was running with `HOME=/root`, so `os.homedir()` made it look for `/root/.env` instead of the sandbox user's `/home/app/.env`. The durable fix was to anchor `packages/agent-gateway/src/utils/dotenv.ts` to `SANDBOX_HOME_DIR` instead of `homedir()`, because workdir should not determine where the gateway loads secrets from; the key insight is to tie secret discovery to the sandbox contract, not the host's home directory.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_QcNU5tphDuoZ",
+    "createdAt": 1779786035673,
+    "lastUsedAt": 1779786035673,
+    "ageDays": 23.47678023148148,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-23",
+    "timeOfDay": "09:00",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "The same sandbox area in `chat-app` eventually needed a restore flow that would not lose user data when the existing E2B sandbox could not be reached. The work started because `connectExistingSandbox` could fail with E2B placement or auth-style errors, and the earlier auto-recreate behavior risked orphaning a still-valid VM and wiping non-snapshot state. The eventual design was refined several times: a fixed 10s `connectTimeoutMs` was added to `connectExistingSandbox`, then restore-only paths were given longer gateway-ready budgets (`readyTimeoutMs`) because snapshot restores are slower, and the final policy was explicit that connect failure should surface rather than silently recreate when a cached sandbox id exists. The lesson is that destructive fallback is only safe when the system can prove the old sandbox is dead; otherwise, fail fast and make the user/debugger decide.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_AEWbDi-IkoLo",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the agent-gateway/public-config workflow became more robust after the user clarified that the config file should support future unattached apps while still requiring `channelId` at registration time for AI-session-owned apps. The implementation split validation into two stages: `packages/agent-gateway/src/public-config.ts` now allows channel-less rows at rest, while `packages/agent-gateway/src/public-app-service.ts` skips syncing those rows into Convex until they are attached. Later, when the user wanted thread/channel handling to be explained back to the caller, the design shifted again so a new authenticated Convex query resolves child channel IDs to the parent before the gateway writes the config, allowing the response to include a human-readable rewrite message and backup path information for reversibility. The lesson is that registration-time validation, at-rest storage shape, and user-visible feedback do not have to be the same layer; keeping them separate makes the gateway flexible without making the synced channel sidebar ambiguous.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_8k4X6yrjID7V",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the visual-regression workflow itself needed multiple rounds of hardening before it became trustworthy: first it failed because `dorny/paths-filter` lacked repo permissions inside the Playwright container, then because Git refused to inspect the workspace as a safe directory, and later because the CI job was too broad and too slow for the desired cadence. The work iterated through `.github/workflows/ci.yml` several times—adding explicit `permissions`, then `git config --global --add safe.directory \"$GITHUB_WORKSPACE\"`, then changing the trigger model from push-to-main to pull_request, then to a scheduled daily cron against `staging` as the user’s requirements evolved. The durable lesson is that CI for screenshot tests is as much about runner environment, Git hygiene, and trigger policy as it is about the visual assertions; if the job cannot reliably start and scope itself, the snapshots are irrelevant.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_CLCbEj2dQ1Wy",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-19",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the public-app/channel ownership refactor began when the gateway and Convex schema disagreed about where app ownership lived, and later when live prod data started throwing `",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_LnVXu9YRG8Hk",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-19",
+    "timeOfDay": "08:59",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, an apparently random `No app configured for this path` outage turned out to be a stale-gateway problem rather than a data problem: the source already passed `channelId`, but the live `packages/agent-gateway/dist/gateway.js` was still serving an older config parser that dropped it. The diagnosis moved from the `handleRequest()` 404 in `packages/agent-gateway/src/public-app-service.ts` to the generated bundle itself, and the fix was not a code commit but a rebuild of the sandbox gateway artifact with `bun run build:sandbox` so the running process could ingest the new shape. The lesson is that when a system reads from a built artifact, the source tree can be correct while the deployed runtime still fails; the first question should be which bundle is actually serving traffic.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_gKOHdOiKiR1j",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-18",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, a long visual-regression hardening pass started when the `/playground` screenshots and CI runs exposed several separate issues at once: missing TipTap placeholders, a route that 404’d under Next-intl, dev-only licensing checks blocking `ui:check`, and a flaky WebServer startup under the Playwright Docker container. The investigation moved from the `apps/web/app/playground/components/playground-shell.tsx` readiness gate to `apps/web/lib/i18n/path-classification.ts`, then into `package.json`, `apps/web/playwright.config.ts`, and the visual baselines themselves. The durable decisions were to make the Docker flow the default, bypass i18n for `/playground`, raise the WebServer timeout for cold Next boots, and force-focus the editors so the captured screenshots reflect what the user actually sees, including the placeholder state. The lesson is that visual checks need to be treated as a product surface with their own runtime constraints, not as a thin snapshot wrapper around app code.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_WivRJRQ7sdWx",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, an apparently random `",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_zk1MhBiRF3LP",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-18",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the comment-message styling work showed a repeated pattern: the user’s screenshot complaints first pushed the row to feel quieter and more margin-like, then to match the amber highlight color, then to stop looking broken in dark mode, and finally to avoid being shadowed by typography plugin cascade rules. The investigation bounced between `apps/web/components/chat/message/implementations/main-message.tsx`, grouped-message spacing in `message-grouped-timestamp.tsx`, and eventually `packages/tailwind-config/globals.css` when `dark:prose-invert` proved to override same-element prose variables. The final choice was to keep the recolor local in the component, use explicit descendant utilities with `!important` where needed, and tune dark-mode amber to line up with the header tone rather than inventing a second annotation palette. The lesson is that visual semantics beat clever styling abstractions: if a row is meant to read like a quieter annotation, its whole stack—spacing, opacity, prose, and dark mode—must be designed together and verified against the screenshot, not just the text color.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_zNV9n3VujQuz",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-18",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the bumping path for observations originally risked preferring broad summary rows over narrower atomic rows when both covered the same cited fact, so the work shifted from a runtime classifier idea back to a simpler prompt-driven preference. The user explicitly rejected `legacy/blob` framing and wanted the system described as tuning how large reflections get split into smaller ones, so the prompts in `src/memory/observational-prompts.ts` were rewritten to prefer the narrowest matching row and to avoid treating older broad rows as a special case. A separate eval fixture (`evals/bump-prefers-atomic.eval.ts` with `evals/fixtures/bumping/blob-vs-atomic.ts`) was used to prove the new citation guidance works in practice, and the final decision was to keep `applyUsageBumps` simple rather than layering on a brittle overlap classifier. The lesson is that when the prompt can teach the selection rule directly, adding post-hoc heuristics often just encodes the wrong mental model and makes the system harder to explain.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_rfLAQbTeTW-P",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "08:59",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the release and publish workflows were repeatedly exercised because the project is sensitive to version correctness and registry state, not just code health. Several patch releases were cut in sequence, but the more interesting incident was the npm publish failure for `@duetso/agent@0.1.144`: the tag-based release workflow passed build/test/lint, yet the final `npm publish --provenance` step returned a registry 404, which pointed away from package contents and toward token/registry authorization. The user later wanted to know what happened after that, and the rerun eventually published successfully, reinforcing that the problem was transient auth or release-state, not a broken tarball. The durable lesson is that successful build/test checks do not guarantee release completion; publish workflows need registry-specific verification and the failure mode should be interpreted separately from package correctness.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_IW-r6MpAMvOe",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the state-machine interrupt/replacement path needed a race fix because an active agent state could still emit terminal events after a replacement decision had already started, which made the session look aborted even though the replacement run had taken over. The bug was reproduced with a focused `StateMachineController.runDecision` test in `test/state-machine-replacement.test.ts`, then fixed by having each active run expose a `finished` promise and making replacement wait for the previous run’s teardown before constructing the new handle; later work removed the awkward shared `interruptedReason` aliasing by moving interrupt ownership into the handles themselves and replacing the old `interruptedTerminal` flow with a `parentAgentInterrupted` boolean. The user also wanted the system to tolerate repeated wake events without resurrecting an explicitly interrupted state, so `test/state-machine-wake-after-interrupt.test.ts` was added to lock in that no-op behavior. The durable lesson is that the controller should treat interrupted state as an explicit snapshot owned by the active handle, not as mutable ambient state that can be overwritten by a late terminal event or a stray wake.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_6Hu1iR5agbyZ",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-18",
+    "timeOfDay": "08:59",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the prompt-assembly order was corrected after the user pointed out that system prompt files should come first and that `<cwd>` / `<current_date>` should sit near the end before memory observations. The investigation traced assembly through `src/turn-runner/prompts.ts` and `src/turn-runner/skill-context.ts`, confirmed that memory observations are appended separately as a `<system-reminder>` on the latest user message rather than the system role, and then reordered the layers so system instructions lead, files come next, tool guidance and skills follow, and cwd/date land at the tail. The release path then shipped this as versioned changes on `main`, so future prompts inherit the new order automatically. The lesson is that prompt layering is not cosmetic: file precedence, environment context, and memory injection all interact, so the assembly order needs to match the actual precedence the model should perceive.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_KBeWgtlJrjGt",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-18",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the memory-reflection system was reworked because a single giant reflection blob was not durable enough for cross-session recall: the user wanted `duet memory reflect` to emit multiple atomic insight rows, with dry-run output, eval coverage, and bump behavior all aligned to that new unit size. The investigation touched `src/memory/observational.ts`, `src/memory/observational-prompts.ts`, `src/cli/memory-reflect.ts`, `evals/memory-reflect-units.eval.ts`, and the fixture path `evals/fixtures/global-reflect/recent-pool.{json,ts}`; along the way the design was corrected several times, including distinguishing global reflection rows from local in-session blobs, teaching the prompt to prefer the narrowest row for each fact, and making the CLI print priority and observed date headers so the output was readable cold. The durable lesson is that the reflector has two distinct jobs—compressing observations into durable units and preserving enough structure for later bumping and review—and both jobs need explicit prompts, evals, and output shape, not just a better summary model.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_o6UBUezXJHv3",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-18",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the memory system’s observer prompts were tightened because the user did not want examples that only mirrored dev fixtures; they wanted the prompt to teach the rule with independent, real-world-like worked examples instead. The prompt guidance in `src/memory/observational-prompts.ts` was iterated several times: first to remove external article references from the body, then to rename the alternatives bullet as the conflicts/precedent layer, then to use mixed work examples instead of dev-only ones, and finally to add a narrow-vs-summary release-history example so the model learns to cite the most specific row that actually carries the fact. The matching skill docs in `.agents/skills/debug-memory/SKILL.md` were updated alongside the prompts so the operational workflow and the evaluation fixtures do not leak the same phrasing. The durable lesson is that reflection prompts should demonstrate the policy with varied, non-duplicative examples; otherwise the model learns the fixture shape instead of the underlying citation rule.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_EpKhVL21gBdu",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-18",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the UI playground refactor was not just a rename of debug pages; it was a deliberate migration from a legacy `/debug` surface to a production-like `/playground` route group with hermetic fixtures, admin-gated nav, and Playwright coverage. The work branched through scaffolding `apps/web/app/playground/`, then migrated image loader, compose bar, rendering, UI primitives, AI avatar, and email template demos into `apps/web/components/playground/**`, while preserving SPA route shims only where needed during the transition. The final design used a registry-driven playground shell, deleted the old `/debug` tree, added a `visual-regression` CI job, and documented a `ui-playground` skill so future agents can add entries and approve baselines intentionally. The durable lesson is that a visual playground should own its fixtures, navigation, and test workflow end-to-end, rather than borrowing from auth-bound debug pages or ad hoc routes.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_gaZq5Mz-Xv6Y",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-20",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `chat-app` repo, the public-app/channel ownership refactor began when the gateway and Convex schema disagreed about where app ownership lived, and later when live prod data started throwing 404s and schema validation errors after `channelId` became required too early. The investigation crossed `packages/agent-gateway/src/public-config.ts`, `packages/agent-gateway/src/public-app-service.ts`, `packages/backend/convex/schema.ts`, `packages/backend/convex/domains/sandboxes/mutations.ts`, and the browser-facing `/session/public/config` route; along the way the user steered the design away from UI pinning and toward agent-gateway-driven registration, then clarified that `channelId` must stay optional at rest but required only when registering apps for AI sessions. The end state was a channel-owned model in which gateway config writes a `channelId`, Convex stores `sandboxApps.channelId`, sync keys on `(slug, path)` to preserve `_id` stability, and a cleanup migration/backfill existed only long enough to remove old `channels.pinnedAppIds` rows safely. The durable lesson is that the ownership field and the routing identity are not the same thing: keep the channel owner mutable, but preserve the app URL key so custom domains and deep links do not churn.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Yd7CUxqvtXMQ",
+    "createdAt": 1779785979283,
+    "lastUsedAt": 1779785979283,
+    "ageDays": 23.477432893518518,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-19",
+    "timeOfDay": "08:59",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the `duet-agent` monorepo, the LongMemEval harness was built as a proper benchmark product rather than a one-off script because the user wanted a reproducible way to measure the memory system against the public `xiaowu0162/longmemeval` benchmark. The work moved into `benchmarks/longmemeval/`, cloned and cleaned the upstream dataset, added a smoke runner in `run.ts`, introduced per-question `MemorySession` data directories, and eventually added concurrency, stratified sampling, and usage capture so the run could estimate full-run cost before committing to the whole 500-item set. The path also uncovered a persistent upstream/service issue: once concurrency increased, observer-side structured-output calls to `gpt-5.4-mini` started returning repeated gateway 500s, so multiple smoke and stratified runs had to stop after retries rather than pretend the scores reflected model quality. The lesson is that benchmark harnesses need to separate harness health from model-service health, surface retries and abstentions honestly, and keep the benchmark artifacts under one canonical path so future reruns are obvious and reproducible.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_OwyJNdK4NmPG",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779711114629,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the memory-observation formatting work was triggered by a UX request to shorten the stats text to just `Reinforced 1 prior memory`, followed immediately by a stricter clarification that the visible prefix must stay `Memory observation recorded.` whenever observation activity exists. The investigation also uncovered a second constraint: if a memory event produces neither a new observation nor any bump, the assistant should not emit a memory event at all, because the TUI should not show a `[memory:observation]` section for a no-op. The final change in `src/memory/observational.ts` skipped completed memory events when both `observation` and `usageBumped` were empty, while restoring completion messages to the exact `Memory observation recorded.` prefix with an optional `Reinforced N prior memor{y,ies}.` suffix when bumps exist; the TUI playground fixture and `src/tui/step-renderer.ts` comment were updated to match, and the repo typechecked and linted cleanly. The durable lesson is that memory telemetry must distinguish three cases cleanly — new observation, reinforcement-only bump, and no-op — because users care both about what is surfaced and about not surfacing empty events at all.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_D3pJ2bdL5-tP",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779122098497,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the user’s question about whether `handleTerminal` makes sense and what users see in a failed-complete case led to a close read of the failure path rather than a code change. The investigation showed that `handleTerminal('complete')` deliberately skips persisting `event.state` when completion fails, but still flushes buffered output and updates cost/lastUsage before the caller constructs an error agent message, stages the recovery note, wipes session state, and completes the session with error. The one notable branch is that when `state.muted` is true, the error message and recovery-note staging are skipped together, so muted failures end quietly and do not create recovery context. That answer clarified the shape of the session-controller contract: terminal handling is about deciding what survives a turn boundary, while recovery-note staging is the caller’s separate responsibility when the failure should be visible to the next turn. The durable lesson is that cleanup, reporting, and forward-recovery are separate concerns in this code path, and conflating them would make it harder to reason about which failures should leave prompt hints behind.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_VwZh4inlrw3F",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779705163071,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the session-recovery flow was examined because a user asked whether a failed Anthropic stream turn completely deletes turn state and whether the recovery text is actually appended to the next prompt. The investigation traced the failed-`complete` path in `src/session-controller.ts`: on error it wipes `turnState` and other pending state for the session, preserves the working directory, and only carries forward a one-shot `<session-recovery>` block from `pendingRecoveryNote`. That note is not a chat message; it is injected into the next runner’s system prompt for exactly one turn and then cleared, and `handleTerminal('complete')` also avoids persisting `event.state` in the failed-complete path while still flushing output and updating cost/usage. The subtle exception is that muted failures skip both the error message and the recovery-note path, so they end quietly without context staging. The durable lesson is that recovery in this architecture is intentionally narrow: the next turn gets just enough prompt-level reminder to rehydrate context, while the canonical session state is reset so the runner starts cleanly from preserved working-directory state.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_5XGAzP0IEU7I",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779122098497,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the `fix-and-push` CI loop also surfaced a subtle but important prompt-injection boundary: after the user asked whether the recovery text for `Anthropic stream ended before message_stop` is added as a reminder to the next prompt, the investigation verified that `src/session-controller.ts` appends a one-shot `<session-recovery>` block to the next turn’s system prompt only when `pendingRecoveryNote` exists, then clears it. That meant the recovery text is not a chat message and not persistent state; it is a single-turn prompt hint that tells the fresh runner the prior session ended unexpectedly, that working-directory state remains, and that the next turn should recover context from recent channel messages and the workdir. This detail matters because it explains why the transient-error retry work in `src/turn-runner/transient-error.ts` is preferable: if the retry succeeds, the session never needs to fall back to this limited recovery channel at all. The lesson is that the recovery note is intentionally a last-resort bridge, not a substitute for normal continuity, so upstream retry fixes reduce the need to depend on it.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_qC-2TUNjy4ag",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779122098497,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "low",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the `rg` probe around the bundled-ripgrep release path became a quick verification step for the installation story. After the earlier analysis established that `@vscode/ripgrep` is delivered via optional dependencies rather than a lifecycle hook, the user asked to try `rg`, and the shell confirmed that `rg` resolves to the bundled `@vscode/ripgrep-darwin-arm64` binary. A follow-up probe also showed that `withBundledRipgrep` is wired into `src/turn-runner/tools.ts:489`, which means the code path explicitly prepends the bundled binary when tool operations need it, even though the shell PATH already appears to prefer local node_modules binaries in that environment. The lesson is that installation confidence should come from both package metadata and an actual runtime probe, because optional-dependency delivery can succeed while the explicit tool-lookup path still remains the safer implementation detail for internal operations.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_FFOOoTa_n1Jl",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779290776987,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the Vitest 4 upgrade was triggered by a user request to update Vitest across all packages, and the first step was to inventory every workspace still pinned to `^1.6.0`. The upgrade itself was treated as a monorepo-wide compatibility migration: eight package.json files were bumped to `^4.1.6`, `bun.lock` was refreshed, and then the breakages were fixed one surface at a time rather than trying to brute-force the whole repo. The largest breakages were in `apps/web`, where Vitest 4 / rolldown-vite became stricter about JSX, so three JSX-containing `.test.ts` files were renamed to `.test.tsx` and `@vitejs/plugin-react` was bumped from `^4.3.4` to `^6.0.2`; all 397 web tests passed afterward. In `packages/ui`, a `NodeJS.Timeout` type error was resolved by switching to `ReturnType<typeof setTimeout>`, and in `packages/backend`, the old `environmentMatchGlobs` config was migrated to Vitest 4 `test.projects` with separate `node` and `edge-runtime`/`convex` projects while preserving shared options. A final `MarkdownMetadata` overload mismatch in `apps/web` was fixed by converting `vi.fn<TArgs, TReturn>` call sites to the Vitest 4 single function-type generic form, after which full repo verification passed and the upgrade was committed and pushed as `885746567`; a subsequent review cleaned one stale explanatory comment in `packages/backend/vitest.config.ts` as `e898c780e`. The durable lesson is that major test-runner upgrades are really a sequence of environment-specific compatibility migrations, so the safest path is to fix each package’s local assumptions explicitly rather than forcing one global shim.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_Oqt1qZ5XJ3Xk",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779122098497,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the release flow on `main` repeatedly used the same rule: only cut a version after clean typecheck and lint, then tag and push the release commit. That pattern showed up when `v0.1.130`, `v0.1.131`, `v0.1.132`, `v0.1.133`, `v0.1.134`, and `v0.1.135` were released with annotated tags and commit history advanced accordingly, but the important durable example was `v0.1.130`, which bundled the memory-observation formatting change once it had been verified clean. The subsequent releases demonstrate that the repo treats version bumps as a final packaging step over already-validated changes, not as a place to hide risk: each release recorded the exact commit SHA, bumped `package.json`, and only proceeded after `bun run check-types` and `bun run lint` passed. The lesson is that release commits in this monorepo are meant to be mechanically boring and traceable, so the long-term memory should preserve the pattern of “validate first, version second, tag third” rather than just the tag names themselves.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_BG08mN-hKSOV",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779122098497,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "medium",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the bundled-ripgrep work came from a concrete install-time question: the user asked whether the latest `rg`-bundling release path runs a `postinstall` during upgrade, then asked to try using `rg`. The investigation found that the repo has no `postinstall`/`install` lifecycle script, the bundled `@vscode/ripgrep` package also ships without scripts, and the install path relies on platform-specific `optionalDependencies` being resolved by the package manager; `duet upgrade` simply installs `@duetso/agent@<version>`, and if optional deps are skipped the runtime still falls back to system `rg`. A direct environment probe confirmed that `rg` was available and resolving to `node_modules/@vscode/ripgrep-darwin-arm64/bin/rg` version 15.0.0, which proved the optional-dependency path was sufficient without any postinstall hook. That understanding was then packaged into release `v0.1.132`, which included commit `ad046b8` so global installs can resolve the bundled ripgrep binary normally. The lesson is that for tool dependencies, preferring package-manager resolution over lifecycle scripts makes upgrades more predictable and avoids relying on `bun add -g` executing hooks it may skip by default.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_x3K8ALznRekq",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779963691444,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the CI-green loop on `staging` started as a gateway stability chase when the last failure moved from an EPIPE crash to a timeout and then to a `400` on `ask + answer (multi-turn via persisted TurnState) > writes pendingQuestion + waiting-for-input on ask, then resumes via /answer`. The investigation first fixed the async stdin write race in `packages/agent-gateway/src/runner-manager.ts` by adding a no-op `stdin` error listener and a no-op write callback, then extended `packages/agent-gateway/src/session-controller.integration.test.ts` with a 30s timeout so the terminal-race regression could actually run in CI. Once that path was green, the failure shifted to request validation (`\"Invalid input: expected 1\"`), and then the loop found the real root cause in `packages/agent-gateway/src/session-store.ts`: `metadata.json` could be read mid-write during `/answer`, producing truncated JSON, `null`, and a misleading `Session not found` 400. The durable fix was to make `SessionStore.save()` atomic via temp-file + `rename()` and to have `load()` only swallow `ENOENT`, which eliminated the mid-write race. The lesson is that in the gateway, different CI symptoms can be cascading manifestations of the same persistence boundary, so the right order is to stabilize transport races, then lock down state writes atomically, and only then trust the remaining integration failures.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_WMTz1SML2Uu3",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779999308979,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the `CI green loop on staging` state machine started because the user wanted the loop to keep iterating until staging CI was consistently passing. The loop’s first useful decision was to create a `fix-and-push` state that would inspect the latest staging failure, patch the code, run local checks, commit, push, and continue watching CI instead of stopping after a single green run. That workflow paid off twice: first by turning the async stdin EPIPE crash in `packages/agent-gateway/src/runner-manager.ts` into commit `05ad9a191`, and then by turning the terminal-race timeout into a per-test 30s budget in `packages/agent-gateway/src/session-controller.integration.test.ts` as commit `beb774830`. After a subsequent staging run exposed the real persistence race, the same loop pushed `fc197bdff`, making `SessionStore.save()` atomic with temp-file + `rename()` and restricting `load()` to swallow only `ENOENT`, which finally produced two consecutive green staging runs (`25922744180` and rerun `76196398843`) and terminal `ci-green`. The durable lesson is that the staging CI loop is only trustworthy when it keeps watching past the first apparent fix, because the next failure often reveals the actual invariant that still needs hardening.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  },
+  {
+    "id": "mem_n4FsYdZNIZNd",
+    "createdAt": 1779122098497,
+    "lastUsedAt": 1779444463009,
+    "ageDays": 31.161238287037037,
+    "sessionId": "__global_reflection__",
+    "kind": "reflection",
+    "observedDate": "2026-05-15",
+    "timeOfDay": "16:34",
+    "priority": "high",
+    "source": {
+      "kind": "system"
+    },
+    "content": "In the duet-agent monorepo, the Anthropic truncation bug was driven by a user request to detect streams that end before `message_stop` and retry locally rather than resetting the session unless recovery is impossible. The initial investigation showed the existing transient-error regex in `src/turn-runner/transient-error.ts` missed the exact `Anthropic stream ended before message_stop` SSE truncation case, even though `TurnRunner.retryTransientServerErrors` already existed and would have retried if the failure had been classified correctly. Rather than changing the gateway’s reset behavior, the fix stayed local to the turn runner: `src/turn-runner/transient-error.ts` was widened to match `stream ended` and documented with the exact Anthropic error string, and `test/transient-error.test.ts` gained coverage for that case before the code was released as `v0.1.131` after a clean `bun run check-types`, `bun run lint`, and `bun run test` run. The lesson is that when a runner already has a retry path, the safest and most reusable fix is usually to teach failure classification about the new transient symptom instead of broadening recovery at the session-controller layer.",
+    "tags": ["observational-memory", "reflection", "global-prune"]
+  }
+]

--- a/evals/fixtures/session_rUjMi_pUNzhB/reproduce_and_diagnose.txt
+++ b/evals/fixtures/session_rUjMi_pUNzhB/reproduce_and_diagnose.txt
@@ -23,6 +23,9 @@ recognized completion and kept re-checking forever.
 
 ## State shape
 
+Numbers below describe the ORIGINAL live session as captured. The
+committed `state.json` is trimmed (see "Committed fixture" before Repro):
+
     totalMessages: 1299
     roles:        { assistant: 478, toolResult: 806, user: 15 }
     wireGuardHorizon.evictionHorizon: 1781811031668 (ms epoch)
@@ -94,17 +97,30 @@ one dead reply. The earlier "drain to memory before eviction" fix
 preserved CONTENT but did nothing to prevent the runaway loop when no
 user message ever follows.
 
+## Committed fixture (trimmed)
+
+The live session reached 1299 messages, but the committed `state.json` is
+trimmed to the first 349 (indices 0..348): the legit refactor work
+(209..333) plus the FIRST few loop iterations (334..348, cut at a clean
+turn boundary right before the next assistant turn). This proves the fix
+engages the moment the loop begins rather than only after the full
+~1090-message pileup. The starvation trigger is preserved exactly — the
+horizon still equals msgs[208].timestamp and no post-horizon message is a
+user turn — so the broken code still collapses the wire to empty.
+
 ## Repro
 
 - evals/session-loop-wire-starvation.eval.ts — deterministic, the
-  regression guard. Replays this state through the production
+  regression guard. Replays the trimmed state through the production
   wire-shaping transform. RED against the broken code: the starved shape
-  that enabled the loop (retainedMessageCount === 0) despite 1090
-  post-horizon messages, of which zero are user-role. GREEN after the
-  fix: the dispatch carries a bounded, provider-valid recent tail
-  (retained 70, ~69k tokens, head anchored on an assistant turn, well
-  under the 200k window). Falsified by reverting applyEvictionHorizon to
-  the skip-to-user-then-slice form, which re-collapses retained to 0.
+  that enabled the loop (retainedMessageCount === 0) despite a
+  post-horizon tail with zero user-role messages. GREEN after the fix:
+  the dispatch carries a bounded, provider-valid recent tail (head
+  anchored on an assistant turn, well under the 120k message budget /
+  200k window). Falsified by reverting applyEvictionHorizon to the
+  skip-to-user-then-slice form, which re-collapses retained to 0 —
+  verified on the trimmed fixture, so the guard catches the regression at
+  the loop's onset, not just at full pileup.
 
 Why no live single-turn companion eval: a `complete()` call on the
 captured payload does NOT reliably fail when the bug is present, so it

--- a/evals/fixtures/session_rUjMi_pUNzhB/reproduce_and_diagnose.txt
+++ b/evals/fixtures/session_rUjMi_pUNzhB/reproduce_and_diagnose.txt
@@ -1,0 +1,156 @@
+# session_rUjMi_pUNzhB — infinite "pick up where we left off" loop
+
+## Symptom
+
+The session ran away into a tight, self-repeating loop. From message 334
+onward the assistant does the SAME thing every turn, 242 times in a row,
+never making forward progress and never finishing:
+
+    thinking: "Let me check the current state of the work in progress."
+    text:     "I'll pick up where we left off — the typecheck on the kanban refactor…"
+    bash:     cd /Users/david/dev/chat-app && git status && git diff --stat
+    read:     packages/backend/convex/domains/kanban/definitions.ts
+    (sometimes) bash: bunx turbo check-types --filter=@repo/shared … --filter=@repo/backend
+
+It re-orients, re-reads the same file, re-runs the same typecheck, decides
+to "continue," and loops. It never edits, never marks a todo done, never
+commits, never asks the user anything.
+
+This is the model-translation refactor (store kanban role ids, gateway as
+dumb pipe). The work was actually essentially DONE: at message 339 the
+typecheck reports `4 successful, 4 total` — green. The agent simply never
+recognized completion and kept re-checking forever.
+
+## State shape
+
+    totalMessages: 1299
+    roles:        { assistant: 478, toolResult: 806, user: 15 }
+    wireGuardHorizon.evictionHorizon: 1781811031668 (ms epoch)
+    status: interrupted / agent.status: cancelled  (the user killed it)
+    sessionCostUsd: 7.81   (the loop burned ~$7+ of opus-4.8)
+
+## The trigger: horizon landed exactly on the last user message
+
+The last real user turn is message 208 — the literal text "continue":
+
+    [206] user        ts=1781810892757
+    [207] assistant   ts=1781810896469
+    [208] user        ts=1781811031668   "continue"   <- horizon == this ts
+    [209] assistant   ts=1781811031682   (+14ms)
+    [210] toolResult  ts=1781811044236
+    ...
+    [1298] (loop tail) — assistant/toolResult only
+
+    evictionHorizon == 1781811031668 == msgs[208].timestamp EXACTLY.
+
+`applyEvictionHorizon` (src/turn-runner/wire-shaping.ts) drops every
+message with `timestamp <= horizon`, so the "continue" user message at
+208 is itself evicted. Everything after it — 1090 messages, indices
+209..1298 — is the agent's OWN autonomous loop:
+
+    roles in 209..end: { toolResult: 708, assistant: 382, user: 0 }
+
+There is not a single `user`-role message after the horizon. So the
+orphan-head skip in `applyEvictionHorizon`:
+
+    while (firstKept < messages.length && messages[firstKept].role !== "user")
+      firstKept += 1;
+
+walks from index 209 all the way to the end looking for a user turn,
+finds none, and returns an EMPTY list. The dispatched wire carries zero
+real messages.
+
+## Why it loops forever (self-reinforcing wire starvation)
+
+Captured wire payload for the next turn (capturedWirePayload helper):
+
+    rawMessageCount:       1299
+    retainedMessageCount:  0          <- entire transcript collapsed
+    dispatched.length:     2          <- only synthetic prepends
+    dispatchedHasRealUser:  false
+    synthetic prepends:    [observation-context, continuation-hint]
+
+The model sees NO transcript — only (a) the durable `<observations>`
+memory block and (b) the "Please continue naturally" continuation hint.
+The observations block describes the in-flight refactor and a todo list
+with "gateway-dumb-pipe in progress / typecheck needs rerun." That input
+is STATIC, so every turn the model reconstructs the identical plan, runs
+the identical read-only orientation (git status, read definitions.ts,
+re-run the now-green typecheck), and produces only assistant/toolResult
+messages — never a new `user` turn.
+
+Because no new user turn is ever appended, the horizon never gets a fresh
+user anchor below it, `applyEvictionHorizon`'s orphan-head skip keeps
+eating the whole tail, the wire stays starved at 0, and the loop is
+permanent. The agent literally cannot see that it already did this 242
+times.
+
+This is the same wire-starvation mechanism as session_VO5yjfS1vV6_
+(retained collapses to 0 when the post-horizon tail has no user
+survivor), but a worse manifestation: that session ended on a single
+cold greeting because the user was gone; here the runner kept driving
+autonomous turns, so the starved wire feeds an unbounded loop instead of
+one dead reply. The earlier "drain to memory before eviction" fix
+preserved CONTENT but did nothing to prevent the runaway loop when no
+user message ever follows.
+
+## Repro
+
+- evals/session-loop-wire-starvation.eval.ts — deterministic, the
+  regression guard. Replays this state through the production
+  wire-shaping transform. RED against the broken code: the starved shape
+  that enabled the loop (retainedMessageCount === 0) despite 1090
+  post-horizon messages, of which zero are user-role. GREEN after the
+  fix: the dispatch carries a bounded, provider-valid recent tail
+  (retained 70, ~69k tokens, head anchored on an assistant turn, well
+  under the 200k window). Falsified by reverting applyEvictionHorizon to
+  the skip-to-user-then-slice form, which re-collapses retained to 0.
+
+Why no live single-turn companion eval: a `complete()` call on the
+captured payload does NOT reliably fail when the bug is present, so it
+cannot serve as a guard. The rendered observation/memory pack rides the
+wire in BOTH the starved and fixed payloads and already describes the
+kanban refactor in detail, so even with retained=0 the model produces a
+plausible single-turn reply ("I'll rerun the typecheck on the kanban
+helper, let me check the current state of the files"). The real defect is
+multi-turn: with an empty tail the model's own actions never land on the
+wire, so every turn replays the identical re-orientation forever. A
+single forward turn looks fine either way; only the deterministic wire
+shape distinguishes broken from fixed. (Contrast session_VO5yjfS1vV6_,
+where the broken behavior IS a single-turn cold greeting and a live judge
+does discriminate.)
+
+Empirically, with the fix in place the model breaks the loop: it stops
+re-reading and asserts the prior edit is done — across 5 opus-4.8 runs it
+named the recent anchor (`toRunnerKanbanDefinition`, the structural cast
+fix) and moved to run the typecheck, rather than re-`cat`-ing the file as
+it did with the starved wire.
+
+## Fix (implemented on david/fix-wire-starvation-loop)
+
+The repair lives entirely in applyEvictionHorizon (the wire render), not
+in the stored horizon. It still prefers the next real user turn as the
+kept-window anchor. But when NO user turn survives the horizon — the
+runaway-autonomous-run case — it no longer skips to a user message and
+walks off the end into an empty list. It keeps the recent tail anchored
+on the first non-orphan message: it drops only leading `toolResult`
+messages (a tool result whose tool call was evicted is the one head shape
+the provider rejects) and anchors on the next assistant turn. The budget
+walk in findEvictionHorizon still bounds how much of that tail rides the
+wire, so this never reintroduces unbounded context growth — it only
+guarantees a non-empty, provider-valid payload.
+
+Why NOT "never advance the horizon past the last user turn": that pins
+the entire post-user tail on the wire permanently, so a long autonomous
+run (exactly this scenario) grows unbounded and trades the silent loop
+for a context-overflow error. It is also empirically insufficient as a
+stored-horizon floor: the in-transform budget walk (`findEvictionHorizon`,
+gated by `messageTokens` = 0.6 * 200k = 120k tokens) re-advances the
+horizon forward every turn because the 1090-message tail exceeds budget,
+climbing right back over the last user turn. Verified: replaying with the
+persisted horizon set to `msg208.ts - 1` still yields retained=0, while
+truncating the tail under budget yields retained=12 with a real user
+turn. Compaction into durable memory is unaffected either way — the
+`onCompaction` drain runs before the horizon advances, so the evicted
+tail is always preserved in memory regardless of how far the horizon
+moves. The defect and the fix are purely about what the WIRE renders.

--- a/evals/fixtures/session_rUjMi_pUNzhB/system-prompt.txt
+++ b/evals/fixtures/session_rUjMi_pUNzhB/system-prompt.txt
@@ -1,0 +1,104 @@
+<system_prompt_file path="AGENTS.md">
+<content># Coding conventions and best practices
+
+Follow the main project readme (located in `README.md` in the root folder) on coding conventions and best practices. It will also inform you on how to run tests &amp; linters.</content>
+</system_prompt_file>
+
+<use_parallel_tool_calls>
+For maximum efficiency, whenever you perform multiple independent operations, invoke all relevant tools simultaneously rather than sequentially. Prioritize calling tools in parallel whenever possible. For example, when reading 3 files, run 3 tool calls in parallel to read all 3 files into context at the same time. When running multiple read-only commands like `ls` or `list_dir`, always run all of the commands in parallel. Err on the side of maximizing parallel tool calls rather than running too many tools sequentially.
+</use_parallel_tool_calls>
+
+<bash_timeout>
+Bash commands run with a default timeout of 600 seconds (10 minutes); commands that exceed it are killed and reported as timed out. Scope commands so they finish well under that — prefer narrow searches (e.g. `rg` inside the repo) over filesystem-wide walks like `find /`. When a command genuinely needs longer (long builds, test suites, package installs), pass an explicit `timeout` argument in seconds sized to the expected runtime.
+</bash_timeout>
+
+<cwd>
+Current working directory: /Users/david/dev/chat-app.
+Before responding to a request that touches files, code, or project state, spend a tool call or two exploring this directory (e.g. `ls`, `rg`, `read`) so your answer reflects what is actually here rather than assumptions. Skip exploration only for requests that are clearly unrelated to the workspace.
+</cwd>
+
+Available skills (metadata only — `read` the SKILL.md at the listed `path` to load full instructions when a skill's description matches the task at hand, or to edit the skill itself):
+<skills>
+<skill name="write-tests" path="/Users/david/dev/chat-app/.agents/skills/write-tests/SKILL.md">
+<description>Write and revise unit/integration tests for this repo so they assert real behavior instead of coupling to config, types, or implementation internals. Use when adding tests, fixing brittle/flaky tests, reviewing a test diff, or when a test breaks after a config or refactor change that didn't change user-visible behavior.</description>
+</skill>
+<skill name="review" path="/Users/david/dev/chat-app/.agents/skills/review/SKILL.md">
+<description>Review changed code for naming, stale references, unnecessary complexity, and comment quality. Use after completing implementation work, before committing, or when the user asks to review or audit code.</description>
+</skill>
+<skill name="deploy-to-prod" path="/Users/david/dev/chat-app/.agents/skills/deploy-to-prod/SKILL.md">
+<description>Deploy the current state of `staging` to production by fast-forwarding `main` to match it. Use when the user says &quot;deploy to prod&quot;, &quot;ship to prod&quot;, &quot;promote staging to main&quot;, &quot;release to production&quot;, or otherwise asks to cut a production release. Pushing `main` triggers Vercel's prod deployment, which also triggers a Convex prod deployment.</description>
+</skill>
+<skill name="ui-playground" path="/Users/david/dev/chat-app/.agents/skills/ui-playground/SKILL.md">
+<description>Run and reason about the `/playground` visual-regression suite. Use after touching any file under `apps/web/components/**` or `apps/web/spa/**`, when adding a new UI surface, or when the user says &quot;check UI regression&quot;, &quot;visual diff&quot;, &quot;screenshot diff&quot;, &quot;run visual tests&quot;, or &quot;approve baselines&quot;.</description>
+</skill>
+<skill name="add-skill" path="/Users/david/.duet/skills/add-skill/SKILL.md">
+<description>Add, install, or edit agent skills from external sources — GitHub repos, URLs, or webpages. Use when the user asks to add a skill from GitHub, install a skill from a URL or webpage, import an external skill, edit or update an existing installed skill, modify a skill's SKILL.md or resources, or customize an installed skill.</description>
+</skill>
+<skill name="branded-content" path="/Users/david/.duet/skills/branded-content/SKILL.md">
+<description>Generate branded social media content for a person. Extracts brand identity from a website (colors, fonts, logo, voice) via Firecrawl, enriches a person's profile via Crustdata (LinkedIn URL) or FullEnrich (reverse email lookup), then generates a branded social media post (text + 1:1 image). Use when asked to create branded content, social media posts with company branding, or personalized marketing visuals.</description>
+</skill>
+<skill name="ai-gateway" path="/Users/david/.duet/skills/ai-gateway/SKILL.md">
+<description>Proxy to Vercel's AI Gateway for making AI model calls with your Duet API key. Supports text, code, image, and video models via Vercel AI SDK, OpenAI-compatible, and Anthropic-compatible APIs. Use when you need to call AI models (GPT, Claude, Gemini, etc.) from within the sandbox environment.</description>
+</skill>
+<skill name="impeccable" path="/Users/david/.duet/skills/impeccable/SKILL.md">
+<description>Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.</description>
+</skill>
+<skill name="firecrawl" path="/Users/david/.duet/skills/firecrawl/SKILL.md">
+<description>Web scraping, search, crawling, and browser automation via Firecrawl's HTTP API. Returns clean LLM-optimized markdown. Use when the user asks to scrape a webpage, search the web, crawl a site, extract content from URLs, or automate browser interactions for data extraction.</description>
+</skill>
+<skill name="crm" path="/Users/david/.duet/skills/crm/SKILL.md">
+<description>Store and look up people, companies, deals, leads, and pipeline activity using crm.cli. Use whenever the user mentions a contact, company, deal, lead, pipeline, or asks to remember/save a person or business — whether it's a personal CRM (friends, network) or a work CRM (prospects, customers).</description>
+</skill>
+<skill name="pdf" path="/Users/david/.duet/skills/pdf/SKILL.md">
+<description>Create, extract from, and modify PDF files. Generate PDFs with ReportLab (reports, forms, tables, charts), extract text/tables/images with pdfplumber (with pytesseract OCR fallback for scanned documents), and merge/split/rotate/watermark/fill PDFs with pypdf. Use when the user asks to create, generate, build, extract from, parse, OCR, merge, split, rotate, watermark, or fill a PDF.</description>
+</skill>
+<skill name="find-skills" path="/Users/david/.duet/skills/find-skills/SKILL.md">
+<description>Search for and install agent skills from the open skills ecosystem. Use when the user asks to find, discover, search for, or install new skills or capabilities.</description>
+</skill>
+<skill name="webhook-collector" path="/Users/david/.duet/skills/webhook-collector/SKILL.md">
+<description>Create webhook endpoints, send test payloads, and inspect captured events using webhookcollector.dev. Use for both temporary testing and permanent webhook infrastructure. Endpoints are persistent — only event data expires after 24hrs, so pair with a cron to drain events for long-lived use. Use when the user asks to test webhooks, receive callbacks, capture HTTP requests, debug webhook integrations, create a webhook listener, or inspect incoming payloads. No authentication or signup required.</description>
+</skill>
+<skill name="create-skill" path="/Users/david/.duet/skills/create-skill/SKILL.md">
+<description>Create, validate, and install custom local skills. Use when you need to create a new skill (or update an existing skill) that extends agent capabilities with specialized knowledge, workflows, or tool integrations. Also use when asked to add a reusable capability that should persist across sessions.</description>
+</skill>
+<skill name="github" path="/Users/david/.duet/skills/github/SKILL.md">
+<description>Interact with GitHub using the `gh` CLI. Use `gh issue`, `gh pr`, `gh run`, and `gh api` for issues, PRs, CI runs, and advanced queries.</description>
+</skill>
+<skill name="file-conversion" path="/Users/david/.duet/skills/file-conversion/SKILL.md">
+<description>Convert files between formats — images (JPG/PNG/WEBP/HEIC/SVG via Pillow, pillow-heif, cairosvg), video (clip extraction and video-to-GIF via moviepy/ffmpeg), and documents (DOCX/PPTX ↔ Markdown ↔ PDF via pypandoc, python-docx, python-pptx, libreoffice, markitdown). Use when the user asks to convert, transform, resize, rasterize, re-encode, or change the format of an image, video clip, or document file.</description>
+</skill>
+<skill name="media-creation" path="/Users/david/.duet/skills/media-creation/SKILL.md">
+<description>Generate images and videos using Duet's AI Gateway. Create images from text prompts (GPT Image 2 default), generate video clips (Seedance 2.0). Falls back to Fal AI only for capabilities not available on the gateway.</description>
+</skill>
+<skill name="composio-credentials" path="/Users/david/.duet/skills/composio-credentials/SKILL.md">
+<description>Reference for calling Composio tools (Linear, GitHub, Slack, etc.) from standalone sandbox apps via the Duet proxy. Use when building any service, app, or script that needs to call external APIs through Composio outside of the MCP tool context — e.g., a Node.js server deployed as a Duet public app.</description>
+</skill>
+<skill name="go-to-market" path="/Users/david/.duet/skills/go-to-market/SKILL.md">
+<description>Research accounts, enrich leads, search contacts, look up firmographics, query Crustdata and FullEnrich APIs, profile/research/analyze competitors, write sales emails, perform SEO keyword research, Amazon/Google Shopping product research, App Store optimization, AI search visibility analysis, and website technology lookups using DataForSEO.</description>
+</skill>
+<skill name="vercel-react-native-skills" path="/Users/david/.agents/skills/vercel-react-native-skills/SKILL.md">
+<description>React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules. Triggers on tasks involving React Native, Expo, mobile performance, or native platform APIs.</description>
+</skill>
+<skill name="web-design-guidelines" path="/Users/david/.agents/skills/web-design-guidelines/SKILL.md">
+<description>Review UI code for Web Interface Guidelines compliance. Use when asked to &quot;review my UI&quot;, &quot;check accessibility&quot;, &quot;audit design&quot;, &quot;review UX&quot;, or &quot;check my site against best practices&quot;.</description>
+</skill>
+<skill name="vercel-react-view-transitions" path="/Users/david/.agents/skills/vercel-react-view-transitions/SKILL.md">
+<description>Guide for implementing smooth, native-feeling animations using React's View Transition API (`&lt;ViewTransition&gt;` component, `addTransitionType`, and CSS view transition pseudo-elements). Use this skill whenever the user wants to add page transitions, animate route changes, create shared element animations, animate enter/exit of components, animate list reorder, implement directional (forward/back) navigation animations, or integrate view transitions in Next.js. Also use when the user mentions view transitions, `startViewTransition`, `ViewTransition`, transition types, or asks about animating between UI states in React without third-party animation libraries.</description>
+</skill>
+<skill name="opentui" path="/Users/david/.agents/skills/opentui/SKILL.md">
+<description>Build terminal UIs with OpenTUI. Covers the core API, keymaps, React and Solid bindings, components, layout, keyboard input, plugins, and testing.</description>
+</skill>
+<skill name="vercel-react-best-practices" path="/Users/david/.agents/skills/vercel-react-best-practices/SKILL.md">
+<description>React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.</description>
+</skill>
+<skill name="vercel-composition-patterns" path="/Users/david/.agents/skills/vercel-composition-patterns/SKILL.md">
+<description>React composition patterns that scale. Use when refactoring components with boolean prop proliferation, building flexible component libraries, or designing reusable APIs. Triggers on tasks involving compound components, render props, context providers, or component architecture. Includes React 19 API changes.</description>
+</skill>
+<skill name="relay" path="&lt;duet-builtin&gt;/relay/SKILL.md">
+<description>Run durable, multi-step, or recurring work as a state machine of sub-agent, script, poll, and timer states so the work survives session boundaries and progress stays visible to the user.</description>
+</skill>
+</skills>
+
+<current_date>
+Today's date (UTC): 2026-06-18. Resolution is intentionally limited to the day to preserve prompt caching. If you need finer-grained time, run `date` via bash.
+</current_date>

--- a/evals/session-loop-wire-starvation.eval.ts
+++ b/evals/session-loop-wire-starvation.eval.ts
@@ -11,17 +11,24 @@ import { capturedWirePayload } from "./helpers/capture-wire-payload.js";
  *
  * That session ran away into a tight infinite loop: from message 334 on,
  * the assistant re-issued the SAME "let me check the current state / pick
- * up where we left off" orientation 242 times — git status, re-read
+ * up where we left off" orientation ~240 times — git status, re-read
  * `packages/backend/convex/domains/kanban/definitions.ts`, re-run the
  * (already green) typecheck — never editing, never finishing, until the
  * user killed it. Full write-up in
  * `evals/fixtures/session_rUjMi_pUNzhB/reproduce_and_diagnose.txt`.
  *
+ * The committed `state.json` is trimmed to message 348 — the legit
+ * refactor work (209–333) plus the FIRST few loop iterations (334+) — so
+ * the eval proves the fix engages the moment the loop begins, not only
+ * after the full ~1090-message pileup the live session reached. The
+ * starvation trigger is intact: the horizon still sits on the last user
+ * turn and no user turn survives it.
+ *
  * Root cause is wire starvation. The eviction horizon advanced to
  * EXACTLY the timestamp of the last user turn (message 208, the literal
  * text "continue"). `applyEvictionHorizon` drops messages with
  * `timestamp <= horizon`, so that user turn is itself evicted, and every
- * one of the 1090 messages after it is the agent's own autonomous loop —
+ * one of the messages after it is the agent's own autonomous loop —
  * zero user-role survivors. The broken orphan-head skip then walked the
  * entire tail looking for a `user` message, found none, and collapsed
  * the wire to zero real messages. The model saw only the durable
@@ -78,19 +85,19 @@ describe("session_rUjMi_pUNzhB infinite loop from wire starvation", () => {
         const messages: AgentMessage[] = turnState.state.agent.messages;
         const horizon: number = turnState.state.wireGuardHorizon.evictionHorizon;
 
-        // Fixture sanity: the runaway transcript is real and large — the
-        // loop appended ~1090 autonomous turns, and not one of them is a
-        // user turn. That zero-user tail is the structural trigger: the
-        // horizon sits on the last user message, so `applyEvictionHorizon`'s
+        // Fixture sanity: the trimmed transcript stops a few iterations
+        // into the loop, and not one post-horizon message is a user turn.
+        // That zero-user tail is the structural trigger: the horizon sits
+        // on the last user message (208), so `applyEvictionHorizon`'s
         // orphan-head skip has nothing to anchor on past it. These two are
         // properties of the captured data, not the code under test.
-        expect(payload.rawMessageCount).toBe(1299);
+        expect(payload.rawMessageCount).toBe(349);
         expect(postHorizonUserCount(messages, horizon)).toBe(0);
 
-        // The invariant the runner must hold: a session with this much
-        // post-horizon history must NOT be dispatched an empty transcript.
-        // Against the broken code the transform collapsed all 1090 tail
-        // messages to zero real messages and shipped only the two static
+        // The invariant the runner must hold: a session whose post-horizon
+        // history has no user turn must NOT be dispatched an empty
+        // transcript. Against the broken code the transform collapsed the
+        // whole tail to zero real messages and shipped only the two static
         // synthetic prepends, so the model re-planned identically every
         // turn and looped forever. The fix keeps a recent, budget-bounded
         // tail anchored on a provider-valid head, so the model sees its
@@ -111,11 +118,12 @@ describe("session_rUjMi_pUNzhB infinite loop from wire starvation", () => {
         const firstReal = payload.dispatched[payload.syntheticPrepends.length];
         expect(firstReal?.role).not.toBe("toolResult");
 
-        // Not overflowing: the budget walk still evicts the bulk of the
-        // 1090-message tail, so the dispatch stays far under the effective
-        // context window. Retaining a tail does NOT reintroduce unbounded
-        // growth — it is bounded by the same `messageTokens` budget that
-        // drove eviction in the first place.
+        // Not overflowing: the dispatch stays far under the effective
+        // context window. On the full untrimmed session the budget walk
+        // evicts the bulk of the 1090-message tail to hold this bound;
+        // here the trimmed tail is already well within it. Retaining a
+        // tail does NOT reintroduce unbounded growth — it is bounded by
+        // the same `messageTokens` budget that drove eviction.
         expect(payload.retainedMessageCount).toBeLessThan(payload.rawMessageCount);
         expect(payload.dispatchedTokens).toBeLessThan(120_000);
       } finally {

--- a/evals/session-loop-wire-starvation.eval.ts
+++ b/evals/session-loop-wire-starvation.eval.ts
@@ -1,0 +1,127 @@
+import { describe, expect } from "bun:test";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { testIfDocker } from "../test/helpers/docker-only.js";
+import { capturedWirePayload } from "./helpers/capture-wire-payload.js";
+
+/**
+ * Real-data regression for session_rUjMi_pUNzhB.
+ *
+ * That session ran away into a tight infinite loop: from message 334 on,
+ * the assistant re-issued the SAME "let me check the current state / pick
+ * up where we left off" orientation 242 times — git status, re-read
+ * `packages/backend/convex/domains/kanban/definitions.ts`, re-run the
+ * (already green) typecheck — never editing, never finishing, until the
+ * user killed it. Full write-up in
+ * `evals/fixtures/session_rUjMi_pUNzhB/reproduce_and_diagnose.txt`.
+ *
+ * Root cause is wire starvation. The eviction horizon advanced to
+ * EXACTLY the timestamp of the last user turn (message 208, the literal
+ * text "continue"). `applyEvictionHorizon` drops messages with
+ * `timestamp <= horizon`, so that user turn is itself evicted, and every
+ * one of the 1090 messages after it is the agent's own autonomous loop —
+ * zero user-role survivors. The broken orphan-head skip then walked the
+ * entire tail looking for a `user` message, found none, and collapsed
+ * the wire to zero real messages. The model saw only the durable
+ * observation block + the continuation hint, both static, so it
+ * reconstructed the identical plan every turn, emitted only
+ * assistant/tool messages (never a new user anchor), and the horizon
+ * could never recover — a permanent loop.
+ *
+ * The fix keeps a recent, budget-bounded tail anchored on a
+ * provider-valid head when no user turn survives, so the model sees its
+ * own recent work and breaks out. This eval is the regression guard: it
+ * is GREEN with the fix (a large post-horizon tail is never dispatched
+ * as an empty transcript) and RED if applyEvictionHorizon regresses to
+ * skipping to a user turn that does not exist — `retainedMessageCount`
+ * collapses back to 0 and the `toBeGreaterThan(0)` assertion fails, which
+ * IS the reproduction.
+ *
+ * Run via the docker eval harness so the path matches `bun run eval`:
+ *
+ *   docker run --rm -v "$PWD:/src:ro" -w /work -e HOME=/tmp/home \
+ *     -e DUET_TEST_IN_DOCKER=1 \
+ *     oven/bun:1.3.11 sh -lc 'cp -R /src/. /work && \
+ *     bun install --frozen-lockfile >/dev/null 2>&1 && \
+ *     bun test ./evals/session-loop-wire-starvation.eval.ts'
+ */
+
+const FIXTURE_DIR = join(import.meta.dir, "fixtures", "session_rUjMi_pUNzhB");
+const SESSION_ID = "session_rUjMi_pUNzhB";
+
+function postHorizonUserCount(messages: AgentMessage[], horizon: number): number {
+  return messages.filter(
+    (m) => m.role === "user" && ((m as { timestamp?: number }).timestamp ?? 0) > horizon,
+  ).length;
+}
+
+describe("session_rUjMi_pUNzhB infinite loop from wire starvation", () => {
+  testIfDocker(
+    "keeps a bounded, provider-valid recent tail on the wire instead of collapsing a huge post-horizon tail to empty",
+    async () => {
+      const [stateJson, dumpJson] = await Promise.all([
+        readFile(join(FIXTURE_DIR, "state.json"), "utf8"),
+        readFile(join(FIXTURE_DIR, "memory-dump.json"), "utf8"),
+      ]);
+      const turnState = JSON.parse(stateJson);
+      const memoryDump = JSON.parse(dumpJson);
+
+      const { payload, dispose } = await capturedWirePayload({
+        turnState,
+        memoryDump,
+        sessionId: SESSION_ID,
+      });
+
+      try {
+        const messages: AgentMessage[] = turnState.state.agent.messages;
+        const horizon: number = turnState.state.wireGuardHorizon.evictionHorizon;
+
+        // Fixture sanity: the runaway transcript is real and large — the
+        // loop appended ~1090 autonomous turns, and not one of them is a
+        // user turn. That zero-user tail is the structural trigger: the
+        // horizon sits on the last user message, so `applyEvictionHorizon`'s
+        // orphan-head skip has nothing to anchor on past it. These two are
+        // properties of the captured data, not the code under test.
+        expect(payload.rawMessageCount).toBe(1299);
+        expect(postHorizonUserCount(messages, horizon)).toBe(0);
+
+        // The invariant the runner must hold: a session with this much
+        // post-horizon history must NOT be dispatched an empty transcript.
+        // Against the broken code the transform collapsed all 1090 tail
+        // messages to zero real messages and shipped only the two static
+        // synthetic prepends, so the model re-planned identically every
+        // turn and looped forever. The fix keeps a recent, budget-bounded
+        // tail anchored on a provider-valid head, so the model sees its
+        // own recent work and can break the loop.
+        //
+        // Not starved: real transcript messages ride the wire.
+        expect(
+          payload.retainedMessageCount,
+          "wire starved: post-horizon messages collapsed to an empty dispatch",
+        ).toBeGreaterThan(0);
+        expect(payload.dispatched.length).toBeGreaterThan(2);
+
+        // The retained head is provider-valid: never a leading orphan tool
+        // result (a `toolResult` whose matching tool call was evicted). The
+        // autonomous tail carries no user turn, so anchoring on an assistant
+        // message is correct — the two synthetic prepends already give the
+        // wire its user-role head.
+        const firstReal = payload.dispatched[payload.syntheticPrepends.length];
+        expect(firstReal?.role).not.toBe("toolResult");
+
+        // Not overflowing: the budget walk still evicts the bulk of the
+        // 1090-message tail, so the dispatch stays far under the effective
+        // context window. Retaining a tail does NOT reintroduce unbounded
+        // growth — it is bounded by the same `messageTokens` budget that
+        // drove eviction in the first place.
+        expect(payload.retainedMessageCount).toBeLessThan(payload.rawMessageCount);
+        expect(payload.dispatchedTokens).toBeLessThan(120_000);
+      } finally {
+        await dispose();
+      }
+    },
+    60_000,
+  );
+});

--- a/src/turn-runner/wire-shaping.ts
+++ b/src/turn-runner/wire-shaping.ts
@@ -166,8 +166,21 @@ export function calculateWireTokens(messages: AgentMessage[]): number {
 
 /**
  * Drop messages whose timestamp is at or before the eviction horizon, then
- * skip any orphan tool results or assistant messages at the new head so
- * the provider API receives a list that starts with a `user` turn.
+ * pick a provider-valid head for the surviving tail.
+ *
+ * Preferred anchor is the next real `user` turn: the cleanest head and the
+ * strongest context anchor. But a long autonomous run (a tool loop with no
+ * intervening user input) can leave a post-horizon tail with NO user turn
+ * at all. Skipping to a user message then would walk off the end and return
+ * an empty list — which starves the wire and lets the model loop forever,
+ * re-planning identically from durable memory every turn because it never
+ * sees its own recent work (see session_rUjMi_pUNzhB). When no user turn
+ * survives, fall back to keeping the recent tail anchored on the first
+ * non-orphan message: drop only leading `toolResult` messages, since a tool
+ * result whose matching tool call was evicted is the one head shape the
+ * provider rejects. The budget walk in {@link findEvictionHorizon} still
+ * bounds how much of that tail rides the wire, so this never reintroduces
+ * unbounded context growth — it only guarantees a non-empty, valid payload.
  */
 export function applyEvictionHorizon(messages: AgentMessage[], horizon: number): AgentMessage[] {
   if (horizon <= 0) return messages;
@@ -175,11 +188,24 @@ export function applyEvictionHorizon(messages: AgentMessage[], horizon: number):
   while (firstKept < messages.length && messageTimestamp(messages[firstKept]!) <= horizon) {
     firstKept += 1;
   }
-  while (firstKept < messages.length && messages[firstKept]!.role !== "user") {
-    firstKept += 1;
-  }
   if (firstKept === 0) return messages;
-  return messages.slice(firstKept);
+
+  let userAnchor = firstKept;
+  while (userAnchor < messages.length && messages[userAnchor]!.role !== "user") {
+    userAnchor += 1;
+  }
+  if (userAnchor < messages.length) return messages.slice(userAnchor);
+
+  let nonOrphan = firstKept;
+  while (nonOrphan < messages.length && messages[nonOrphan]!.role === "toolResult") {
+    nonOrphan += 1;
+  }
+  // Degenerate tail of nothing but orphan tool results: empty-after-skip and
+  // provider-invalid both lose, so keep the raw post-horizon slice — a
+  // non-empty payload is the lesser evil and effectively never happens in
+  // practice (tool results sit adjacent to the call that produced them).
+  if (nonOrphan >= messages.length) return messages.slice(firstKept);
+  return messages.slice(nonOrphan);
 }
 
 /**

--- a/test/wire-shaping.test.ts
+++ b/test/wire-shaping.test.ts
@@ -48,11 +48,11 @@ describe("applyEvictionHorizon", () => {
     ]);
   });
 
-  test("sweeps past orphan toolResult and assistant at the new head when the cut splits a tool pair", () => {
-    // Cut falls right after the assistant tool_use. Without the sweep the
-    // dispatched list would start with `toolResult` (no matching assistant
-    // tool_use earlier in the conversation) and the provider API would
-    // reject the request.
+  test("anchors on the next user turn when one survives the horizon", () => {
+    // Cut falls right after the assistant tool_use. The dispatched list
+    // must not start with `toolResult` (no matching assistant tool_use
+    // earlier in the conversation) or the provider API rejects it. A real
+    // user turn survives downstream, so it is the preferred anchor.
     const messages = [
       userText("user1", 1),
       assistantToolCall("toolu_1", 2),
@@ -70,13 +70,38 @@ describe("applyEvictionHorizon", () => {
     expect(out).toHaveLength(4);
   });
 
-  test("returns an empty list when no user message remains after the horizon", () => {
+  test("keeps the assistant-anchored tail when no user turn survives the horizon", () => {
+    // A long autonomous run (tool loop, no intervening user input) leaves a
+    // post-horizon tail with no user turn. Skipping to a user message would
+    // walk off the end and return [], starving the wire and letting the
+    // model loop forever (session_rUjMi_pUNzhB). Anchor on the first
+    // non-orphan message instead: here that is the surviving assistant
+    // tool_use, whose result follows it, so the head is provider-valid.
     const messages = [
       userText("only-user", 1),
       assistantToolCall("toolu_1", 2),
       toolResultText("toolu_1", "ok", 3),
     ];
-    expect(applyEvictionHorizon(messages, 1)).toEqual([]);
+    const out = applyEvictionHorizon(messages, 1);
+    expect(out.map((m) => m.role)).toEqual(["assistant", "toolResult"]);
+  });
+
+  test("drops leading orphan tool results when no user turn survives the horizon", () => {
+    // The cut splits a tool pair AND no user turn follows. The leading
+    // toolResult is an orphan (its tool_use was evicted), so it must be
+    // dropped; the next assistant tool_use is the first valid head.
+    const messages = [
+      userText("only-user", 1),
+      assistantToolCall("toolu_1", 2),
+      toolResultText("toolu_1", "ok", 3),
+      assistantToolCall("toolu_2", 4),
+      toolResultText("toolu_2", "ok", 5),
+    ];
+    // horizon=2 drops user + first assistant, leaving an orphan toolResult
+    // at the head.
+    const out = applyEvictionHorizon(messages, 2);
+    expect(out[0]?.role).toBe("assistant");
+    expect(out.map((m) => m.role)).toEqual(["assistant", "toolResult"]);
   });
 });
 


### PR DESCRIPTION
## Problem

A session (`session_rUjMi_pUNzhB`) ran away into a tight infinite loop, burning ~\$7 of opus before the user killed it. From message 334 on, the assistant re-issued the same "let me check the current state / pick up where we left off" orientation ~240 times — re-running an already-green typecheck, re-reading the same files, never finishing.

**Root cause is wire starvation.** The eviction horizon advanced to *exactly* the timestamp of the last user turn (message 208, the literal text `continue`). `applyEvictionHorizon` drops messages with `timestamp <= horizon`, so that user turn was itself evicted, and every message after it was the agent's own autonomous loop — zero user-role survivors. The old orphan-head skip walked the entire tail looking for a `user` message, found none, and returned an **empty list**. The model then saw only the static durable-observation block + continuation hint, reconstructed the identical plan every turn, emitted only assistant/tool messages (never a new user anchor), and the horizon could never recover — a permanent loop.

## Fix

`applyEvictionHorizon` now picks a provider-valid head for the surviving tail:

- **Preferred anchor:** the next real `user` turn (unchanged behavior, strongest context anchor).
- **Fallback when no user turn survives:** keep the recent tail anchored on the first non-orphan message — drop only leading `toolResult` messages (an orphan tool result whose call was evicted is the one head shape the provider rejects).

The budget walk in `findEvictionHorizon` still bounds how much of that tail rides the wire, so this never reintroduces unbounded context growth — it only guarantees a non-empty, valid payload.

## Tests

- **`test/wire-shaping.test.ts`** — unit coverage for the three head shapes: user-anchored, assistant-anchored (no user survives), and leading-orphan-toolResult drop. The old "returns an empty list" test is rewritten to assert the new non-empty contract.
- **`evals/session-loop-wire-starvation.eval.ts`** — deterministic real-data regression that replays the captured session through the production wire-shaping transform. RED against the broken code (`retainedMessageCount === 0`), GREEN after the fix.
- The committed `state.json` is **trimmed from 1299 to 349 messages** — the legit refactor work plus the first few loop iterations — so the guard catches the regression at the loop's *onset*, not only after the full ~1090-message pileup. The starvation trigger is preserved exactly (horizon == `msgs[208].timestamp`, zero post-horizon user turns).

Full diagnosis in `evals/fixtures/session_rUjMi_pUNzhB/reproduce_and_diagnose.txt`.

Verified: `tsc --noEmit`, `oxlint`, `oxfmt`, and all wire-shaping unit + eval tests pass (eval falsified by reverting the fix → re-collapses to 0).