### PR TITLE
refactor(cli): review fixes for duet model

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -322,20 +322,20 @@ OPTIONS
   -o, --out <path>         Write output here; image/video auto-name when omitted
   --system <text>          System prompt for text/image-language models
   --size <WxH>             Image size, e.g. 1024x1024
-  --aspect <W:H>          Aspect ratio, e.g. 16:9
+  --aspect <W:H>           Aspect ratio, e.g. 16:9
   --n <count>              Number of outputs to generate
-  --seed <int>            Generation seed
-  --duration <seconds>    Video length
-  --resolution <WxH>      Video resolution, e.g. 1280x720
-  --fps <int>             Video frames per second
-  --env-file <path>       Shared env file to load after cwd .env
-  -h, --help              Show this help
+  --seed <int>             Generation seed
+  --duration <seconds>     Video length
+  --resolution <WxH>       Video resolution, e.g. 1280x720
+  --fps <int>              Video frames per second
+  --env-file <path>        Shared env file to load after cwd .env
+  -h, --help               Show this help
 
 EXAMPLES
   duet model -m openai/gpt-5.5 "write a haiku about gateways"
-  duet model -m black-forest-labs/flux-1.1-pro -o art.png "a fox in snow"
+  duet model -m bfl/flux-pro-1.1 -o art.png "a fox in snow"
   duet model -m google/gemini-2.5-flash-image --type image --image src.png "add a hat"
