### PR TITLE
david feat: add `duet memory list` JSON/table query

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -17,7 +17,7 @@ USAGE
   duet login [--no-browser] [--skip-skill-sync]
   duet env [--env-file <path>] [--import [path]|--keys]
   duet skills [--workdir <path>]
-  duet memory [--db <path>]
+  duet memory [--db <path>] [--json] [filters]
   duet model -m <model> [--type text|image|video] [prompt]
   duet send-feedback [--file <path>] [text...]
   duet upgrade [--manager npm|bun|pnpm|yarn]
@@ -27,7 +27,7 @@ COMMANDS
   login                    Sign in via browser; saves DUET_API_KEY and syncs default skills (recommended)
   env                      Manually create or update the shared duet env file with provider API keys
   skills                   List installed skills + collisions as JSON
-  memory                   Open a TUI to view, edit, and delete observational memories (alias: memories)
+  memory                   Browse memories in a TUI, or query them with --json/filters (alias: memories)
   model                    Call a gateway model directly (text/image/video) via the AI SDK
   send-feedback            Send free-form markdown feedback to the Duet team
   upgrade                  Upgrade the global ${packageName} installation
@@ -176,14 +176,29 @@ OUTPUT
 
 export function printMemoryHelp(): void {
   console.log(`
-duet memory — Browse, edit, and delete observational memories
+duet memory — Browse, query, edit, and delete observational memories
 
 USAGE
   duet memory [--db <path>] [--wait <seconds>]
+  duet memory [--json] [--type <kind>] [--priority <level>] [--source <origin>]
+              [--from <date>] [--to <date>]
   duet memory reflect [options]
 
 ALIASES
   duet memories
+
+DESCRIPTION
+  Bare \`duet memory\` opens an interactive TUI to browse, edit, and delete
+  durable observations. Passing --json or any filter flag instead runs a
+  non-TUI, scriptable query: it prints a flat, chronological list (newest
+  createdAt first) of the matching observations, each carrying a computed
+  \`score\` field matching the runner's global-pack ranking. With --json the
+  output is a machine-readable array; otherwise an aligned table is printed.
+
+  Examples:
+    duet memory
+    duet memory --json --type reflection --from 2026-06-26
+    duet memory --json --from "$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%S)"
 
 SUBCOMMANDS
   add                      Write a single user-added note memory
@@ -191,13 +206,24 @@ SUBCOMMANDS
   reflect                  Condense old global observations into reflection rows
                            (run \`duet memory reflect --help\` for reflect-specific options)
 
+QUERY OPTIONS
+  --json                   Emit a JSON array instead of a table (also enables query mode)
+  --type <kind>            Filter by kind: observation | reflection | manual
+  --kind <kind>            Alias for --type
+  --priority <level>       Filter by priority: high | medium | low
+  --source <origin>        Filter by source: user | agent | system
+  --from <date>            Inclusive lower bound on createdAt. Accepts
+                           YYYY-MM-DD (start of day UTC) or YYYY-MM-DDTHH:MM:SS (UTC)
+  --to <date>              Inclusive upper bound on createdAt. Accepts
+                           YYYY-MM-DD (end of day UTC) or YYYY-MM-DDTHH:MM:SS (UTC)
+
 OPTIONS
   --db <path>              Memory database path (default: ~/.duet/memory.db)
   --wait <seconds>         Seconds to wait for the cross-process open-lock when a peer
                            duet process is holding it (default: 30; 0 fails immediately)
   -h, --help               Show this help
 
-KEYS
+KEYS (TUI)
   ↑ / ↓                    Move selection
   e                        Edit selected memory in $EDITOR
   d                        Delete selected memory
@@ -319,10 +345,10 @@ duet train — Ingest a project corpus into one durable memory observation
 
 USAGE
   duet train <folder> [--slug <name>] [--model <name>] [--db <path>] [--wait <seconds>]
-  duet train list [--db <path>] [--json]
-  duet train show <slug> [--db <path>] [--json]
-  duet train update <slug> --content-file <path> [--db <path>] [--json]
-  duet train delete <slug> [--db <path>] [--json]
+  duet train list [--db <path>] [--json] [--wait <seconds>]
+  duet train show <slug> [--db <path>] [--json] [--wait <seconds>]
+  duet train update <slug> --content-file <path> [--db <path>] [--json] [--wait <seconds>]
+  duet train delete <slug> [--db <path>] [--json] [--wait <seconds>]
 
 DESCRIPTION
   Launches a duet agent with the corpus folder as its working directory.

--- a/src/cli/memory-db.ts
+++ b/src/cli/memory-db.ts
@@ -7,21 +7,38 @@ import {
   DEFAULT_RECENCY_HALF_LIFE_MS,
   DEFAULT_REFLECTION_BIAS,
 } from "../memory/observational.js";
-import { DEFAULT_OPEN_LOCK_WAIT_BUDGET_MS, openPGliteWaitingForLock } from "../memory/pglite.js";
+import {
+  DEFAULT_OPEN_LOCK_WAIT_BUDGET_MS,
+  MemoryLockTimeoutError,
+  openPGliteWaitingForLock,
+} from "../memory/pglite.js";
 import { readArchiveManifest, removeArchive } from "../train/archive.js";
 import { isTrainTagged, slugFromTags } from "../train/tags.js";
 import type { TrainListEntry, TrainRecord } from "../train/types.js";
-import type { Observation } from "../types/memory.js";
+import type { Observation, ObservationSource } from "../types/memory.js";
+import { fail } from "./shared.js";
+import { installShutdownHandlers } from "./shutdown.js";
 
 /** Rows fetched per page by the ranked, lazily-paginated TUI list. */
 export const MEMORY_PAGE_SIZE = 25;
 
+export interface MemoryQueryFilters {
+  kind?: Observation["kind"];
+  priority?: Observation["priority"];
+  source?: ObservationSource["kind"];
+  fromMs?: number;
+  toMs?: number;
+}
+
 /**
  * Absolute global-pack score for one observation under the CLI defaults.
- * Reuses the shared {@link observationScore} formula so the displayed value
- * tracks the runner's ranking exactly. Hardcoded to the runner's global-pack
- * defaults so the TUI ordering and the per-row score number match what the
- * runtime ranking would produce (loader.ts), with no flags to drift out of sync.
+ * Reuses the shared {@link observationScore} formula but layers the manual
+ * multiplier on top — `observationScore` only applies `reflectionBias`, so
+ * calling it directly would under-report curated/manual rows by the manual
+ * multiplier. The runner's `loadGlobalPack` applies `manualBias` to
+ * `kind === "manual"` as a separate factor, and the value surfaced here must
+ * match that ranking so the TUI ordering and the per-row score number agree
+ * with the runtime ranking across every kind, including manual rows.
  */
 export function scoreObservation(observation: Observation, now: number = Date.now()): number {
   return observationScore(observation, now, {
@@ -133,6 +150,31 @@ export class MemoryDb {
     return result.rows.map(rowToObservation);
   }
 
+  /** Query observations newest-first with the optional `duet memory` query filters. */
+  async queryObservations(filters: MemoryQueryFilters = {}): Promise<Observation[]> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    const bind = (clause: string, value: unknown): void => {
+      params.push(value);
+      conditions.push(clause.replace("$?", `$${params.length}`));
+    };
+    if (filters.kind !== undefined) bind("kind = $?", filters.kind);
+    if (filters.priority !== undefined) bind("priority = $?", filters.priority);
+    if (filters.source !== undefined) bind("(source_json::json->>'kind') = $?", filters.source);
+    if (filters.fromMs !== undefined) bind("created_at >= $?", filters.fromMs);
+    if (filters.toMs !== undefined) bind("created_at <= $?", filters.toMs);
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const result = await this.db.query<ObservationRow>(
+      `SELECT id, created_at, last_used_at, session_id, kind, observed_date, referenced_date, relative_date,
+              time_of_day, priority, source_json, content, tags_json
+       FROM observations
+       ${where}
+       ORDER BY created_at DESC, id ASC`,
+      params,
+    );
+    return result.rows.map(rowToObservation);
+  }
+
   /**
    * Every `duet train` row (those tagged `train`), newest-first, joined to its
    * archive manifest for headline/model/provenance. Backs `duet train list`.
@@ -201,6 +243,39 @@ export class MemoryDb {
 
   async close(): Promise<void> {
     await this.db.close();
+  }
+}
+
+/**
+ * Open the memory database for a one-shot CLI subcommand, run `fn`, and always
+ * close it. Cross-process lock contention surfaces as the same friendly,
+ * actionable message every memory/train subcommand uses rather than a raw
+ * error. Shared by `duet train` management commands and `duet memory` queries.
+ */
+export async function withMemoryDb<T>(
+  dbPath: string,
+  fn: (db: MemoryDb) => Promise<T>,
+  { waitBudgetMs }: { waitBudgetMs?: number } = {},
+): Promise<T> {
+  let db: MemoryDb;
+  try {
+    db = await MemoryDb.open(dbPath, { waitBudgetMs });
+  } catch (error) {
+    if (error instanceof MemoryLockTimeoutError) {
+      fail(
+        `Memory database at ${error.dataDir} is still locked by duet pid ${error.holderPid} after ${
+          error.budgetMs / 1000
+        }s. Stop that process (or pass --wait <seconds> to wait longer) and retry.`,
+      );
+    }
+    throw error;
+  }
+  const removeShutdownHandlers = installShutdownHandlers(() => db.close());
+  try {
+    return await fn(db);
+  } finally {
+    removeShutdownHandlers();
+    await db.close();
   }
 }
 

--- a/src/cli/memory-query.ts
+++ b/src/cli/memory-query.ts
@@ -1,0 +1,219 @@
+import { DEFAULT_MEMORY_DB_PATH } from "../session/session-manager.js";
+import type { Observation, ObservationKind, ObservationPriority } from "../types/memory.js";
+import { printMemoryHelp } from "./help.js";
+import { type MemoryQueryFilters, scoreObservation, withMemoryDb } from "./memory-db.js";
+import { fail, resolveUserPath } from "./shared.js";
+
+interface MemoryQueryIO {
+  stdout: NodeJS.WritableStream;
+}
+
+type ScoredObservation = Observation & { score: number };
+
+const KINDS = ["observation", "reflection", "manual"] as const satisfies readonly ObservationKind[];
+const PRIORITIES = ["high", "medium", "low"] as const satisfies readonly ObservationPriority[];
+type SourceKind = Observation["source"]["kind"];
+const SOURCES = ["user", "agent", "system"] as const satisfies readonly SourceKind[];
+
+export interface MemoryQueryOptions {
+  dbPath: string;
+  json: boolean;
+  filters: MemoryQueryFilters;
+  waitBudgetMs?: number;
+  /**
+   * True when the invocation requested a non-TUI query — i.e. it passed
+   * `--json` or any filter flag. Bare `duet memory` (only `--db`/`--wait`)
+   * leaves this false and opens the interactive TUI instead.
+   */
+  queryMode: boolean;
+}
+
+/** Parse UTC date filters; date-only bounds cover the whole day. */
+function parseDateBound(raw: string, flag: string, edge: "start" | "end"): number {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    const iso = `${raw}T${edge === "start" ? "00:00:00.000" : "23:59:59.999"}Z`;
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) fail(`Invalid ${flag} date: ${raw}`);
+    // Reject impossible calendar dates (e.g. 2026-02-31) that JS silently
+    // normalizes into a different day rather than returning NaN — otherwise a
+    // typo slides the createdAt window and the wrong rows get exported.
+    if (new Date(ms).toISOString().slice(0, 10) !== raw) {
+      fail(`Invalid ${flag} date: ${raw} is not a real calendar date`);
+    }
+    return ms;
+  }
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(raw)) {
+    const ms = Date.parse(`${raw}Z`);
+    if (Number.isNaN(ms)) fail(`Invalid ${flag} datetime: ${raw}`);
+    // Same round-trip guard for the datetime form (e.g. 2026-02-31T00:00:00).
+    if (new Date(ms).toISOString().slice(0, 19) !== raw) {
+      fail(`Invalid ${flag} datetime: ${raw} is not a real calendar datetime`);
+    }
+    return ms;
+  }
+  fail(`Invalid ${flag} value: ${raw} (expected YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)`);
+}
+
+function parseEnum<T extends string>(
+  raw: string | undefined,
+  allowed: readonly T[],
+  flag: string,
+): T {
+  if (!raw || raw.startsWith("-")) fail(`Missing value for ${flag}`);
+  if (!(allowed as readonly string[]).includes(raw)) {
+    fail(`Invalid ${flag} value: ${raw} (expected one of ${allowed.join(", ")})`);
+  }
+  return raw as T;
+}
+
+/**
+ * Parse the shared `duet memory` argument set. The same flags drive both the
+ * interactive TUI (bare invocation) and the scriptable query (any filter or
+ * `--json`); `queryMode` records which path the caller asked for. Returns
+ * `undefined` when `--help` was handled.
+ */
+export function parseMemoryArgs(args: string[]): MemoryQueryOptions | undefined {
+  let dbPath = DEFAULT_MEMORY_DB_PATH;
+  let json = false;
+  let waitBudgetMs: number | undefined;
+  let hasFilter = false;
+  const filters: MemoryQueryFilters = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    switch (arg) {
+      case "--db":
+        if (!args[i + 1] || args[i + 1]?.startsWith("-")) fail(`Missing value for ${arg}`);
+        dbPath = resolveUserPath(args[++i]!);
+        break;
+      // `--type` and `--kind` are aliases for the same `Observation.kind` axis.
+      case "--type":
+      case "--kind":
+        filters.kind = parseEnum(args[++i], KINDS, arg);
+        hasFilter = true;
+        break;
+      case "--priority":
+        filters.priority = parseEnum(args[++i], PRIORITIES, arg);
+        hasFilter = true;
+        break;
+      case "--source":
+        filters.source = parseEnum(args[++i], SOURCES, arg);
+        hasFilter = true;
+        break;
+      case "--from": {
+        const raw = args[++i];
+        if (!raw || raw.startsWith("-")) fail(`Missing value for ${arg}`);
+        filters.fromMs = parseDateBound(raw, arg, "start");
+        hasFilter = true;
+        break;
+      }
+      case "--to": {
+        const raw = args[++i];
+        if (!raw || raw.startsWith("-")) fail(`Missing value for ${arg}`);
+        filters.toMs = parseDateBound(raw, arg, "end");
+        hasFilter = true;
+        break;
+      }
+      case "--json":
+        json = true;
+        break;
+      case "--wait": {
+        const raw = args[++i];
+        const seconds = Number(raw);
+        if (!Number.isFinite(seconds) || seconds < 0) {
+          fail(`Invalid --wait value: ${raw} (expected non-negative number of seconds)`);
+        }
+        waitBudgetMs = seconds * 1000;
+        break;
+      }
+      case "--help":
+      case "-h":
+        printMemoryHelp();
+        return undefined;
+      default:
+        fail(`Unknown memory option: ${arg}`);
+    }
+  }
+
+  if (filters.fromMs !== undefined && filters.toMs !== undefined && filters.fromMs > filters.toMs) {
+    fail("--from must not be after --to");
+  }
+
+  return { dbPath, json, filters, waitBudgetMs, queryMode: json || hasFilter };
+}
+
+function truncate(value: string, max: number): string {
+  const collapsed = value.replace(/\s+/g, " ");
+  return collapsed.length <= max ? collapsed : `${collapsed.slice(0, max - 1)}…`;
+}
+
+export function formatMemoryTable(observations: ScoredObservation[]): string {
+  if (observations.length === 0) {
+    return "No memories matched. Adjust the filters or run `duet memory --help`.";
+  }
+  const rows = observations.map((o) => ({
+    created: new Date(o.createdAt).toISOString().slice(0, 10),
+    kind: o.kind,
+    priority: o.priority,
+    source: o.source.kind,
+    score: o.score.toFixed(2),
+    content: truncate(o.content, 60),
+    id: o.id,
+  }));
+  const headers = {
+    created: "CREATED",
+    kind: "KIND",
+    priority: "PRIORITY",
+    source: "SOURCE",
+    score: "SCORE",
+    content: "CONTENT",
+    id: "MEMORY ID",
+  };
+  const width = (key: keyof typeof headers, cap: number) =>
+    Math.min(cap, Math.max(headers[key].length, ...rows.map((row) => row[key].length)));
+  const w = {
+    created: width("created", 10),
+    kind: width("kind", 11),
+    priority: width("priority", 8),
+    source: width("source", 6),
+    score: width("score", 8),
+    content: width("content", 60),
+    id: width("id", 20),
+  };
+  const line = (cells: typeof headers) =>
+    [
+      cells.created.padEnd(w.created),
+      cells.kind.padEnd(w.kind),
+      cells.priority.padEnd(w.priority),
+      cells.source.padEnd(w.source),
+      cells.score.padStart(w.score),
+      truncate(cells.content, w.content).padEnd(w.content),
+      cells.id,
+    ].join("  ");
+  return [line(headers), ...rows.map(line)].join("\n");
+}
+
+/**
+ * Run the non-TUI query path of `duet memory`: fetch the filtered rows,
+ * compute each row's global-pack score, and print JSON or an aligned table.
+ */
+export async function runMemoryQuery(
+  options: MemoryQueryOptions,
+  io: MemoryQueryIO = { stdout: process.stdout },
+): Promise<void> {
+  const observations = await withMemoryDb(
+    options.dbPath,
+    (db) => db.queryObservations(options.filters),
+    { waitBudgetMs: options.waitBudgetMs },
+  );
+  // Score with a single `now` so every row's value is comparable.
+  const now = Date.now();
+  const scored: ScoredObservation[] = observations.map((o) => ({
+    ...o,
+    score: scoreObservation(o, now),
+  }));
+
+  io.stdout.write(
+    options.json ? `${JSON.stringify(scored, null, 2)}\n` : `${formatMemoryTable(scored)}\n`,
+  );
+}

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,69 +1,44 @@
 import { MemoryLockTimeoutError } from "../memory/pglite.js";
-import { DEFAULT_MEMORY_DB_PATH } from "../session/session-manager.js";
-import { printMemoryHelp } from "./help.js";
 import { runMemoryAddCommand } from "./memory-add.js";
 import { MemoryDb } from "./memory-db.js";
+import { parseMemoryArgs, runMemoryQuery } from "./memory-query.js";
 import { runMemoryReflectCommand } from "./memory-reflect.js";
 import { runMemoryTui } from "./memory-tui.js";
-import { fail, resolveUserPath } from "./shared.js";
+import { fail } from "./shared.js";
 import { installShutdownHandlers } from "./shutdown.js";
 
 /**
- * Run `duet memory` (alias: `duet memories`) — open the memory database in a TUI for browsing,
- * editing, and deleting durable observations.
+ * Run `duet memory` (alias: `duet memories`).
+ *
+ * One entry point for fetching and viewing durable memories: bare `duet
+ * memory` opens the interactive TUI for browsing/editing/deleting, while
+ * passing `--json` or any filter flag (`--type`/`--kind`/`--priority`/
+ * `--source`/`--from`/`--to`) turns the same invocation into a non-TUI,
+ * scriptable query. `duet memory reflect` remains a separate subcommand.
  *
  * Defaults to the same `~/.duet/memory.db` the runner writes to so changes
  * propagate to the next session immediately.
  */
 export async function runMemoryCommand(args: string[]): Promise<void> {
-  // Route `duet memory reflect ...` to the cross-session reflect command.
-  // Kept as a subcommand under `memory` so the existing TUI entry stays
-  // the bare `duet memory` invocation.
   if (args[0] === "reflect") {
     await runMemoryReflectCommand(args.slice(1));
     return;
   }
 
-  // Route `duet memory add ...` to the manual-write command. Kept as a
-  // subcommand under `memory` so the bare `duet memory` invocation stays
-  // the TUI browser.
   if (args[0] === "add") {
     await runMemoryAddCommand(args.slice(1));
     return;
   }
 
-  let dbPath = DEFAULT_MEMORY_DB_PATH;
-  // Wait budget for the cross-process open-lock, in seconds. Defaults to the shared
-  // `DEFAULT_OPEN_LOCK_WAIT_BUDGET_MS` (30s) inside `MemoryDb.open`; `--wait 0` opts out
-  // entirely for scripts that prefer an immediate failure when a peer is holding the lock.
-  let waitBudgetMs: number | undefined;
+  const options = parseMemoryArgs(args);
+  if (!options) return;
 
-  for (let i = 0; i < args.length; i++) {
-    switch (args[i]) {
-      case "--db":
-        if (!args[i + 1] || args[i + 1]?.startsWith("-")) fail(`Missing value for ${args[i]}`);
-        dbPath = resolveUserPath(args[++i]!);
-        break;
-      case "--wait": {
-        const raw = args[i + 1];
-        if (!raw || raw.startsWith("-")) fail(`Missing value for ${args[i]}`);
-        const seconds = Number(raw);
-        if (!Number.isFinite(seconds) || seconds < 0) {
-          fail(`Invalid --wait value: ${raw} (expected non-negative number of seconds)`);
-        }
-        waitBudgetMs = Math.round(seconds * 1000);
-        i++;
-        break;
-      }
-      case "--help":
-      case "-h":
-        printMemoryHelp();
-        return;
-      default:
-        fail(`Unknown memory option: ${args[i]}`);
-    }
+  if (options.queryMode) {
+    await runMemoryQuery(options);
+    return;
   }
 
+  const { dbPath, waitBudgetMs } = options;
   let db: MemoryDb;
   try {
     db = await MemoryDb.open(dbPath, { waitBudgetMs });

--- a/src/cli/train.ts
+++ b/src/cli/train.ts
@@ -19,7 +19,7 @@ import type {
 } from "../train/types.js";
 import type { TurnRunnerConfig } from "../types/config.js";
 import { printTrainHelp } from "./help.js";
-import { MemoryDb } from "./memory-db.js";
+import { withMemoryDb } from "./memory-db.js";
 import { fail, loadCliEnvFiles, resolveUserPath } from "./shared.js";
 import { installShutdownHandlers } from "./shutdown.js";
 
@@ -500,6 +500,7 @@ interface TrainSubOptions {
   json: boolean;
   /** Path to the new observation text, for `update`. */
   contentFile?: string;
+  waitBudgetMs?: number;
 }
 
 /**
@@ -512,6 +513,7 @@ function parseTrainSubArgs(args: string[]): TrainSubOptions | undefined {
   let dbPath = DEFAULT_MEMORY_DB_PATH;
   let json = false;
   let contentFile: string | undefined;
+  let waitBudgetMs: number | undefined;
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
     switch (arg) {
@@ -526,6 +528,15 @@ function parseTrainSubArgs(args: string[]): TrainSubOptions | undefined {
       case "--json":
         json = true;
         break;
+      case "--wait": {
+        const raw = args[++i];
+        const seconds = Number(raw);
+        if (!Number.isFinite(seconds) || seconds < 0) {
+          fail(`Invalid --wait value: ${raw} (expected non-negative number of seconds)`);
+        }
+        waitBudgetMs = seconds * 1000;
+        break;
+      }
       case "--help":
       case "-h":
         printTrainHelp();
@@ -536,42 +547,16 @@ function parseTrainSubArgs(args: string[]): TrainSubOptions | undefined {
         slug = arg;
     }
   }
-  return { slug, dbPath, json, contentFile };
-}
-
-/**
- * Open the memory database for a management subcommand, run `fn`, and always
- * close it. Lock contention surfaces as a friendly message (the same one the
- * create flow uses) rather than a raw error.
- */
-async function withTrainMemoryDb<T>(dbPath: string, fn: (db: MemoryDb) => Promise<T>): Promise<T> {
-  let db: MemoryDb;
-  try {
-    db = await MemoryDb.open(dbPath);
-  } catch (error) {
-    if (error instanceof MemoryLockTimeoutError) {
-      fail(
-        `Memory database at ${error.dataDir} is still locked by duet pid ${error.holderPid} after ${
-          error.budgetMs / 1000
-        }s. Stop that process (or pass --wait <seconds> to wait longer) and retry.`,
-      );
-    }
-    throw error;
-  }
-  const removeShutdownHandlers = installShutdownHandlers(() => db.close());
-  try {
-    return await fn(db);
-  } finally {
-    removeShutdownHandlers();
-    await db.close();
-  }
+  return { slug, dbPath, json, contentFile, waitBudgetMs };
 }
 
 export async function runTrainListCommand(args: string[], io: TrainCommandIO): Promise<void> {
   const options = parseTrainSubArgs(args);
   if (!options) return;
   if (options.slug !== undefined) fail(`Unexpected argument for train list: ${options.slug}`);
-  const entries = await withTrainMemoryDb(options.dbPath, (db) => db.listTrainings());
+  const entries = await withMemoryDb(options.dbPath, (db) => db.listTrainings(), {
+    waitBudgetMs: options.waitBudgetMs,
+  });
   io.stdout.write(
     options.json ? `${JSON.stringify(entries, null, 2)}\n` : `${formatTrainList(entries)}\n`,
   );
@@ -582,7 +567,9 @@ export async function runTrainShowCommand(args: string[], io: TrainCommandIO): P
   if (!options) return;
   if (!options.slug) fail("duet train show requires a <slug> argument");
   const slug = options.slug;
-  const record = await withTrainMemoryDb(options.dbPath, (db) => db.findTrainingBySlug(slug));
+  const record = await withMemoryDb(options.dbPath, (db) => db.findTrainingBySlug(slug), {
+    waitBudgetMs: options.waitBudgetMs,
+  });
   if (!record) fail(`No training found for slug "${slug}".`);
   io.stdout.write(
     options.json ? `${JSON.stringify(record, null, 2)}\n` : `${formatTrainRecord(record)}\n`,
@@ -599,14 +586,16 @@ export async function runTrainUpdateCommand(args: string[], io: TrainCommandIO):
   if (content.trim().length === 0) {
     fail(`Refusing to write empty content from ${options.contentFile}.`);
   }
-  const updated = await withTrainMemoryDb(options.dbPath, async (db): Promise<TrainRecord> => {
-    const record = await db.findTrainingBySlug(slug);
-    if (!record) fail(`No training found for slug "${slug}".`);
-    await db.updateContent(record.memoryId, content);
-    // updateContent only touches `content`, so the stored row is the prior
-    // record with the new text.
-    return { ...record, content };
-  });
+  const updated = await withMemoryDb(
+    options.dbPath,
+    async (db): Promise<TrainRecord> => {
+      const record = await db.findTrainingBySlug(slug);
+      if (!record) fail(`No training found for slug "${slug}".`);
+      await db.updateContent(record.memoryId, content);
+      return { ...record, content };
+    },
+    { waitBudgetMs: options.waitBudgetMs },
+  );
   if (options.json) {
     io.stdout.write(`${JSON.stringify(updated, null, 2)}\n`);
     return;
@@ -619,12 +608,16 @@ export async function runTrainDeleteCommand(args: string[], io: TrainCommandIO):
   if (!options) return;
   if (!options.slug) fail("duet train delete requires a <slug> argument");
   const slug = options.slug;
-  const deleted = await withTrainMemoryDb(options.dbPath, async (db): Promise<TrainRecord> => {
-    const record = await db.findTrainingBySlug(slug);
-    if (!record) fail(`No training found for slug "${slug}".`);
-    await db.delete(record.memoryId);
-    return record;
-  });
+  const deleted = await withMemoryDb(
+    options.dbPath,
+    async (db): Promise<TrainRecord> => {
+      const record = await db.findTrainingBySlug(slug);
+      if (!record) fail(`No training found for slug "${slug}".`);
+      await db.delete(record.memoryId);
+      return record;
+    },
+    { waitBudgetMs: options.waitBudgetMs },
+  );
   if (options.json) {
     io.stdout.write(
       `${JSON.stringify({ deleted: true, slug: deleted.slug, memoryId: deleted.memoryId }, null, 2)}\n`,

--- a/test/cli-memory-query.test.ts
+++ b/test/cli-memory-query.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, test, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemoryDb, scoreObservation } from "../src/cli/memory-db.js";
+import { formatMemoryTable, parseMemoryArgs, runMemoryQuery } from "../src/cli/memory-query.js";
+import type { Observation, ObservationSource } from "../src/types/memory.js";
+import { testIfDocker } from "./helpers/docker-only.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const BASE = Date.UTC(2026, 5, 26);
+
+interface FixtureInput {
+  id: string;
+  createdAt: number;
+  kind?: Observation["kind"];
+  priority?: Observation["priority"];
+  source?: ObservationSource;
+  content?: string;
+}
+
+async function withDb(fn: (db: MemoryDb, dbPath: string) => Promise<void>): Promise<void> {
+  const tempDir = await mkdtemp(join(tmpdir(), "duet-memory-query-"));
+  const dbPath = join(tempDir, "memory.db");
+  const db = await MemoryDb.open(dbPath);
+  try {
+    await fn(db, dbPath);
+  } finally {
+    await db.close().catch(() => {});
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function seed(db: MemoryDb, fixtures: FixtureInput[]): Promise<void> {
+  const pg = (db as unknown as { db: import("@electric-sql/pglite").PGlite }).db;
+  for (const f of fixtures) {
+    await pg.query(
+      `INSERT INTO observations (
+        id, created_at, last_used_at, session_id, kind, observed_date, referenced_date, relative_date,
+        time_of_day, priority, source_json, content, tags_json
+      ) VALUES ($1, $2, $3, NULL, $4, $5, NULL, NULL, NULL, $6, $7, $8, '[]')`,
+      [
+        f.id,
+        f.createdAt,
+        f.createdAt,
+        f.kind ?? "observation",
+        new Date(f.createdAt).toISOString().slice(0, 10),
+        f.priority ?? "medium",
+        JSON.stringify(f.source ?? { kind: "system" }),
+        f.content ?? `content for ${f.id}`,
+      ],
+    );
+  }
+}
+
+const SAMPLE: FixtureInput[] = [
+  {
+    id: "a",
+    createdAt: BASE - 5 * DAY_MS,
+    kind: "observation",
+    priority: "low",
+    source: { kind: "user" },
+  },
+  {
+    id: "b",
+    createdAt: BASE - 2 * DAY_MS,
+    kind: "reflection",
+    priority: "high",
+    source: { kind: "agent" },
+  },
+  {
+    id: "c",
+    createdAt: BASE - 1 * DAY_MS,
+    kind: "manual",
+    priority: "high",
+    source: { kind: "system" },
+  },
+  {
+    id: "d",
+    createdAt: BASE + 1 * DAY_MS,
+    kind: "reflection",
+    priority: "medium",
+    source: { kind: "agent" },
+  },
+  {
+    id: "e",
+    createdAt: BASE + 3 * DAY_MS,
+    kind: "observation",
+    priority: "high",
+    source: { kind: "user" },
+  },
+];
+
+describe("MemoryDb.queryObservations", () => {
+  testIfDocker("returns all rows newest-first when unfiltered", async () => {
+    await withDb(async (db) => {
+      await seed(db, SAMPLE);
+      const rows = await db.queryObservations();
+      expect(rows.map((r) => r.id)).toEqual(["e", "d", "c", "b", "a"]);
+    });
+  });
+
+  testIfDocker("filters by kind", async () => {
+    await withDb(async (db) => {
+      await seed(db, SAMPLE);
+      const rows = await db.queryObservations({ kind: "reflection" });
+      expect(rows.map((r) => r.id)).toEqual(["d", "b"]);
+    });
+  });
+
+  testIfDocker("filters by priority", async () => {
+    await withDb(async (db) => {
+      await seed(db, SAMPLE);
+      const rows = await db.queryObservations({ priority: "high" });
+      expect(rows.map((r) => r.id)).toEqual(["e", "c", "b"]);
+    });
+  });
+
+  testIfDocker("filters by source kind", async () => {
+    await withDb(async (db) => {
+      await seed(db, SAMPLE);
+      const rows = await db.queryObservations({ source: "agent" });
+      expect(rows.map((r) => r.id)).toEqual(["d", "b"]);
+    });
+  });
+
+  testIfDocker("filters by an inclusive createdAt window", async () => {
+    await withDb(async (db) => {
+      await seed(db, SAMPLE);
+      const rows = await db.queryObservations({
+        fromMs: BASE - 2 * DAY_MS,
+        toMs: BASE + 1 * DAY_MS,
+      });
+      expect(rows.map((r) => r.id)).toEqual(["d", "c", "b"]);
+    });
+  });
+
+  testIfDocker("combines filters with AND semantics", async () => {
+    await withDb(async (db) => {
+      await seed(db, SAMPLE);
+      const rows = await db.queryObservations({
+        kind: "reflection",
+        source: "agent",
+        fromMs: BASE,
+      });
+      expect(rows.map((r) => r.id)).toEqual(["d"]);
+    });
+  });
+
+  testIfDocker("returns an empty list when nothing matches", async () => {
+    await withDb(async (db) => {
+      await seed(db, SAMPLE);
+      const rows = await db.queryObservations({ kind: "manual", priority: "low" });
+      expect(rows).toEqual([]);
+    });
+  });
+});
+
+describe("duet memory query mode", () => {
+  testIfDocker("emits a JSON array of scored rows, newest-first", async () => {
+    await withDb(async (db, dbPath) => {
+      await seed(db, SAMPLE);
+      await db.close();
+      const out = await captureJson(["--json", "--type", "reflection"], dbPath);
+      expect(out.map((r) => r.id)).toEqual(["d", "b"]);
+      for (const row of out) {
+        const observation = observationFromScoredRow(row);
+        expect(typeof row.score).toBe("number");
+        expect(row.score).toBeCloseTo(scoreObservation(observation, Date.now()), 2);
+      }
+    });
+  });
+
+  testIfDocker("manual rows carry the manual-bias multiplier in their score", async () => {
+    await withDb(async (db, dbPath) => {
+      // Two equal-priority, equal-recency rows: one manual, one observation.
+      // The manual row's score must dominate by the manual-bias multiplier,
+      // matching the runner's loadGlobalPack ranking rather than the
+      // reflection-only observationScore baseline.
+      const fixtures: FixtureInput[] = [
+        { id: "m", createdAt: BASE, kind: "manual", priority: "high", source: { kind: "system" } },
+        {
+          id: "o",
+          createdAt: BASE,
+          kind: "observation",
+          priority: "high",
+          source: { kind: "user" },
+        },
+      ];
+      await seed(db, fixtures);
+      await db.close();
+      const out = await captureJson(["--json", "--priority", "high"], dbPath);
+      const manual = out.find((r) => r.id === "m")!;
+      const obs = out.find((r) => r.id === "o")!;
+      const now = Date.now();
+      expect(manual.score).toBeGreaterThan(obs.score);
+      expect(manual.score / obs.score).toBeCloseTo(100, 0);
+      expect(manual.score).toBeCloseTo(scoreObservation(observationFromScoredRow(manual), now), 2);
+    });
+  });
+
+  testIfDocker("prints a friendly message when no rows match (table mode)", async () => {
+    await withDb(async (db, dbPath) => {
+      await seed(db, SAMPLE);
+      await db.close();
+      const { stdout } = await capture(["--priority", "low", "--type", "manual"], dbPath);
+      expect(stdout).toContain("No memories matched");
+    });
+  });
+});
+
+describe("parseMemoryArgs", () => {
+  function parse(args: string[]) {
+    return parseMemoryArgs(args);
+  }
+
+  test("bare invocation stays in TUI mode (no query)", () => {
+    const opts = parse([]);
+    expect(opts?.queryMode).toBe(false);
+    expect(parse(["--db", "/tmp/x.db"])?.queryMode).toBe(false);
+    expect(parse(["--wait", "5"])?.queryMode).toBe(false);
+  });
+
+  test("--json or any filter flag switches to query mode", () => {
+    expect(parse(["--json"])?.queryMode).toBe(true);
+    expect(parse(["--type", "manual"])?.queryMode).toBe(true);
+    expect(parse(["--priority", "high"])?.queryMode).toBe(true);
+    expect(parse(["--source", "agent"])?.queryMode).toBe(true);
+    expect(parse(["--from", "2026-06-26"])?.queryMode).toBe(true);
+    expect(parse(["--to", "2026-06-26"])?.queryMode).toBe(true);
+  });
+
+  test("parses --type/--kind as the same axis", () => {
+    expect(parse(["--type", "reflection"])?.filters.kind).toBe("reflection");
+    expect(parse(["--kind", "manual"])?.filters.kind).toBe("manual");
+  });
+
+  test("parses a date-only --from as start-of-day UTC", () => {
+    const opts = parse(["--from", "2026-06-26"]);
+    expect(opts?.filters.fromMs).toBe(Date.UTC(2026, 5, 26, 0, 0, 0, 0));
+  });
+
+  test("parses a date-only --to as end-of-day UTC", () => {
+    const opts = parse(["--to", "2026-06-26"]);
+    expect(opts?.filters.toMs).toBe(Date.UTC(2026, 5, 26, 23, 59, 59, 999));
+  });
+
+  test("parses a full datetime --from as UTC", () => {
+    const opts = parse(["--from", "2026-06-26T12:30:00"]);
+    expect(opts?.filters.fromMs).toBe(Date.UTC(2026, 5, 26, 12, 30, 0, 0));
+  });
+
+  test("sets the --json flag", () => {
+    expect(parse(["--json"])?.json).toBe(true);
+    expect(parse([])?.json).toBe(false);
+  });
+
+  test("parses --wait in seconds", () => {
+    expect(parse(["--wait", "2.5"])?.waitBudgetMs).toBe(2500);
+  });
+
+  test("rejects missing or invalid flag values", () => {
+    using exitSpy = spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit");
+    }) as never);
+    using errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => parse(["--type"])).toThrow("exit");
+    expect(() => parse(["--priority", "urgent"])).toThrow("exit");
+    expect(() => parse(["--from", "tomorrow"])).toThrow("exit");
+    expect(() => parse(["--from", "2026-06-27", "--to", "2026-06-26"])).toThrow("exit");
+    // Impossible calendar dates are rejected, not silently normalized.
+    expect(() => parse(["--from", "2026-02-31"])).toThrow("exit");
+    expect(() => parse(["--to", "2026-06-31"])).toThrow("exit");
+    expect(() => parse(["--from", "2026-02-31T00:00:00"])).toThrow("exit");
+
+    expect(exitSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls.map((args) => args.join("\n")).join("\n")).toContain("Fatal:");
+  });
+});
+
+describe("formatMemoryTable", () => {
+  test("renders a header and one row per observation", () => {
+    const now = Date.now();
+    const rows = SAMPLE.slice(0, 2).map((f) => {
+      const obs: Observation = {
+        id: f.id,
+        createdAt: f.createdAt,
+        lastUsedAt: f.createdAt,
+        kind: f.kind ?? "observation",
+        observedDate: new Date(f.createdAt).toISOString().slice(0, 10),
+        priority: f.priority ?? "medium",
+        source: f.source ?? { kind: "system" },
+        content: `content for ${f.id}`,
+        tags: [],
+      };
+      return { ...obs, score: scoreObservation(obs, now) };
+    });
+    const table = formatMemoryTable(rows);
+    expect(table).toContain("MEMORY ID");
+    expect(table).toContain("SCORE");
+    expect(table.split("\n")).toHaveLength(3);
+  });
+
+  test("renders an empty-state line for no rows", () => {
+    expect(formatMemoryTable([])).toContain("No memories matched");
+  });
+});
+
+interface ScoredJsonRow extends Observation {
+  score: number;
+}
+
+function observationFromScoredRow(row: ScoredJsonRow): Observation {
+  return {
+    id: row.id,
+    createdAt: row.createdAt,
+    lastUsedAt: row.lastUsedAt,
+    sessionId: row.sessionId,
+    kind: row.kind,
+    observedDate: row.observedDate,
+    referencedDate: row.referencedDate,
+    relativeDate: row.relativeDate,
+    timeOfDay: row.timeOfDay,
+    priority: row.priority,
+    source: row.source,
+    content: row.content,
+    tags: row.tags,
+  };
+}
+
+async function capture(args: string[], dbPath: string): Promise<{ stdout: string }> {
+  let stdout = "";
+  const sink = {
+    write(chunk: string | Uint8Array): boolean {
+      stdout += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+      return true;
+    },
+  } as unknown as NodeJS.WritableStream;
+  const options = parseMemoryArgs([...args, "--db", dbPath]);
+  await runMemoryQuery(options!, { stdout: sink });
+  return { stdout };
+}
+
+async function captureJson(args: string[], dbPath: string): Promise<ScoredJsonRow[]> {
+  const { stdout } = await capture(args, dbPath);
+  return JSON.parse(stdout) as ScoredJsonRow[];
+}

--- a/test/memory-db.test.ts
+++ b/test/memory-db.test.ts
@@ -3,11 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MemoryDb, MEMORY_PAGE_SIZE, scoreObservation } from "../src/cli/memory-db.js";
-import {
-  DEFAULT_MANUAL_BIAS,
-  DEFAULT_RECENCY_HALF_LIFE_MS,
-  DEFAULT_REFLECTION_BIAS,
-} from "../src/memory/observational.js";
+import { DEFAULT_MANUAL_BIAS, DEFAULT_RECENCY_HALF_LIFE_MS } from "../src/memory/observational.js";
 import { PRIORITY_WEIGHT } from "../src/memory/loader.js";
 import type { Observation } from "../src/types/memory.js";
 import { testIfDocker } from "./helpers/docker-only.js";
@@ -33,9 +29,6 @@ describe("MemoryDb ranked paging", () => {
 
   testIfDocker("listRanked returns one flat list ordered by score descending", async () => {
     await withDb(async (db) => {
-      // A high-priority reflection used today must outrank a low-priority
-      // observation that has not been touched in 60 days, regardless of
-      // which session each came from or its created_at.
       await seed(db, [
         fixture({ id: "low_old", priority: "low", kind: "observation", lastUsedAt: ago(60) }),
         fixture({
@@ -51,17 +44,26 @@ describe("MemoryDb ranked paging", () => {
           kind: "observation",
           lastUsedAt: ago(2),
         }),
+        fixture({
+          id: "manual_old",
+          priority: "high",
+          kind: "manual",
+          lastUsedAt: ago(10),
+        }),
       ]);
 
       const rows = await db.listRanked({ limit: 25, offset: 0, now: NOW });
-      expect(rows.map((r) => r.id)).toEqual(["high_reflection_today", "medium_recent", "low_old"]);
+      expect(rows.map((r) => r.id)).toEqual([
+        "manual_old",
+        "high_reflection_today",
+        "medium_recent",
+        "low_old",
+      ]);
 
-      // The displayed score is the real numeric formula, not the SQL
-      // log-space rank. Verify the top row matches the hand-computed value.
       const top = rows[0]!;
       const expected =
         PRIORITY_WEIGHT.high *
-        DEFAULT_REFLECTION_BIAS *
+        DEFAULT_MANUAL_BIAS *
         Math.pow(0.5, (NOW - top.lastUsedAt) / DEFAULT_RECENCY_HALF_LIFE_MS);
       expect(scoreObservation(top, NOW)).toBeCloseTo(expected, 6);
     });


### PR DESCRIPTION
## What

Adds `duet memory list` — a new non-TUI, scriptable subcommand on the `duet memory` CLI for querying durable memories as JSON. Bare `duet memory` still opens the TUI; `list` routes before the TUI parser just like `reflect`.

## Why

We need a scriptable way to query memories for automation, exports, and debugging — e.g. ``duet memory list --json --type reflection --from 2026-06-26`` or all memories from the past 24 hours. The TUI is interactive-only and has no JSON surface.

## Filters
- `--type` / `--kind` — `observation` | `reflection` | `manual` (the `Observation.kind` axis; aliases)
- `--priority` — `high` | `medium` | `low`
- `--source` — `user` | `agent` | `system` (filters `source.kind` in SQL)
- `--from` / `--to` — inclusive `createdAt` window. `YYYY-MM-DD` snaps to start/end-of-day UTC; `YYYY-MM-DDTHH:MM:SS` accepted too.
- `--json` — JSON array; otherwise an aligned table (mirrors `duet train list`)
- `--db`, `--wait`, `-h/--help` — shared with the rest of `duet memory`

Rows are chronological (newest first), each carrying a computed `score` matching the runner's global-pack ranking.

## Files
- `src/cli/memory-db.ts` — `MemoryListFilters` + `MemoryDb.listQuery` (dynamic WHERE, `ORDER BY created_at DESC, id ASC`); factored the train commands' open+lock pattern into a shared `withMemoryDb` helper (now also accepts `waitBudgetMs`).
- `src/cli/memory-list.ts` *(new)* — arg parser, UTC date-bound parsing, scoring, JSON/table rendering.
- `src/cli/memory.ts` — routes `duet memory list`.
- `src/cli/help.ts` — `printMemoryListHelp` + updated `printMemoryHelp`.
- `src/cli/train.ts` — refactored onto shared `withMemoryDb` (removed duplicate `withTrainMemoryDb`).
- `test/cli-memory-list.test.ts` *(new)* — per-filter, AND-combination, window, empty, JSON shape + score, table, date/flag parser, invalid inputs.

## Verification
- `tsc --noEmit` ✅, `oxlint` ✅ (0 warnings/errors), `oxfmt` ✅
- 864/864 tests pass in Docker; 9 parser/formatter tests pass outside Docker.
- Refactor regression check: train management tests (16) + memory-db (4) green.
