### PR TITLE
feat(turn-runner): fork-context sub-agent reminder

### DIFF
--- a/src/turn-runner/prompts.ts
+++ b/src/turn-runner/prompts.ts
@@ -103,6 +103,25 @@ export function createStateAgentSystemPromptLayer(context?: {
 }
 
 /**
+ * Reminder injected at the head of a forked agent state's tail user turn. When
+ * `forkContext` is on, the sub-agent is seeded with a verbatim copy of the
+ * parent (orchestrator) agent's transcript, so the model opens onto a full
+ * conversation it can mistake for its own — concluding it is the parent still
+ * mid-turn and continuing that thread instead of running this state. This block
+ * draws the line explicitly: everything above is inherited parent context to
+ * read, the task is only what follows, and the sub-agent cannot route. It rides
+ * in the user turn (not the system prompt) so the forked system prompt stays
+ * byte-identical to the parent's and preserves the provider prompt-cache prefix.
+ */
+export function createForkContextReminder(): string {
+  return dedent`
+    <system-reminder>
+    The conversation above is a copy of the parent (orchestrator) agent's transcript, handed to you only as background context. You are NOT the parent agent and you are not continuing that conversation — you are now a fresh sub-agent running a single state of the state machine. Read the transcript above as reference material about what has happened; do not treat its last message as something you just said or were about to answer. Your one task is the instruction that follows this reminder. Do that task, report what you did and found, and remember you cannot select or route to other states — the orchestrator does that after reading your report.
+    </system-reminder>
+  `;
+}
+
+/**
  * Situates the sub-agent inside the larger state machine so it scopes its work
  * to the current state instead of trying to deliver the whole process.
  *

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -63,6 +63,7 @@ import { agentEventToTurnEvents, agentMessageText } from "./agent-events.js";
 import {
   createRecallMemorySystemPromptLayer,
   createSourceOfTruthSystemPromptLayer,
+  createForkContextReminder,
   createStateAgentSystemPromptLayer,
   createStateMachineSystemPromptLayer,
 } from "./prompts.js";
@@ -1262,7 +1263,7 @@ export class TurnRunner {
         : this.createBaseSystemPromptWithAppendedLayers({ skills: stateSkills })
       : undefined;
     const tailPrompt = forkContext
-      ? [identityLayer, input.state.systemPrompt, expandedPrompt]
+      ? [createForkContextReminder(), identityLayer, input.state.systemPrompt, expandedPrompt]
           .filter((part): part is string => Boolean(part))
           .join("\n\n")
       : expandedPrompt;

--- a/test/state-machine-fork-context-reminder.test.ts
+++ b/test/state-machine-fork-context-reminder.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { TurnRunner, type AgentConfigInput } from "../src/turn-runner/turn-runner.js";
+import type { TurnRunnerControlResult } from "../src/turn-runner/tools.js";
+import { createForkContextReminder } from "../src/turn-runner/prompts.js";
+import type { StateAgentHandle } from "../src/turn-runner/state-machine-controller.js";
+import type { StateMachineAgentState } from "../src/types/state-machine.js";
+import type { TurnState } from "../src/types/protocol.js";
+
+/**
+ * Deterministic guard for the fork-context reminder. When `forkContext` is on,
+ * the sub-agent is seeded with the parent's transcript, so it can mistake that
+ * conversation for its own and act as the parent. The reminder rides in the
+ * tail USER turn (not the system prompt — that stays byte-identical to the
+ * parent for prompt-cache reuse), which is why this test captures the prompt
+ * argument handed to `agent.prompt`, not the composed system prompt.
+ */
+
+const RUNNING_STATE: TurnState = {
+  status: "running",
+  mode: "agent",
+  options: {},
+  agent: { status: "running", messages: [] },
+};
+
+/**
+ * Drives the real createStateAgentHandle path and returns the tail prompt the
+ * sub-agent would actually run. `agent.prompt` is stubbed so no network call
+ * happens and `retryTransientServerErrors` short-circuits on the clean state.
+ */
+async function captureTailPrompt(state: StateMachineAgentState): Promise<string> {
+  let tail: string | undefined;
+
+  class CapturingTurnRunner extends TurnRunner {
+    constructor() {
+      super({ model: "anthropic:claude-opus-4-8", skillDiscovery: { includeDefaults: false } });
+    }
+
+    protected override createAgent(
+      input: AgentConfigInput,
+      onControlResult?: (result: TurnRunnerControlResult) => void,
+    ): Agent {
+      const agent = super.createAgent(input, onControlResult);
+      agent.prompt = (async (prompt: string) => {
+        tail = prompt;
+      }) as typeof agent.prompt;
+      return agent;
+    }
+  }
+
+  const runner = new CapturingTurnRunner();
+  (runner as unknown as { state: TurnState }).state = RUNNING_STATE;
+  const handle = (
+    runner as unknown as {
+      createStateAgentHandle: (input: {
+        state: StateMachineAgentState;
+        prompt: string;
+      }) => StateAgentHandle;
+    }
+  ).createStateAgentHandle({ state, prompt: state.prompt });
+
+  await handle.prompt();
+  if (tail === undefined) throw new Error("agent.prompt was not invoked");
+  return tail;
+}
+
+describe("fork-context reminder", () => {
+  test("the reminder draws the parent/sub-agent line and forbids routing", () => {
+    const reminder = createForkContextReminder();
+    expect(reminder).toContain("<system-reminder>");
+    expect(reminder).toContain("copy of the parent");
+    expect(reminder).toContain("You are NOT the parent agent");
+    expect(reminder).toContain("fresh sub-agent");
+    expect(reminder).toContain("cannot select or route to other states");
+  });
+
+  test("a forked agent state leads its tail turn with the reminder", async () => {
+    const tail = await captureTailPrompt({
+      kind: "agent",
+      name: "recall_secret",
+      forkContext: true,
+      prompt: "Find the token in the conversation above and reply with it.",
+    });
+
+    const reminderIndex = tail.indexOf("<system-reminder>");
+    const identityIndex = tail.indexOf("state_agent_identity");
+    const taskIndex = tail.indexOf("Find the token");
+
+    // The reminder must land first so the model resets its identity before it
+    // reads the inherited transcript's identity layer or the task itself.
+    expect(reminderIndex).toBe(0);
+    expect(identityIndex).toBeGreaterThan(reminderIndex);
+    expect(taskIndex).toBeGreaterThan(identityIndex);
+  });
+
+  test("a non-forked agent state has no reminder and no inlined identity", async () => {
+    const tail = await captureTailPrompt({
+      kind: "agent",
+      name: "recall_secret",
+      prompt: "Find the token in the conversation above and reply with it.",
+    });
+
+    // Fresh-context states carry their identity in the system prompt, so the
+    // tail turn is just the task — no reminder, no identity layer inlined.
+    expect(tail).not.toContain("<system-reminder>");
+    expect(tail).not.toContain("state_agent_identity");
+    expect(tail).toBe("Find the token in the conversation above and reply with it.");
+  });
+});


### PR DESCRIPTION
When an agent state runs with `forkContext: true`, the sub-agent is seeded with a verbatim copy of the parent (orchestrator) agent's transcript. Opening onto a full conversation, the model can mistake it for its own and act as the parent continuing mid-turn instead of running this single state.

This adds `createForkContextReminder()` and prepends it to the forked state's **tail user turn** (ahead of the identity layer and the task). It explicitly tells the sub-agent: the conversation above is inherited parent context to read, you are now a fresh sub-agent running one state, the task is what follows, and you cannot route to other states.

It rides in the user turn (not the system prompt) so the forked system prompt stays byte-identical to the parent's and preserves the provider prompt-cache prefix — same design the existing fork path already uses for the identity layer. Non-forked states are unchanged (no reminder, identity stays in the system prompt).

**Verification**
- New deterministic test `test/state-machine-fork-context-reminder.test.ts` (3 pass): reminder content, reminder leads the forked tail turn, non-forked tail is just the task.
- Existing `state-machine-agent-identity-layer.test.ts` still green (6 pass).
- Live `evals/state-machine-agent-fork-context.eval.ts` all 3 pass in docker (fork seeds, fresh stays fresh, override flips on).