### PR TITLE
refactor(cli): drop video download cap, cover nano-banana --image

### DIFF
--- a/evals/model-direct.eval.ts
+++ b/evals/model-direct.eval.ts
@@ -10,6 +10,7 @@ import { testIfDocker } from "../test/helpers/docker-only.js";
 const textModel = process.env.EVAL_MODEL ?? "anthropic/claude-haiku-4.5";
 const imageModel = process.env.EVAL_IMAGE_MODEL ?? "openai/gpt-image-1-mini";
 const videoModel = process.env.EVAL_VIDEO_MODEL ?? "bytedance/seedance-2.0-fast";
+const nanoBananaModel = process.env.EVAL_NANO_BANANA_MODEL ?? "google/gemini-2.5-flash-image";
 
 /**
  * `duet model` talks to a gateway model directly through the AI SDK, bypassing
@@ -51,6 +52,45 @@ describe("duet model direct CLI", () => {
       expect((await stat(out)).size).toBeGreaterThan(1000);
     },
     180_000,
+  );
+
+  // Nano-banana is a `language` model that emits images, so --type image routes
+  // through generateText + result.files, and --image must inline the source so
+  // the model edits it. Generate a source image, then edit it through that path.
+  testIfDocker(
+    "edits an image through a nano-banana language model with --image",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "duet-model-"));
+      const src = join(dir, "fox.png");
+      const edited = join(dir, "edited.png");
+      const gen = Bun.spawn(
+        ["bun", "src/cli.ts", "model", "-m", imageModel, "--type", "image", "-o", src, "a red fox"],
+        { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" },
+      );
+      expect(await gen.exited, await new Response(gen.stderr).text()).toBe(0);
+
+      const proc = Bun.spawn(
+        [
+          "bun",
+          "src/cli.ts",
+          "model",
+          "-m",
+          nanoBananaModel,
+          "--type",
+          "image",
+          "--image",
+          src,
+          "-o",
+          edited,
+          "add a blue hat",
+        ],
+        { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" },
+      );
+      const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+      expect(exitCode, stderr).toBe(0);
+      expect((await stat(edited)).size).toBeGreaterThan(1000);
+    },
+    240_000,
   );
 
   testIfDocker(

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -1,7 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { extname } from "node:path";
 import {
-  createDownload,
   experimental_generateVideo as generateVideo,
   generateImage,
   generateText,
@@ -163,10 +162,6 @@ async function runLanguageImagePath(
   }
 }
 
-// Video files are large; cap downloads at 512 MiB rather than the SDK's 2 GiB
-// default so a runaway URL response fails fast instead of filling the disk.
-const VIDEO_MAX_BYTES = 512 * 1024 * 1024;
-
 /** Generate one or more videos, writing each to disk. Supports image->video. */
 async function runVideoPath(parsed: ModelArgs & { model: string; prompt: string }): Promise<void> {
   const gateway = createDuetModelGateway();
@@ -179,9 +174,6 @@ async function runVideoPath(parsed: ModelArgs & { model: string; prompt: string 
     fps: parsed.fps,
     n: parsed.n,
     seed: parsed.seed,
-    // Some video models return a URL the SDK must fetch; reuse the gateway's
-    // 15-minute fetch indirectly and bound the body to VIDEO_MAX_BYTES.
-    download: createDownload({ maxBytes: VIDEO_MAX_BYTES }),
   }).catch(failOnBillingError);
 
   for (const warning of result.warnings) {


### PR DESCRIPTION
Removes the artificial 512 MiB video download cap (use the AI SDK default; the cap protected against no real failure). Adds a live docker eval that edits an image through the nano-banana language-model path with `--image` — generates a source image, then edits it via google/gemini-2.5-flash-image. Verified live: nano-banana edit + video paths both pass.