### PR TITLE
[walter] refactor: rename /reset slash command to /clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,12 +327,12 @@ Type `/` in the composer to open the command picker, or send any of these as a m
 - **`/model <name>`** — switch the model used for **subsequent** turns. Accepts the same shorthands and `provider:modelId` forms as the `--model` flag (e.g. `/model sonnet-4.6`, `/model anthropic:claude-opus-4-7`). Unknown shorthands or missing provider credentials surface an error and leave the current model in place. The in-flight turn (if any) keeps the model it started with.
 - **`/thinking <level>`** — switch the thinking level for the **next** turn. One of `minimal`, `low`, `medium`, `high`, `xhigh`. The runner clamps to the active model's supported range at use-time. The in-flight turn (if any) keeps its level.
 - **`/feedback <message>`** — send free-form feedback to the Duet team.
-- **`/reset`** — dispose the current session and start a fresh one.
+- **`/clear`** — dispose the current session and start a fresh one.
 - **`/copy [last|all|<N>]`** — copy transcript text to the system clipboard (default: last agent reply).
 - **`/paste`**, **`/image <path>`**, **`/clear-images`** — image-attachment helpers, covered in the next section.
 - **`/diag`** — toggle key and selection event logging when triaging terminal-specific issues.
 
-`/model`, `/thinking`, `/reset`, `/paste`, `/clear-images`, and `/diag` also work **anywhere inside a longer prompt**. `hey can you review this /model gpt-5.5` swaps the model for the very turn that delivers the message; the slash form is stripped from what the agent sees, so the model receives `hey can you review this`. When the whole prompt is just slash commands, no agent turn runs at all. Commands that take rest-of-line arguments (`/feedback`, `/copy`, `/image`) only fire when they own the whole message.
+`/model`, `/thinking`, `/clear`, `/paste`, `/clear-images`, and `/diag` also work **anywhere inside a longer prompt**. `hey can you review this /model gpt-5.5` swaps the model for the very turn that delivers the message; the slash form is stripped from what the agent sees, so the model receives `hey can you review this`. When the whole prompt is just slash commands, no agent turn runs at all. Commands that take rest-of-line arguments (`/feedback`, `/copy`, `/image`) only fire when they own the whole message.
 
 The inline form also works for the non-TUI one-shot CLI: `duet "hey can you review this /model gpt-5.5"` swaps the model and dispatches the stripped prompt to the agent; `duet "/model gpt-5.5"` applies the swap and exits without dispatching a turn.
 

--- a/src/cli/inline-slash.ts
+++ b/src/cli/inline-slash.ts
@@ -3,7 +3,7 @@ import { validateThinkingLevel } from "../session/thinking-level.js";
 import { applyInlineSlashCommands, type SlashCommandContext } from "../tui/slash-commands.js";
 import type { TurnRunnerConfig } from "../types/config.js";
 
