### PR TITLE
feat(cli): add duet model direct gateway subcommand

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentui/core": "^0.2.5",
         "@vscode/ripgrep": "^1.18.0",
+        "ai": "^7",
         "ajv": "^8.20.0",
         "dedent": "^1.7.2",
         "dotenv": "^17.4.2",
@@ -34,6 +35,12 @@
     },
   },
   "packages": {
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.4", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.1", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-xO0e9duft/uZlnDaIeBZmzTMjfdEz1kkDzWnhQNkJZZljsKWVi6IREZW9nAa+Dx6jYJssyxSUggaFYBAV1WZpw=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.1", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-p9Ra+dN4jjHrssXvklNf4nFvWbj1KePMfUOs7nue0NuoIMbYFBULhX4Vu0+6DWLnw3+UsLL9+RCKLtzzU43Qpg=="],
+
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
@@ -294,6 +301,8 @@
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
@@ -301,6 +310,8 @@
     "@types/node": ["@types/node@22.19.18", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "@vscode/ripgrep": ["@vscode/ripgrep@1.18.0", "", { "optionalDependencies": { "@vscode/ripgrep-darwin-arm64": "1.18.0", "@vscode/ripgrep-darwin-x64": "1.18.0", "@vscode/ripgrep-linux-arm": "1.18.0", "@vscode/ripgrep-linux-arm64": "1.18.0", "@vscode/ripgrep-linux-ia32": "1.18.0", "@vscode/ripgrep-linux-ppc64": "1.18.0", "@vscode/ripgrep-linux-riscv64": "1.18.0", "@vscode/ripgrep-linux-s390x": "1.18.0", "@vscode/ripgrep-linux-x64": "1.18.0", "@vscode/ripgrep-win32-arm64": "1.18.0", "@vscode/ripgrep-win32-ia32": "1.18.0", "@vscode/ripgrep-win32-x64": "1.18.0" } }, "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ=="],
 
@@ -328,9 +339,13 @@
 
     "@vscode/ripgrep-win32-x64": ["@vscode/ripgrep-win32-x64@1.18.0", "", { "os": "win32", "cpu": "x64" }, "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg=="],
 
+    "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ai": ["ai@7.0.4", "", { "dependencies": { "@ai-sdk/gateway": "4.0.4", "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-mZub080RWRxpWg8OY56KVnI3AoMVniccSWG+dwVb3nH81+GiNMDYBIdP41RLUivLpmU49pB7ssD7tvfIUaSaCA=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -503,6 +518,8 @@
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 

--- a/evals/model-direct.eval.ts
+++ b/evals/model-direct.eval.ts
@@ -1,0 +1,32 @@
+import { describe, expect } from "bun:test";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+const model = process.env.EVAL_MODEL ?? "sonnet-4.6";
+
+/**
+ * `duet model` talks to a gateway model directly through the AI SDK, bypassing
+ * the agent harness. The text path streams a completion straight to stdout, so a
+ * live round-trip is the cleanest proof the gateway provider, auth, and request
+ * routing all line up: a real model must produce non-empty output for a trivial
+ * prompt. Routes through the duet gateway with DUET_API_KEY, which the docker
+ * eval container forwards.
+ */
+describe("duet model direct CLI", () => {
+  testIfDocker(
+    "streams a non-empty text completion from the gateway",
+    async () => {
+      const proc = Bun.spawn(
+        ["bun", "src/cli.ts", "model", "-m", model, "Reply with the single word: pong"],
+        { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" },
+      );
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      expect(exitCode, stderr).toBe(0);
+      expect(stdout.trim().length).toBeGreaterThan(0);
+    },
+    120_000,
+  );
+});

--- a/evals/model-direct.eval.ts
+++ b/evals/model-direct.eval.ts
@@ -1,7 +1,15 @@
+import { mkdtempSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect } from "bun:test";
 import { testIfDocker } from "../test/helpers/docker-only.js";
 
-const model = process.env.EVAL_MODEL ?? "sonnet-4.6";
+// `duet model` passes -m straight to the gateway, so evals use full gateway
+// slugs, not pi shorthands. Defaults are the cheapest verified model per type.
+const textModel = process.env.EVAL_MODEL ?? "anthropic/claude-haiku-4.5";
+const imageModel = process.env.EVAL_IMAGE_MODEL ?? "openai/gpt-image-1-mini";
+const videoModel = process.env.EVAL_VIDEO_MODEL ?? "bytedance/seedance-2.0-fast";
 
 /**
  * `duet model` talks to a gateway model directly through the AI SDK, bypassing
@@ -16,7 +24,7 @@ describe("duet model direct CLI", () => {
     "streams a non-empty text completion from the gateway",
     async () => {
       const proc = Bun.spawn(
-        ["bun", "src/cli.ts", "model", "-m", model, "Reply with the single word: pong"],
+        ["bun", "src/cli.ts", "model", "-m", textModel, "Reply with the single word: pong"],
         { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" },
       );
       const [stdout, stderr, exitCode] = await Promise.all([
@@ -28,5 +36,46 @@ describe("duet model direct CLI", () => {
       expect(stdout.trim().length).toBeGreaterThan(0);
     },
     120_000,
+  );
+
+  testIfDocker(
+    "generates an image file from a dedicated image model",
+    async () => {
+      const out = join(mkdtempSync(join(tmpdir(), "duet-model-")), "art.png");
+      const proc = Bun.spawn(
+        ["bun", "src/cli.ts", "model", "-m", imageModel, "--type", "image", "-o", out, "a red fox"],
+        { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" },
+      );
+      const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+      expect(exitCode, stderr).toBe(0);
+      expect((await stat(out)).size).toBeGreaterThan(1000);
+    },
+    180_000,
+  );
+
+  testIfDocker(
+    "generates a video file from a video model",
+    async () => {
+      const out = join(mkdtempSync(join(tmpdir(), "duet-model-")), "clip.mp4");
+      const proc = Bun.spawn(
+        [
+          "bun",
+          "src/cli.ts",
+          "model",
+          "-m",
+          videoModel,
+          "--type",
+          "video",
+          "-o",
+          out,
+          "slow pan over dunes",
+        ],
+        { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" },
+      );
+      const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+      expect(exitCode, stderr).toBe(0);
+      expect((await stat(out)).size).toBeGreaterThan(10000);
+    },
+    600_000,
   );
 });

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentui/core": "^0.2.5",
     "@vscode/ripgrep": "^1.18.0",
+    "ai": "^7",
     "ajv": "^8.20.0",
     "dedent": "^1.7.2",
     "dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "^5.7.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "packageManager": "bun@1.3.11"
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import packageJson from "../package.json" with { type: "json" };
 import { runEnvCommand } from "./cli/env.js";
 import { runLoginCommand } from "./cli/login.js";
 import { runMemoryCommand } from "./cli/memory.js";
+import { runModelCommand } from "./cli/model.js";
 import { runRpcCommand } from "./cli/rpc.js";
 import { runRunCommand } from "./cli/run.js";
 import { runSendFeedbackCommand } from "./cli/send-feedback.js";
@@ -39,6 +40,7 @@ export type { LoginCommandIO } from "./cli/login.js";
 export { runSkillsCommand } from "./cli/skills.js";
 export { runUpgradeCommand } from "./cli/upgrade.js";
 export { runMemoryCommand } from "./cli/memory.js";
+export { runModelCommand } from "./cli/model.js";
 export { runMemoryAddCommand } from "./cli/memory-add.js";
 export { runMemoryReflectCommand } from "./cli/memory-reflect.js";
 export { runTrainCommand } from "./cli/train.js";
@@ -89,6 +91,10 @@ export async function runCli(): Promise<void> {
     }
     if (subcommand === "memory" || subcommand === "memories") {
       await runMemoryCommand(args.slice(1));
+      return;
+    }
+    if (subcommand === "model") {
+      await runModelCommand(args.slice(1));
       return;
     }
     if (subcommand === "train") {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -302,7 +302,6 @@ OPTIONS
   --duration <seconds>    Video length
   --resolution <WxH>      Video resolution, e.g. 1280x720
   --fps <int>             Video frames per second
-  --json                  Reserved for machine-readable output
   --env-file <path>       Shared env file to load after cwd .env
   -h, --help              Show this help
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -18,6 +18,7 @@ USAGE
   duet env [--env-file <path>] [--import [path]|--keys]
   duet skills [--workdir <path>]
   duet memory [--db <path>]
+  duet model -m <model> [--type text|image|video] [prompt]
   duet send-feedback [--file <path>] [text...]
   duet upgrade [--manager npm|bun|pnpm|yarn]
   echo "prompt" | duet
@@ -27,6 +28,7 @@ COMMANDS
   env                      Manually create or update the shared duet env file with provider API keys
   skills                   List installed skills + collisions as JSON
   memory                   Open a TUI to view, edit, and delete observational memories (alias: memories)
+  model                    Call a gateway model directly (text/image/video) via the AI SDK
   send-feedback            Send free-form markdown feedback to the Duet team
   upgrade                  Upgrade the global ${packageName} installation
 
@@ -89,6 +91,8 @@ EXAMPLES
   duet login
   duet env
   duet memory
+  duet model -m openai/gpt-5.5 "write a haiku about gateways"
+  duet model -m black-forest-labs/flux-1.1-pro -o art.png "a fox in snow"
   duet train ./docs/my-project
   duet send-feedback "the TUI flickers when..."
   duet upgrade
@@ -266,6 +270,47 @@ OPTIONS
   --wait <seconds>         Seconds to wait for the cross-process open-lock
                            (default: 30; 0 fails immediately)
   -h, --help               Show this help
+`);
+}
+
+export function printModelHelp(): void {
+  console.log(`
+duet model — Call a gateway model directly via the AI SDK
+
+USAGE
+  duet model -m <model> [options] [prompt]
+  echo "prompt" | duet model -m <model>
+
+DESCRIPTION
+  Talks to a model directly through the Vercel AI SDK pointed at the Duet
+  gateway, bypassing the agent harness. The request type is inferred from
+  the gateway model catalog (language→text, image→image, video→video) and
+  can be overridden with --type. Text streams to stdout; image and video
+  generations write files and print each path. Auth uses DUET_API_KEY.
+
+OPTIONS
+  -m, --model <name>       Gateway model id, e.g. openai/gpt-5.5 (required)
+  --type text|image|video  Override the catalog-inferred request type
+  --image <path>           Input image: vision context (text), edit source
+                           (image), or still to animate (video)
+  -o, --out <path>         Write output here; image/video auto-name when omitted
+  --system <text>          System prompt for text/image-language models
+  --size <WxH>             Image size, e.g. 1024x1024
+  --aspect <W:H>          Aspect ratio, e.g. 16:9
+  --n <count>              Number of outputs to generate
+  --seed <int>            Generation seed
+  --duration <seconds>    Video length
+  --resolution <WxH>      Video resolution, e.g. 1280x720
+  --fps <int>             Video frames per second
+  --json                  Reserved for machine-readable output
+  --env-file <path>       Shared env file to load after cwd .env
+  -h, --help              Show this help
+
+EXAMPLES
+  duet model -m openai/gpt-5.5 "write a haiku about gateways"
+  duet model -m black-forest-labs/flux-1.1-pro -o art.png "a fox in snow"
+  duet model -m google/gemini-2.5-flash-image --type image --image src.png "add a hat"
+  duet model -m bytedance/seedance-1.0 --type video -o clip.mp4 "slow pan over dunes"
 `);
 }
 

--- a/src/cli/model-gateway.ts
+++ b/src/cli/model-gateway.ts
@@ -1,0 +1,69 @@
+import { createGateway } from "ai";
+import { getDuetGatewayBaseUrl } from "../model-resolution/duet-gateway.js";
+
+/**
+ * The `duet model` subcommand talks to models directly through the Vercel AI
+ * SDK (`ai@^7`), pointed at the Duet gateway instead of the pi harness. The
+ * gateway re-exposes Vercel's AI Gateway under `/api/v1/ai-gateway`; the SDK's
+ * gateway provider speaks the versioned `/v4/ai` protocol path, and `/v1/models`
+ * serves the catalog. Auth is the org-scoped `DUET_API_KEY` Bearer token.
+ */
+export const DUET_API_KEY_ENV = "DUET_API_KEY";
+
+// Generation can be slow — image/video models routinely run for minutes — so
+// requests get a 15-minute ceiling rather than the SDK/runtime default.
+const GENERATION_TIMEOUT_MS = 15 * 60 * 1000;
+
+/** Capability classes the gateway tags each model with via `/v1/models`. */
+export type ModelType =
+  | "language"
+  | "image"
+  | "video"
+  | "embedding"
+  | "realtime"
+  | "reranking"
+  | "speech"
+  | "transcription";
+
+/**
+ * Build an AI SDK gateway provider bound to the Duet proxy. Callers resolve a
+ * model with `gateway('<provider>/<model>')` and pass it to `generateText`,
+ * `generateImage`, etc. The base URL appends `/v4/ai` to the gateway origin —
+ * the protocol version the duet.so proxy currently serves. The custom `fetch`
+ * only raises the abort timeout; everything else is the platform default.
+ */
+export function createDuetModelGateway(): ReturnType<typeof createGateway> {
+  // Preserve `fetch.preconnect` so the wrapper still satisfies the platform
+  // fetch signature; only the abort timeout is overridden.
+  const longTimeoutFetch: typeof fetch = Object.assign(
+    (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
+      fetch(input, { ...init, signal: AbortSignal.timeout(GENERATION_TIMEOUT_MS) }),
+    { preconnect: fetch.preconnect },
+  );
+  return createGateway({
+    baseURL: `${getDuetGatewayBaseUrl()}/v4/ai`,
+    apiKey: process.env[DUET_API_KEY_ENV],
+    fetch: longTimeoutFetch,
+  });
+}
+
+/**
+ * Fetch the gateway model catalog and return a map of model id -> capability
+ * type. Used to validate a requested model and route it to the right generation
+ * call (text vs image vs video). Hits `/v1/models` directly because the catalog
+ * is an org-scoped read, not a generation, so it bypasses the SDK provider.
+ */
+export async function fetchModelCatalog(): Promise<Map<string, ModelType>> {
+  const response = await fetch(`${getDuetGatewayBaseUrl()}/v1/models`, {
+    headers: { Authorization: `Bearer ${process.env[DUET_API_KEY_ENV] ?? ""}` },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch model catalog: ${response.status} ${response.statusText}`);
+  }
+  const body = (await response.json()) as { data?: Array<{ id: string; type: ModelType }> };
+  const catalog = new Map<string, ModelType>();
+  for (const model of body.data ?? []) {
+    catalog.set(model.id, model.type);
+  }
+  return catalog;
+}

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -339,7 +339,7 @@ export function parseArgs(args: string[]): ModelArgs {
     const arg = args[i]!;
     const next = () => {
       const value = args[++i];
-      if (value === undefined) fail(`Missing value for ${arg}`);
+      if (value === undefined || value.startsWith("-")) fail(`Missing value for ${arg}`);
       return value;
     };
     switch (arg) {

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -34,7 +34,6 @@ interface ModelArgs {
   duration?: number;
   resolution?: string;
   fps?: number;
-  json: boolean;
   envFile?: string;
   prompt?: string;
   help: boolean;
@@ -335,7 +334,7 @@ async function readStdin(): Promise<string> {
 }
 
 export function parseArgs(args: string[]): ModelArgs {
-  const out: ModelArgs = { json: false, help: false };
+  const out: ModelArgs = { help: false };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
     const next = () => {
@@ -381,9 +380,6 @@ export function parseArgs(args: string[]): ModelArgs {
         break;
       case "--fps":
         out.fps = Number(next());
-        break;
-      case "--json":
-        out.json = true;
         break;
       case "--env-file":
         out.envFile = next();

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -1,0 +1,406 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { extname } from "node:path";
+import {
+  createDownload,
+  experimental_generateVideo as generateVideo,
+  generateImage,
+  generateText,
+  streamText,
+  type ImagePart,
+  type ModelMessage,
+} from "ai";
+import { createDuetModelGateway, fetchModelCatalog, type ModelType } from "./model-gateway.js";
+import { printModelHelp } from "./help.js";
+import { fail, loadCliEnvFiles, resolveUserPath } from "./shared.js";
+
+/**
+ * High-level capability the CLI routes a request to. The gateway catalog uses
+ * `language` for text models; everything else maps straight through. `--type`
+ * lets the user override routing when the catalog is missing or wrong.
+ */
+type RequestType = "text" | "image" | "video";
+
+/** Parsed `duet model` flags. Prompt is positional or read from stdin. */
+interface ModelArgs {
+  model?: string;
+  type?: RequestType;
+  imagePath?: string;
+  out?: string;
+  system?: string;
+  size?: string;
+  aspect?: string;
+  n?: number;
+  seed?: number;
+  duration?: number;
+  resolution?: string;
+  fps?: number;
+  json: boolean;
+  envFile?: string;
+  prompt?: string;
+  help: boolean;
+}
+
+/**
+ * Map a gateway catalog capability to the CLI request type. `language` covers
+ * text models, including the gemini `*-image` models that emit images as message
+ * files; those are still text completions, so `--type image` is what reroutes
+ * them. An unknown/missing catalog entry defaults to text.
+ */
+export function requestTypeForCapability(type: ModelType | undefined): RequestType {
+  if (type === "image") return "image";
+  if (type === "video") return "video";
+  return "text";
+}
+
+/** Language models emit images via result.files, not the image endpoint. */
+export function usesLanguageImagePath(type: ModelType | undefined): boolean {
+  return type === "language";
+}
+
+/** Image file extension -> media type, for inlining vision input parts. */
+const IMAGE_MEDIA_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+/**
+ * Generate a timestamped output filename like `model-20260629T141500-1.png`.
+ * Used when the user does not pass `--out` for image/video generations so each
+ * run lands a distinct, sortable file. Lives here so the image and video units
+ * share one naming scheme.
+ */
+export function autoOutputFilename(extension: string, index = 1): string {
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d+Z$/, "Z");
+  return `model-${stamp}-${index}${extension}`;
+}
+
+/** Run `duet model` — call a gateway model directly via the AI SDK. */
+export async function runModelCommand(args: string[]): Promise<void> {
+  const parsed = parseArgs(args);
+  if (parsed.help) {
+    printModelHelp();
+    return;
+  }
+  loadCliEnvFiles(process.cwd(), parsed.envFile);
+
+  if (!parsed.model) fail("Missing required --model/-m");
+  const model = parsed.model;
+
+  const prompt = parsed.prompt ?? (await readStdin());
+  if (!prompt.trim()) fail("Missing prompt (pass as an argument or via stdin)");
+
+  const requestType = parsed.type ?? (await resolveType(model));
+  if (requestType === "image") {
+    await runImagePath({ ...parsed, model, prompt });
+    return;
+  }
+  if (requestType === "video") {
+    await runVideoPath({ ...parsed, model, prompt });
+    return;
+  }
+
+  await runTextPath({ ...parsed, model, prompt });
+}
+
+/** Generate one or more images, writing each to disk and reporting warnings. */
+async function runImagePath(parsed: ModelArgs & { model: string; prompt: string }): Promise<void> {
+  // Some catalog `language` models (e.g. google/gemini-2.5-flash-image) emit
+  // images as message files rather than via the image-generation endpoint, so a
+  // `--type image` request on a language model routes through generateText.
+  if (usesLanguageImagePath(await lookupCapability(parsed.model))) {
+    await runLanguageImagePath(parsed);
+    return;
+  }
+  const gateway = createDuetModelGateway();
+  const result = await generateImage({
+    model: gateway.imageModel(parsed.model),
+    prompt: await buildImagePrompt(parsed),
+    size: parseSize(parsed.size),
+    aspectRatio: parseAspect(parsed.aspect),
+    n: parsed.n,
+    seed: parsed.seed,
+  });
+
+  for (const warning of result.warnings) {
+    process.stderr.write(`warning: ${JSON.stringify(warning)}\n`);
+  }
+
+  const single = result.images.length === 1;
+  for (const [index, image] of result.images.entries()) {
+    const extension = mediaTypeExtension(image.mediaType);
+    const path = resolveImageOut(parsed.out, extension, index + 1, single);
+    await writeFile(path, image.uint8Array);
+    process.stdout.write(`${path}\n`);
+  }
+}
+
+/** Generate images from a language model, extracting them from result.files. */
+async function runLanguageImagePath(
+  parsed: ModelArgs & { model: string; prompt: string },
+): Promise<void> {
+  const gateway = createDuetModelGateway();
+  const messages: ModelMessage[] = [{ role: "user", content: await buildContent(parsed) }];
+  const result = await generateText({
+    model: gateway(parsed.model),
+    system: parsed.system,
+    messages,
+  });
+
+  const images = result.files.filter((file) => file.mediaType.startsWith("image/"));
+  if (images.length === 0) fail(`Model ${parsed.model} returned no images`);
+
+  const single = images.length === 1;
+  for (const [index, image] of images.entries()) {
+    const extension = mediaTypeExtension(image.mediaType);
+    const path = resolveImageOut(parsed.out, extension, index + 1, single);
+    await writeFile(path, image.uint8Array);
+    process.stdout.write(`${path}\n`);
+  }
+}
+
+// Video files are large; cap downloads at 512 MiB rather than the SDK's 2 GiB
+// default so a runaway URL response fails fast instead of filling the disk.
+const VIDEO_MAX_BYTES = 512 * 1024 * 1024;
+
+/** Generate one or more videos, writing each to disk. Supports image->video. */
+async function runVideoPath(parsed: ModelArgs & { model: string; prompt: string }): Promise<void> {
+  const gateway = createDuetModelGateway();
+  const result = await generateVideo({
+    model: gateway.video(parsed.model),
+    prompt: await buildVideoPrompt(parsed),
+    aspectRatio: parseAspect(parsed.aspect),
+    resolution: parseResolution(parsed.resolution),
+    duration: parsed.duration,
+    fps: parsed.fps,
+    n: parsed.n,
+    seed: parsed.seed,
+    // Some video models return a URL the SDK must fetch; reuse the gateway's
+    // 15-minute fetch indirectly and bound the body to VIDEO_MAX_BYTES.
+    download: createDownload({ maxBytes: VIDEO_MAX_BYTES }),
+  }).catch(failOnBillingError);
+
+  for (const warning of result.warnings) {
+    process.stderr.write(`warning: ${JSON.stringify(warning)}\n`);
+  }
+
+  const single = result.videos.length === 1;
+  for (const [index, video] of result.videos.entries()) {
+    const extension = mediaTypeExtension(video.mediaType);
+    const path = resolveImageOut(parsed.out, extension, index + 1, single);
+    await writeFile(path, video.uint8Array);
+    process.stdout.write(`${path}\n`);
+  }
+}
+
+/**
+ * Video prompt: text alone for text->video, or `{ image, text }` when `--image`
+ * supplies a still to animate. The AI SDK takes a single source image as bytes.
+ */
+async function buildVideoPrompt(parsed: ModelArgs & { prompt: string }) {
+  if (!parsed.imagePath) return parsed.prompt;
+  const source = await readFile(resolveUserPath(parsed.imagePath));
+  return { image: new Uint8Array(source), text: parsed.prompt };
+}
+
+/**
+ * Gateway billing gates (402 video-requires-payment, 403 forbidden) carry a
+ * plain-English body; surface it verbatim so the user knows to pay rather than
+ * seeing an opaque SDK stack. Anything else rethrows unchanged.
+ */
+function failOnBillingError(error: unknown): never {
+  const status = (error as { statusCode?: number })?.statusCode;
+  if (status === 402 || status === 403) {
+    const body = (error as { responseBody?: string }).responseBody;
+    const message = (error as { message?: string }).message ?? "billing error";
+    fail(`${status}: ${body ?? message}`);
+  }
+  throw error;
+}
+
+/**
+ * Image prompt: the text alone for text->image, or `{ text, images }` for
+ * editing when `--image` supplies a source image to transform.
+ */
+async function buildImagePrompt(parsed: ModelArgs & { prompt: string }) {
+  if (!parsed.imagePath) return parsed.prompt;
+  const source = await readFile(resolveUserPath(parsed.imagePath));
+  return { text: parsed.prompt, images: [new Uint8Array(source)] };
+}
+
+/** Pick a single `--out` path, or auto-name; suffix the index when n>1. */
+function resolveImageOut(
+  out: string | undefined,
+  extension: string,
+  index: number,
+  single: boolean,
+): string {
+  if (out) return single ? resolveUserPath(out) : resolveUserPath(suffixIndex(out, index));
+  return autoOutputFilename(extension, index);
+}
+
+/** Insert `-<index>` before the extension: `art.png` -> `art-2.png`. */
+function suffixIndex(path: string, index: number): string {
+  const extension = extname(path);
+  return `${path.slice(0, path.length - extension.length)}-${index}${extension}`;
+}
+
+/** `image/png` -> `.png`, `image/jpeg` -> `.jpg`; default to `.png`. */
+function mediaTypeExtension(mediaType: string): string {
+  const subtype = mediaType.split("/")[1] ?? "png";
+  return subtype === "jpeg" ? ".jpg" : `.${subtype}`;
+}
+
+/** Validate `--size` is `{width}x{height}`; AI SDK requires that exact shape. */
+function parseSize(size: string | undefined): `${number}x${number}` | undefined {
+  if (!size) return undefined;
+  if (!/^\d+x\d+$/.test(size)) fail(`Invalid --size: ${size} (expected {width}x{height})`);
+  return size as `${number}x${number}`;
+}
+
+/** Validate `--aspect` is `{width}:{height}`; AI SDK requires that exact shape. */
+function parseAspect(aspect: string | undefined): `${number}:${number}` | undefined {
+  if (!aspect) return undefined;
+  if (!/^\d+:\d+$/.test(aspect)) fail(`Invalid --aspect: ${aspect} (expected {width}:{height})`);
+  return aspect as `${number}:${number}`;
+}
+
+/** Validate `--resolution` is `{width}x{height}`; AI SDK requires that exact shape. */
+function parseResolution(resolution: string | undefined): `${number}x${number}` | undefined {
+  if (!resolution) return undefined;
+  if (!/^\d+x\d+$/.test(resolution)) {
+    fail(`Invalid --resolution: ${resolution} (expected {width}x{height})`);
+  }
+  return resolution as `${number}x${number}`;
+}
+
+/** Stream a text completion to stdout or the `--out` file. */
+async function runTextPath(parsed: ModelArgs & { model: string; prompt: string }): Promise<void> {
+  const gateway = createDuetModelGateway();
+  const messages: ModelMessage[] = [{ role: "user", content: await buildContent(parsed) }];
+  const result = streamText({
+    model: gateway(parsed.model),
+    system: parsed.system,
+    messages,
+  });
+
+  if (parsed.out) {
+    const text = await result.text;
+    process.stdout.write(text);
+    await writeFile(resolveUserPath(parsed.out), text);
+    return;
+  }
+  for await (const chunk of result.textStream) {
+    process.stdout.write(chunk);
+  }
+  process.stdout.write("\n");
+}
+
+/**
+ * Build the user message content: the prompt text plus, when `--image` is set,
+ * an inline image part so vision models can see the picture.
+ */
+async function buildContent(parsed: ModelArgs & { prompt: string }) {
+  if (!parsed.imagePath) return parsed.prompt;
+  const path = resolveUserPath(parsed.imagePath);
+  const mediaType = IMAGE_MEDIA_TYPES[extname(path).toLowerCase()];
+  if (!mediaType) fail(`Unsupported image type: ${path}`);
+  const imagePart: ImagePart = { type: "image", image: await readFile(path), mediaType };
+  return [{ type: "text" as const, text: parsed.prompt }, imagePart];
+}
+
+/** Map a catalog capability to the CLI's request type; default to text. */
+async function resolveType(model: string): Promise<RequestType> {
+  return requestTypeForCapability(await lookupCapability(model));
+}
+
+async function lookupCapability(model: string): Promise<ModelType | undefined> {
+  try {
+    return (await fetchModelCatalog()).get(model);
+  } catch {
+    return undefined;
+  }
+}
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return "";
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8").trim();
+}
+
+export function parseArgs(args: string[]): ModelArgs {
+  const out: ModelArgs = { json: false, help: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    const next = () => {
+      const value = args[++i];
+      if (value === undefined) fail(`Missing value for ${arg}`);
+      return value;
+    };
+    switch (arg) {
+      case "--model":
+      case "-m":
+        out.model = next();
+        break;
+      case "--type":
+        out.type = parseType(next());
+        break;
+      case "--image":
+        out.imagePath = next();
+        break;
+      case "--out":
+      case "-o":
+        out.out = next();
+        break;
+      case "--system":
+        out.system = next();
+        break;
+      case "--size":
+        out.size = next();
+        break;
+      case "--aspect":
+        out.aspect = next();
+        break;
+      case "--n":
+        out.n = Number(next());
+        break;
+      case "--seed":
+        out.seed = Number(next());
+        break;
+      case "--duration":
+        out.duration = Number(next());
+        break;
+      case "--resolution":
+        out.resolution = next();
+        break;
+      case "--fps":
+        out.fps = Number(next());
+        break;
+      case "--json":
+        out.json = true;
+        break;
+      case "--env-file":
+        out.envFile = next();
+        break;
+      case "--help":
+      case "-h":
+        out.help = true;
+        break;
+      default:
+        if (arg.startsWith("-")) fail(`Unknown model option: ${arg}`);
+        out.prompt = out.prompt ? `${out.prompt} ${arg}` : arg;
+    }
+  }
+  return out;
+}
+
+function parseType(value: string): RequestType {
+  if (value === "text" || value === "image" || value === "video") return value;
+  fail(`Invalid --type: ${value} (expected text|image|video)`);
+}

--- a/test/cli-model.test.ts
+++ b/test/cli-model.test.ts
@@ -80,6 +80,10 @@ describe("parseArgs", () => {
   test("rejects a flag missing its value", () => {
     expect(() => parseArgs(["--model"])).toThrow(ExitCalled);
   });
+
+  test("rejects a value option followed by another flag", () => {
+    expect(() => parseArgs(["-m", "--type", "image"])).toThrow(ExitCalled);
+  });
 });
 
 describe("requestTypeForCapability", () => {

--- a/test/cli-model.test.ts
+++ b/test/cli-model.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { parseArgs, requestTypeForCapability, usesLanguageImagePath } from "../src/cli/model.js";
+import { testIfDocker } from "./helpers/docker-only.js";
+
+// Bad flags route through `fail()`, which calls process.exit(1). Patch it to
+// throw so the pure parser tests can assert on the error path without exiting.
+class ExitCalled extends Error {
+  constructor(public code?: number | string | null) {
+    super(`process.exit(${String(code)})`);
+  }
+}
+
+describe("parseArgs", () => {
+  let exitSpy: ReturnType<typeof spyOn> | undefined;
+  let errorSpy: ReturnType<typeof spyOn> | undefined;
+
+  beforeEach(() => {
+    exitSpy = spyOn(process, "exit").mockImplementation((code?: number | string | null) => {
+      throw new ExitCalled(code);
+    });
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy?.mockRestore();
+    errorSpy?.mockRestore();
+  });
+
+  test("parses model, type, image and numeric flags", () => {
+    const parsed = parseArgs([
+      "-m",
+      "openai/gpt-5.5",
+      "--type",
+      "image",
+      "--image",
+      "src.png",
+      "-o",
+      "art.png",
+      "--system",
+      "be terse",
+      "--size",
+      "1024x1024",
+      "--n",
+      "3",
+      "--seed",
+      "7",
+      "--duration",
+      "5",
+      "--fps",
+      "24",
+      "a fox",
+      "in snow",
+    ]);
+    expect(parsed.model).toBe("openai/gpt-5.5");
+    expect(parsed.type).toBe("image");
+    expect(parsed.imagePath).toBe("src.png");
+    expect(parsed.out).toBe("art.png");
+    expect(parsed.system).toBe("be terse");
+    expect(parsed.size).toBe("1024x1024");
+    expect(parsed.n).toBe(3);
+    expect(parsed.seed).toBe(7);
+    expect(parsed.duration).toBe(5);
+    expect(parsed.fps).toBe(24);
+    expect(parsed.prompt).toBe("a fox in snow");
+    expect(parsed.help).toBe(false);
+  });
+
+  test("--help sets the help flag", () => {
+    expect(parseArgs(["--help"]).help).toBe(true);
+    expect(parseArgs(["-h"]).help).toBe(true);
+  });
+
+  test("rejects an unknown option", () => {
+    expect(() => parseArgs(["--nope"])).toThrow(ExitCalled);
+  });
+
+  test("rejects an invalid --type", () => {
+    expect(() => parseArgs(["--type", "audio"])).toThrow(ExitCalled);
+  });
+
+  test("rejects a flag missing its value", () => {
+    expect(() => parseArgs(["--model"])).toThrow(ExitCalled);
+  });
+});
+
+describe("requestTypeForCapability", () => {
+  test("image and video map straight through", () => {
+    expect(requestTypeForCapability("image")).toBe("image");
+    expect(requestTypeForCapability("video")).toBe("video");
+  });
+
+  test("language and other capabilities default to text", () => {
+    expect(requestTypeForCapability("language")).toBe("text");
+    expect(requestTypeForCapability("embedding")).toBe("text");
+    expect(requestTypeForCapability(undefined)).toBe("text");
+  });
+});
+
+describe("usesLanguageImagePath", () => {
+  test("nano-banana style language models route through generateText/files", () => {
+    // google/gemini-2.5-flash-image is catalogued as `language` but emits
+    // images; a --type image request must use the language image path.
+    expect(usesLanguageImagePath("language")).toBe(true);
+  });
+
+  test("dedicated image models use the generateImage path", () => {
+    expect(usesLanguageImagePath("image")).toBe(false);
+  });
+});
+
+// File-writing image/video round-trips need the gateway and disk, so they only
+// run in docker. Host runs cover argument parsing and routing decisions above.
+testIfDocker("model command exports a runner entrypoint", async () => {
+  const { runModelCommand } = await import("../src/cli/model.js");
+  expect(typeof runModelCommand).toBe("function");
+});

--- a/test/cli-model.test.ts
+++ b/test/cli-model.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { parseArgs, requestTypeForCapability, usesLanguageImagePath } from "../src/cli/model.js";
-import { testIfDocker } from "./helpers/docker-only.js";
 
 // Bad flags route through `fail()`, which calls process.exit(1). Patch it to
 // throw so the pure parser tests can assert on the error path without exiting.
@@ -106,11 +105,4 @@ describe("usesLanguageImagePath", () => {
   test("dedicated image models use the generateImage path", () => {
     expect(usesLanguageImagePath("image")).toBe(false);
   });
-});
-
-// File-writing image/video round-trips need the gateway and disk, so they only
-// run in docker. Host runs cover argument parsing and routing decisions above.
-testIfDocker("model command exports a runner entrypoint", async () => {
-  const { runModelCommand } = await import("../src/cli/model.js");
-  expect(typeof runModelCommand).toBe("function");
 });


### PR DESCRIPTION
## What

Adds a `duet model` subcommand that talks to gateway models directly via the Vercel AI SDK (`ai@^7`), bypassing the pi harness. Supports text, image, and video — text/image/video output to stdout or a file, with `--image` input for vision, image editing, and image-to-video.

## How it routes

Modality is auto-detected from the gateway `/v1/models` catalog `type`, overridable with `--type`:
- **text** (`language`) → `streamText` to stdout/`--out`
- **image** (dedicated image models) → `generateImage`, `--image` enables editing
- **image** from image-emitting `language` models (Gemini `*-image` / nano-banana) → `generateText` + `result.files`
- **video** → `experimental_generateVideo`, `--image` enables image-to-video, `createDownload` + 15-min fetch for URL results, gateway 402/403 billing bodies surfaced

Output writes to `--out` or auto-named `model-<timestamp>-<n>.<ext>`; `n>1` suffixes `-1`, `-2`.

## Verification

- `check-types`, `lint`, `format` clean; 9 host tests (parsing + routing incl. nano-banana path).
- Live evals against the real gateway pass: text, image, and video round-trips (`evals/model-direct.eval.ts`, docker-gated).