-  duet model -m bytedance/seedance-1.0 --type video -o clip.mp4 "slow pan over dunes"
+  duet model -m bytedance/seedance-2.0 --type video -o clip.mp4 "slow pan over dunes"
 `);
 }
 

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -93,9 +93,16 @@ export async function runModelCommand(args: string[]): Promise<void> {
   const prompt = parsed.prompt ?? (await readStdin());
   if (!prompt.trim()) fail("Missing prompt (pass as an argument or via stdin)");
 
-  const requestType = parsed.type ?? (await resolveType(model));
+  // The catalog is only needed to auto-detect the type or to tell a dedicated
+  // image model from a language model that emits images; forced text/video skip
+  // it. Fetch at most once and thread the result into the image path.
+  const capability =
+    parsed.type === undefined || parsed.type === "image"
+      ? await lookupCapability(model)
+      : undefined;
+  const requestType = parsed.type ?? requestTypeForCapability(capability);
   if (requestType === "image") {
-    await runImagePath({ ...parsed, model, prompt });
+    await runImagePath({ ...parsed, model, prompt, capability });
     return;
   }
   if (requestType === "video") {
@@ -107,11 +114,13 @@ export async function runModelCommand(args: string[]): Promise<void> {
 }
 
 /** Generate one or more images, writing each to disk and reporting warnings. */
-async function runImagePath(parsed: ModelArgs & { model: string; prompt: string }): Promise<void> {
+async function runImagePath(
+  parsed: ModelArgs & { model: string; prompt: string; capability: ModelType | undefined },
+): Promise<void> {
   // Some catalog `language` models (e.g. google/gemini-2.5-flash-image) emit
   // images as message files rather than via the image-generation endpoint, so a
   // `--type image` request on a language model routes through generateText.
-  if (usesLanguageImagePath(await lookupCapability(parsed.model))) {
+  if (usesLanguageImagePath(parsed.capability)) {
     await runLanguageImagePath(parsed);
     return;
   }
@@ -123,7 +132,7 @@ async function runImagePath(parsed: ModelArgs & { model: string; prompt: string 
     aspectRatio: parseAspect(parsed.aspect),
     n: parsed.n,
     seed: parsed.seed,
-  });
+  }).catch(failOnBillingError);
 
   for (const warning of result.warnings) {
     process.stderr.write(`warning: ${JSON.stringify(warning)}\n`);
@@ -132,7 +141,7 @@ async function runImagePath(parsed: ModelArgs & { model: string; prompt: string 
   const single = result.images.length === 1;
   for (const [index, image] of result.images.entries()) {
     const extension = mediaTypeExtension(image.mediaType);
-    const path = resolveImageOut(parsed.out, extension, index + 1, single);
+    const path = resolveOutputPath(parsed.out, extension, index + 1, single);
     await writeFile(path, image.uint8Array);
     process.stdout.write(`${path}\n`);
   }
@@ -148,7 +157,7 @@ async function runLanguageImagePath(
     model: gateway(parsed.model),
     system: parsed.system,
     messages,
-  });
+  }).catch(failOnBillingError);
 
   const images = result.files.filter((file) => file.mediaType.startsWith("image/"));
   if (images.length === 0) fail(`Model ${parsed.model} returned no images`);
@@ -156,7 +165,7 @@ async function runLanguageImagePath(
   const single = images.length === 1;
   for (const [index, image] of images.entries()) {
     const extension = mediaTypeExtension(image.mediaType);
-    const path = resolveImageOut(parsed.out, extension, index + 1, single);
+    const path = resolveOutputPath(parsed.out, extension, index + 1, single);
     await writeFile(path, image.uint8Array);
     process.stdout.write(`${path}\n`);
   }
@@ -183,7 +192,7 @@ async function runVideoPath(parsed: ModelArgs & { model: string; prompt: string 
   const single = result.videos.length === 1;
   for (const [index, video] of result.videos.entries()) {
     const extension = mediaTypeExtension(video.mediaType);
-    const path = resolveImageOut(parsed.out, extension, index + 1, single);
+    const path = resolveOutputPath(parsed.out, extension, index + 1, single);
     await writeFile(path, video.uint8Array);
     process.stdout.write(`${path}\n`);
   }
@@ -200,9 +209,10 @@ async function buildVideoPrompt(parsed: ModelArgs & { prompt: string }) {
 }
 
 /**
- * Gateway billing gates (402 video-requires-payment, 403 forbidden) carry a
+ * Gateway billing gates (402 requires-payment, 403 forbidden) carry a
  * plain-English body; surface it verbatim so the user knows to pay rather than
- * seeing an opaque SDK stack. Anything else rethrows unchanged.
+ * seeing an opaque SDK stack. Shared by the image, language-image, and video
+ * paths since any paid model can hit it. Anything else rethrows unchanged.
  */
 function failOnBillingError(error: unknown): never {
   const status = (error as { statusCode?: number })?.statusCode;
@@ -225,7 +235,7 @@ async function buildImagePrompt(parsed: ModelArgs & { prompt: string }) {
 }
 
 /** Pick a single `--out` path, or auto-name; suffix the index when n>1. */
-function resolveImageOut(
+function resolveOutputPath(
   out: string | undefined,
   extension: string,
   index: number,
@@ -303,11 +313,6 @@ async function buildContent(parsed: ModelArgs & { prompt: string }) {
   if (!mediaType) fail(`Unsupported image type: ${path}`);
   const imagePart: ImagePart = { type: "image", image: await readFile(path), mediaType };
   return [{ type: "text" as const, text: parsed.prompt }, imagePart];
-}
-
-/** Map a catalog capability to the CLI's request type; default to text. */
-async function resolveType(model: string): Promise<RequestType> {
-  return requestTypeForCapability(await lookupCapability(model));
 }
 
 async function lookupCapability(model: string): Promise<ModelType | undefined> {


### PR DESCRIPTION
Review cleanup of the merged `duet model` CLI:

- **Fetch the model catalog at most once.** Auto-detected image requests previously fetched `/v1/models` twice (type detection + dedicated-vs-language check). Now the capability is resolved once in `runModelCommand` and threaded into the image path; forced `--type text|video` skip the fetch entirely. Removed the redundant `resolveType` wrapper.
- **Consistent billing-error handling.** `failOnBillingError` (402/403 → actionable message) was only on the video path; applied it to the image and language-image generations too, since any paid model can hit it.
- **Renamed `resolveImageOut` → `resolveOutputPath`** — it serves video output too.
- **Fixed invalid help example slugs.** `black-forest-labs/flux-1.1-pro` and `bytedance/seedance-1.0` don't exist in the gateway catalog; replaced with real ids (`bfl/flux-pro-1.1`, `bytedance/seedance-2.0`) and aligned the OPTIONS columns.

Verified: check-types/lint/format clean, 10 host tests pass, and all four live evals (text, image, nano-banana --image, video) pass in docker.