-/** Slash commands the non-TUI CLI applies inline. /reset, /paste, /clear-images, /diag
+/** Slash commands the non-TUI CLI applies inline. /clear, /paste, /clear-images, /diag
  *  have no meaning in a one-shot run so the CLI intentionally ignores them. */
 const CLI_INLINE_COMMANDS: ReadonlySet<string> = new Set(["model", "thinking"]);
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -383,7 +383,7 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
       // eslint-disable-next-line no-constant-condition
       while (true) {
         let pendingResumeSessionId: string | undefined;
-        let pendingReset = false;
+        let pendingClear = false;
         await runTui({
           session: activeSession,
           ...(activeHistory ? { history: activeHistory } : {}),
@@ -391,8 +391,8 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
           onResumeRequest: (id: string) => {
             pendingResumeSessionId = id;
           },
-          onResetRequest: () => {
-            pendingReset = true;
+          onClearRequest: () => {
+            pendingClear = true;
           },
           resumeHistoryMessages,
           modelName,
@@ -406,8 +406,8 @@ export async function runRunCommand(args: string[], pkg: PackageMetadata): Promi
           upgradeStatus$,
         });
 
-        if (pendingReset) {
-          // `/reset` from the slash dispatcher: drop the current session
+        if (pendingClear) {
+          // `/clear` from the slash dispatcher: drop the current session
           // (flushing state.json) and start a fresh one. The new session
           // boots with starters visible — same as launching `duet`
           // without `--resume`.

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -105,13 +105,13 @@ export interface RunTuiInput {
    */
   onResumeRequest?: (sessionId: string) => void;
   /**
-   * Called when the user submits `/reset`. The outer dispatcher should
+   * Called when the user submits `/clear`. The outer dispatcher should
    * dispose the current session, `manager.create({})`, and re-enter
    * `runTui` with the fresh session and no replayed history. The TUI
    * tears its own renderer down right after invoking this so the
    * dispatcher's `runTui` promise resolves and the loop can rebuild.
    */
-  onResetRequest?: () => void;
+  onClearRequest?: () => void;
   /**
    * Trailing user-turn exchanges to replay from prior history. Each
    * exchange is the user prompt plus the assistant blocks that followed
@@ -378,8 +378,8 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
       copyController,
       transcriptWriter,
       appendBlock,
-      onReset: () => {
-        input.onResetRequest?.();
+      onClear: () => {
+        input.onClearRequest?.();
         renderer.destroy();
       },
       setModel: (model: string) => input.session.setModel(model),

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -17,7 +17,7 @@ export interface SlashCommandContext {
    * Controllers are optional because not every consumer of this
    * interface wires the full TUI. The non-TUI CLI applies inline
    * `/model` and `/thinking` against a stripped-down context that
-   * has no clipboard, transcript, or reset surface — those commands
+   * has no clipboard, transcript, or session-management surface — those commands
    * are filtered out via `applyInlineSlashCommands`'s `onlyCommands`
    * before they could ever run, so the handlers that depend on these
    * controllers never see a missing one in practice.
@@ -27,12 +27,12 @@ export interface SlashCommandContext {
   transcriptWriter?: TranscriptWriter;
   appendBlock(label: string | null, body: string, fg: string): void;
   /**
-   * Invoked by `/reset` to ask the outer dispatcher to dispose the
+   * Invoked by `/clear` to ask the outer dispatcher to dispose the
    * current session and re-enter `runTui` with a fresh one. The TUI
    * tears its renderer down immediately after so the parent `while`
    * loop in `cli/run.ts` wakes and performs the swap.
    */
-  onReset?(): void;
+  onClear?(): void;
   /**
    * Invoked by `/model <name>` to swap the model used for subsequent
    * turns. Returns the canonicalized name the session will use on the
@@ -64,7 +64,7 @@ export interface SlashCommandContext {
  * takes when it appears anywhere in a longer prompt rather than as the
  * whole submitted message.
  *
- * - `"none"`: bare invocation only (`/reset`). Matches `/name` with
+ * - `"none"`: bare invocation only (`/clear`). Matches `/name` with
  *   whitespace / start / end boundaries on both sides.
  * - `"token"`: requires one whitespace-bounded argument (`/model X`).
  *   Matches `/name <token>` with whitespace / start before and consumes
@@ -171,12 +171,12 @@ export const BUILT_IN_SLASH_COMMANDS: readonly BuiltInSlashCommand[] = [
     },
   },
   {
-    name: "reset",
+    name: "clear",
     description: "Dispose the current session and start a fresh one",
-    matches: (message) => isBare(message, "reset"),
+    matches: (message) => isBare(message, "clear"),
     handle: (_, ctx) => {
-      ctx.appendBlock("[reset]", "starting a new session…", COLORS.system);
-      ctx.onReset?.();
+      ctx.appendBlock("[clear]", "starting a new session…", COLORS.system);
+      ctx.onClear?.();
     },
     inline: "none",
   },

--- a/test/helpers/tui-harness.ts
+++ b/test/helpers/tui-harness.ts
@@ -50,8 +50,8 @@ export interface TuiHarness {
   answerCalls: SessionAnswerInput[];
   /** Number of times `session.interrupt()` has been invoked. */
   interruptCalls: number;
-  /** Number of times the TUI fired its `onResetRequest` callback. */
-  resetRequestCalls: number;
+  /** Number of times the TUI fired its `onClearRequest` callback. */
+  clearRequestCalls: number;
   /** True once `runTui` has resolved (the renderer was destroyed / the TUI
    *  exited). Lets Ctrl+C tests assert a clean quit happened. */
   exited: boolean;
@@ -186,7 +186,7 @@ export async function bootTui(options: BootTuiOptions = {}): Promise<TuiHarness>
   const promptCalls: SessionPromptInput[] = [];
   const answerCalls: SessionAnswerInput[] = [];
   let interruptCalls = 0;
-  let resetRequestCalls = 0;
+  let clearRequestCalls = 0;
   // Mirror every event the Session emits so `pushAskTerminal` can wait
   // until the runner's `ask` has actually flowed Runner → Session → TUI
   // before returning. `Session.emit` iterates handlers synchronously, so
@@ -240,8 +240,8 @@ export async function bootTui(options: BootTuiOptions = {}): Promise<TuiHarness>
     memoryModelName: "harness",
     upgradeStatus$,
     renderer,
-    onResetRequest: () => {
-      resetRequestCalls += 1;
+    onClearRequest: () => {
+      clearRequestCalls += 1;
     },
   })
     .catch((error) => {
@@ -292,8 +292,8 @@ export async function bootTui(options: BootTuiOptions = {}): Promise<TuiHarness>
     get interruptCalls() {
       return interruptCalls;
     },
-    get resetRequestCalls() {
-      return resetRequestCalls;
+    get clearRequestCalls() {
+      return clearRequestCalls;
     },
     get exited() {
       return exited;

--- a/test/session-model-switch.test.ts
+++ b/test/session-model-switch.test.ts
@@ -166,7 +166,7 @@ describe("Session model-switch persistence", () => {
         appendBlock: (label: string | null, body: string) => {
           blocks.push({ label, body });
         },
-        onReset: () => {},
+        onClear: () => {},
         setModel: (model: string) => session.setModel(model),
         setThinkingLevel: (level: string) => session.setThinkingLevel(level),
       };
@@ -220,7 +220,7 @@ describe("Session model-switch persistence", () => {
         appendBlock: (label: string | null, body: string) => {
           blocks.push({ label, body });
         },
-        onReset: () => {},
+        onClear: () => {},
         setModel: (model: string) => session.setModel(model),
         setThinkingLevel: (level: string) => session.setThinkingLevel(level),
       };
@@ -262,7 +262,7 @@ describe("Session model-switch persistence", () => {
         appendBlock: (label: string | null, body: string) => {
           blocks.push({ label, body });
         },
-        onReset: () => {},
+        onClear: () => {},
         setModel: (model: string) => session.setModel(model),
         setThinkingLevel: (level: string) => session.setThinkingLevel(level),
       };

--- a/test/tui-autocomplete.test.ts
+++ b/test/tui-autocomplete.test.ts
@@ -13,7 +13,8 @@ import { testIfDocker } from "./helpers/docker-only.js";
  * locks the *visible* picker contract:
  *
  *  - `/` opens the slash picker with a "commands" header.
- *  - `/cl` narrows to `clear-images` (built-in prefix match).
+ *  - `/cl` narrows to both `/clear` and `/clear-images` (built-in prefix
+ *    match — both commands share the `cl` prefix after the rename).
  *  - Tab completes the highlighted row into the composer.
  *  - Esc closes the picker without exiting the TUI.
  *  - `@` opens the file picker against a seeded `workDir` fixture and Tab
@@ -46,14 +47,16 @@ describe("TUI autocomplete pickers", () => {
       expect(frame).toContain("/clear-images");
     });
 
-    testIfDocker("typing `/cl` narrows the picker to `clear-images`", async () => {
+    testIfDocker("typing `/cl` narrows the picker to `clear` and `clear-images`", async () => {
       await harness.mockInput.typeText("/cl");
       await harness.flush();
 
       const frame = await harness.captureCharFrame();
-      // The narrowed picker must show `/clear-images` and must not show
+      // After the `/reset` → `/clear` rename, `/cl` matches BOTH `/clear` and
+      // `/clear-images`. The narrowed picker must show both and must not show
       // other built-ins whose names do not start with `cl` (e.g. `/image`,
-      // `/copy`, `/diag`).
+      // `/diag`, `/feedback`).
+      expect(frame).toContain("/clear");
       expect(frame).toContain("/clear-images");
       expect(frame).not.toContain("/image\n");
       expect(frame).not.toContain("/diag");
@@ -61,13 +64,18 @@ describe("TUI autocomplete pickers", () => {
     });
 
     testIfDocker("Tab completes the highlighted slash row into the composer", async () => {
-      await harness.mockInput.typeText("/cl");
+      // Use `/pa`, whose first letter `p` is unique among the built-in
+      // commands, so it resolves to exactly `/paste`. A unique-first-letter
+      // command avoids the `/clear` vs `/clear-images` shared-prefix ambiguity
+      // (any prefix of `clear` matches both, and `clear` sorts first) and stays
+      // robust even if a partial flush settles only the first typed char.
+      await harness.mockInput.typeText("/pa");
       await harness.flush();
       // Picker auto-highlights the first match; Tab inserts the full name.
       harness.mockInput.pressTab();
       await harness.flush();
 
-      expect(harness.inputField.plainText).toBe("/clear-images ");
+      expect(harness.inputField.plainText).toBe("/paste ");
       // Picker must close after completion so the next Enter submits.
       const frame = await harness.captureCharFrame();
       expect(frame).not.toContain("commands");

--- a/test/tui-slash-commands.test.ts
+++ b/test/tui-slash-commands.test.ts
@@ -154,9 +154,9 @@ describe("TUI slash commands", () => {
     },
   );
 
-  testIfDocker("/reset fires the host reset callback and never dispatches a prompt", async () => {
+  testIfDocker("/clear fires the host clear callback and never dispatches a prompt", async () => {
     const promptsBefore = harness.promptCalls.length;
-    await harness.mockInput.typeText("/reset");
+    await harness.mockInput.typeText("/clear");
     await harness.flush();
     // Slash autocomplete may pop open on the leading `/`; close it so
     // Enter triggers `submit` instead of completing a row.
@@ -165,8 +165,8 @@ describe("TUI slash commands", () => {
     harness.mockInput.pressEnter();
     await harness.flush();
 
-    expect(harness.resetRequestCalls).toBe(1);
-    // /reset is a local slash command — it must never reach the runner.
+    expect(harness.clearRequestCalls).toBe(1);
+    // /clear is a local slash command — it must never reach the runner.
     expect(harness.promptCalls.length).toBe(promptsBefore);
   });
 

--- a/test/tui-slash-model-command.test.ts
+++ b/test/tui-slash-model-command.test.ts
@@ -28,7 +28,7 @@ function makeContext(
     appendBlock: (label, body, fg) => {
       blocks.push({ label, body, fg });
     },
-    onReset: () => {},
+    onClear: () => {},
     setModel,
     setThinkingLevel,
     ...overrides,
@@ -375,21 +375,21 @@ describe("applyInlineSlashCommands", () => {
         setModelCalls.push(model);
         return { modelName: model };
       },
-      onReset: () => {
-        throw new Error("onReset must not run when filtered out");
+      onClear: () => {
+        throw new Error("onClear must not run when filtered out");
       },
     });
 
     const { handledCommands, residue } = applyInlineSlashCommands(
-      "/model sonnet-4.6 also /reset please",
+      "/model sonnet-4.6 also /clear please",
       ctx,
       { onlyCommands: new Set(["model", "thinking"]) },
     );
 
     expect(setModelCalls).toEqual(["sonnet-4.6"]);
     expect(handledCommands).toEqual(["model"]);
-    // /reset stays in the residue because it was filtered out of the
+    // /clear stays in the residue because it was filtered out of the
     // inline-eligible set — the CLI intentionally ignores it.
-    expect(residue).toBe("also /reset please");
+    expect(residue).toBe("also /clear please");
   });
 });


### PR DESCRIPTION
Renames the `/reset` TUI slash command to `/clear`. Full rename — no shim, no alias; `/reset` no longer exists.

## Changes
- `src/tui/slash-commands.ts` — command `name`/`matches` → `clear`, `[reset]` → `[clear]` block label, `onReset` → `onClear` in `SlashCommandContext`, comment/JSDoc refs.
- `src/tui/app.ts` — `onResetRequest` → `onClearRequest`, `onReset` wiring, JSDoc.
- `src/cli/run.ts` — `pendingReset` → `pendingClear`, `onResetRequest` → `onClearRequest`, comments.
- `src/cli/inline-slash.ts` — ignored-inline-commands comment.
- `README.md` — both `/reset` refs.
- Tests: `test/tui-slash-commands.test.ts`, `test/helpers/tui-harness.ts`, `test/tui-slash-model-command.test.ts`, `test/session-model-switch.test.ts`.

## Notes
- `/clear` and `/clear-images` coexist safely — both use `isBare` exact-match, no collision/shadowing.
- Protected `reset`/`ECONNRESET` references elsewhere untouched.

## Validation
`bun run check-types`, `bun run lint`, `bun run format:check` all clean; relevant tests pass.