### PR TITLE
[walter] feat: Ctrl+C pops newest queued follow-up into the composer

### DIFF
--- a/examples/tui-playground.ts
+++ b/examples/tui-playground.ts
@@ -223,6 +223,12 @@ export class FakePlaygroundRunner implements SessionTurnRunner {
   // ---- scenario plumbing ---------------------------------------------------
 
   private emit(event: TurnEvent): void {
+    // Keep the snapshot returned by getState() consistent with the queue
+    // events we emit, mirroring the production runner so consumers that read
+    // state.followUpQueue (e.g. the Ctrl+C pop handler) see the live queue.
+    if (event.type === "follow_up_queue") {
+      this.state = { ...this.state, followUpQueue: [...event.followUpQueue] };
+    }
     for (const handler of this.handlers) handler(event);
   }
 

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -17,7 +17,7 @@ import {
 } from "./key-handlers.js";
 import { buildLayout } from "./layout.js";
 import { acquireRenderer, waitForRendererDestroy } from "./renderer-lifecycle.js";
-import { bindSessionToUi } from "./session-subscription.js";
+import { bindSessionToUi, type FollowUpPopSuppression } from "./session-subscription.js";
 import { StarterSection } from "./starter-section.js";
 import { StatusController } from "./status-controller.js";
 import { StepRenderer } from "./step-renderer.js";
@@ -232,6 +232,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   const escapeState: EscapeSuppressionFlag = { suppress: false };
   const ctrlCState: CtrlCSuppressionFlag = { suppress: false };
+  const popSuppression: FollowUpPopSuppression = { pending: [] };
   const setEscapeSuppress = () => {
     escapeState.suppress = true;
   };
@@ -287,6 +288,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     appendLine,
     appendBlock,
     appendUserBlock,
+    popSuppression,
   });
 
   // Esc cancels the in-flight turn; idle Esc is a no-op.
@@ -296,6 +298,9 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
   }
 
   // Ctrl+C is a small state machine rather than an immediate quit:
+  //   0. running turn + empty composer + queued follow-ups → pop the newest
+  //                      queued entry back into the composer (one per press),
+  //                      leaving the turn running.
   //   1. running turn  → interrupt it (identical to Esc), no exit prompt.
   //   2. composer text → clear the composer (multiline included) only;
   //                       attachments, autocomplete, and picker state stay.
@@ -304,6 +309,21 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
   // The exit itself reuses `renderer.destroy()`, the same teardown the old
   // OpenTUI exitOnCtrlC handler used, so shutdown semantics are unchanged.
   function handleCtrlC(): void {
+    if (
+      statusController.isRunning() &&
+      ui.inputField.plainText.length === 0 &&
+      pasteController.attachments().length === 0
+    ) {
+      const queue = input.session.getState()?.followUpQueue ?? [];
+      const popped = queue.at(-1);
+      if (popped) {
+        popSuppression.pending.push(popped);
+        input.session.editFollowUpQueue({ prompts: queue.slice(0, -1) });
+        pasteController.stageImages(popped.images ?? []);
+        ui.inputField.insertText(popped.message);
+        return;
+      }
+    }
     if (statusController.isRunning()) {
       handleEscape();
       return;

--- a/src/tui/paste-controller.ts
+++ b/src/tui/paste-controller.ts
@@ -282,6 +282,11 @@ export class PasteController {
     const candidates = extractImagePathCandidates(message);
     if (candidates.length === 0) return;
     const alreadyAttached = new Set(this.pendingImages.map((p) => p.path));
+    // Re-staged follow-up images keep their bytes but not their source path,
+    // so path-only dedup misses popped prompts that still mention that path.
+    const alreadyAttachedContent = new Set(
+      this.pendingImages.map((p) => imageContentKey(p.attachment)),
+    );
     const seen = new Set<string>();
     for (const candidate of candidates) {
       // Normalize each extracted substring through the same shell-escape /
@@ -306,6 +311,9 @@ export class PasteController {
           rawPath: normalized,
           id: this.nextImageId,
         });
+        const contentKey = imageContentKey(pending.attachment);
+        if (alreadyAttachedContent.has(contentKey)) continue;
+        alreadyAttachedContent.add(contentKey);
         alreadyAttached.add(pending.path);
         this.nextImageId += 1;
         this.pendingImages.push(pending);
@@ -384,6 +392,10 @@ export class PasteController {
       );
     }
   }
+}
+
+function imageContentKey(attachment: TurnPromptImage): string {
+  return `${attachment.mimeType}:${attachment.data}`;
 }
 
 function formatBytes(n: number): string {

--- a/src/tui/paste-controller.ts
+++ b/src/tui/paste-controller.ts
@@ -14,6 +14,7 @@ import {
 } from "./paste.js";
 import type { StatusController } from "./status-controller.js";
 import { COLORS } from "./theme.js";
+import type { TurnPromptImage } from "../types/protocol.js";
 
 export interface PasteControllerOptions {
   /** Composer textarea. The controller inserts `[Image #N]` placeholders
@@ -95,6 +96,21 @@ export class PasteController {
     this.pendingImages = [];
     this.nextImageId = 1;
     this.statusController.setPendingImageCount(0);
+  }
+
+  /** Re-stage already-built image attachments from a queued follow-up. */
+  stageImages(images: readonly TurnPromptImage[]): void {
+    if (images.length === 0) return;
+    for (const attachment of images) {
+      this.pendingImages.push({
+        id: this.nextImageId,
+        label: `[Image #${this.nextImageId}]`,
+        path: "",
+        attachment,
+      });
+      this.nextImageId += 1;
+    }
+    this.statusController.setPendingImageCount(this.pendingImages.length);
   }
 
   /**

--- a/src/tui/session-subscription.ts
+++ b/src/tui/session-subscription.ts
@@ -1,6 +1,6 @@
 import type { BoxRenderable, TextRenderable } from "@opentui/core";
 import type { Session } from "../session/session.js";
-import type { TurnEvent, TurnFollowUpQueueEntry } from "../types/protocol.js";
+import type { TurnEvent, TurnFollowUpQueueEntry, TurnPromptImage } from "../types/protocol.js";
 import type { QuestionPicker } from "./question-picker.js";
 import type { Sidebar } from "./sidebar.js";
 import type { StatusController } from "./status-controller.js";
@@ -13,6 +13,10 @@ import { COLORS } from "./theme.js";
  * the panel never grows past its `maxHeight` in layout.ts.
  */
 const FOLLOW_UP_MAX_VISIBLE = 3;
+
+export interface FollowUpPopSuppression {
+  pending: TurnFollowUpQueueEntry[];
+}
 
 export interface SessionSubscriptionDeps {
   session: Session;
@@ -32,6 +36,12 @@ export interface SessionSubscriptionDeps {
    * already running; this callback fires it later when the queue shrinks.
    */
   appendUserBlock(message: string): void;
+  /**
+   * Entries lifted out of the queue by a Ctrl+C pop. When a removed entry
+   * matches one of these, it is dropped silently rather than rendered as a
+   * delivered `you:` block. Optional so non-TUI callers (tests) can omit it.
+   */
+  popSuppression?: FollowUpPopSuppression;
 }
 
 /**
@@ -77,6 +87,7 @@ export function bindSessionToUi(deps: SessionSubscriptionDeps): () => void {
     appendLine,
     appendBlock,
     appendUserBlock,
+    popSuppression,
   } = deps;
   const refreshSidebar = () => refreshSidebarFromSession({ session, sidebar });
 
@@ -91,12 +102,9 @@ export function bindSessionToUi(deps: SessionSubscriptionDeps): () => void {
     if (event.type === "step") {
       stepRenderer.renderStep(event.step);
     } else if (event.type === "follow_up_queue") {
-      // Render the new queue snapshot, mirror the count into the status
-      // line, and replay any entries the runner just delivered (entries
-      // present in the prior snapshot but absent from the new one) as
-      // proper `you:` transcript blocks.
       const next = event.followUpQueue;
       for (const delivered of diffRemovedEntries(previousQueue, next)) {
+        if (consumeSuppressedPop(popSuppression, delivered)) continue;
         appendUserBlock(delivered.message);
         if (delivered.images?.length) {
           appendBlock(
@@ -167,6 +175,34 @@ function renderFollowUpPanel(
   }
   body.content = lines.join("\n");
   panel.visible = true;
+}
+
+function consumeSuppressedPop(
+  suppression: FollowUpPopSuppression | undefined,
+  removed: TurnFollowUpQueueEntry,
+): boolean {
+  if (!suppression) return false;
+  const index = suppression.pending.findIndex((entry) => sameFollowUpEntry(entry, removed));
+  if (index === -1) return false;
+  suppression.pending.splice(index, 1);
+  return true;
+}
+
+function sameFollowUpEntry(a: TurnFollowUpQueueEntry, b: TurnFollowUpQueueEntry): boolean {
+  return a.message === b.message && sameImages(a.images, b.images);
+}
+
+function sameImages(
+  a: readonly TurnPromptImage[] | undefined,
+  b: readonly TurnPromptImage[] | undefined,
+): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) return false;
+  return left.every(
+    (image, index) =>
+      image.data === right[index]?.data && image.mimeType === right[index]?.mimeType,
+  );
 }
 
 /**

--- a/test/tui-ctrl-c-pop.test.ts
+++ b/test/tui-ctrl-c-pop.test.ts
@@ -159,6 +159,28 @@ describe("TUI Ctrl+C pops queued follow-up", () => {
     });
   });
 
+  testIfDocker(
+    "popping a follow-up whose text references its on-disk image does not double-send it",
+    async () => {
+      const fixture = makePngFixture("ondisk");
+      await startLongRunningTurn();
+      harness.session.editFollowUpQueue({
+        prompts: [{ message: `describe ${fixture}`, images: [TINY_PNG] }],
+      });
+      await harness.flush();
+
+      harness.mockInput.pressCtrlC();
+      await harness.flush();
+      expect(harness.inputField.plainText).toBe(`describe ${fixture}`);
+
+      harness.mockInput.pressEnter();
+      await harness.flush();
+
+      const lastPrompt = harness.promptCalls.at(-1);
+      expect(lastPrompt?.images).toEqual([TINY_PNG]);
+    },
+  );
+
   testIfDocker("pop suppression matches duplicate text by attachment payload", async () => {
     const otherPng = { ...TINY_PNG, data: Buffer.from("other").toString("base64") };
     await startLongRunningTurn();

--- a/test/tui-ctrl-c-pop.test.ts
+++ b/test/tui-ctrl-c-pop.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { bootTui, type TuiHarness } from "./helpers/tui-harness.js";
+import { testIfDocker } from "./helpers/docker-only.js";
+import type { TurnPromptImage } from "../src/types/protocol.js";
+
+const PNG_HEADER = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01, 0x02, 0x03,
+]);
+
+const TINY_PNG: TurnPromptImage = {
+  data: Buffer.from(PNG_HEADER).toString("base64"),
+  mimeType: "image/png",
+};
+
+function makePngFixture(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `duet-tui-ctrl-c-pop-${prefix}-`));
+  const file = join(dir, `${prefix}.png`);
+  writeFileSync(file, PNG_HEADER);
+  return file;
+}
+
+describe("TUI Ctrl+C pops queued follow-up", () => {
+  let harness: TuiHarness;
+
+  beforeEach(async () => {
+    harness = await bootTui();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  async function startLongRunningTurn(): Promise<void> {
+    await harness.mockInput.typeText("/working 30");
+    await harness.flush();
+    harness.mockInput.pressEnter();
+    await harness.waitForPrompt();
+  }
+
+  function queuedMessages(): string[] {
+    return (harness.session.getState()?.followUpQueue ?? []).map((entry) => entry.message);
+  }
+
+  testIfDocker(
+    "Ctrl+C with empty composer pops the newest queued entry without interrupting",
+    async () => {
+      await startLongRunningTurn();
+      harness.session.editFollowUpQueue({
+        prompts: [{ message: "first thought" }, { message: "second thought" }],
+      });
+      await harness.flush();
+      expect(harness.inputField.plainText).toBe("");
+
+      harness.mockInput.pressCtrlC();
+      await harness.flush();
+
+      expect(harness.inputField.plainText).toBe("second thought");
+      expect(queuedMessages()).toEqual(["first thought"]);
+      expect(harness.interruptCalls).toBe(0);
+      expect(harness.exited).toBe(false);
+    },
+  );
+
+  testIfDocker(
+    "repeated Ctrl+C pops only one entry; the next press hits the unchanged branch",
+    async () => {
+      await startLongRunningTurn();
+      harness.session.editFollowUpQueue({
+        prompts: [{ message: "first thought" }, { message: "second thought" }],
+      });
+      await harness.flush();
+
+      harness.mockInput.pressCtrlC();
+      await harness.flush();
+      expect(harness.inputField.plainText).toBe("second thought");
+      expect(harness.interruptCalls).toBe(0);
+
+      harness.mockInput.pressCtrlC();
+      await harness.flush();
+      expect(queuedMessages()).toEqual(["first thought"]);
+      expect(harness.interruptCalls).toBe(1);
+    },
+  );
+
+  testIfDocker("Ctrl+C with text already in the composer does not pop", async () => {
+    await startLongRunningTurn();
+    harness.session.editFollowUpQueue({ prompts: [{ message: "queued entry" }] });
+    await harness.flush();
+
+    await harness.mockInput.typeText("half-typed");
+    await harness.flush();
+    expect(harness.inputField.plainText).toBe("half-typed");
+
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+
+    expect(queuedMessages()).toEqual(["queued entry"]);
+    expect(harness.interruptCalls).toBe(1);
+  });
+
+  testIfDocker("Ctrl+C with only local attachments does not pop", async () => {
+    await startLongRunningTurn();
+    harness.session.editFollowUpQueue({ prompts: [{ message: "queued entry" }] });
+    await harness.flush();
+
+    await harness.mockInput.typeText(`/image ${makePngFixture("pending")}`);
+    harness.mockInput.pressEnter();
+    await harness.flush();
+    harness.inputField.clear();
+    await harness.flush();
+
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+
+    expect(queuedMessages()).toEqual(["queued entry"]);
+    expect(harness.interruptCalls).toBe(1);
+  });
+
+  testIfDocker("a popped entry is not rendered as a delivered you: block", async () => {
+    await startLongRunningTurn();
+    harness.session.editFollowUpQueue({ prompts: [{ message: "popme-marker" }] });
+    await harness.flush();
+
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+    expect(harness.inputField.plainText).toBe("popme-marker");
+    expect(queuedMessages()).toEqual([]);
+
+    harness.inputField.clear();
+    await harness.flush();
+    expect(harness.inputField.plainText).toBe("");
+
+    const frame = await harness.captureCharFrame();
+    expect(frame).not.toContain("popme-marker");
+  });
+
+  testIfDocker("popped image attachments are forwarded on resubmit", async () => {
+    await startLongRunningTurn();
+    harness.session.editFollowUpQueue({
+      prompts: [{ message: "describe [Image #1]", images: [TINY_PNG] }],
+    });
+    await harness.flush();
+
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+    expect(harness.inputField.plainText).toBe("describe [Image #1]");
+
+    harness.mockInput.pressEnter();
+    await harness.flush();
+
+    expect(harness.promptCalls.at(-1)).toMatchObject({
+      message: "describe [Image #1]",
+      behavior: "follow_up",
+      images: [TINY_PNG],
+    });
+  });
+
+  testIfDocker("pop suppression matches duplicate text by attachment payload", async () => {
+    const otherPng = { ...TINY_PNG, data: Buffer.from("other").toString("base64") };
+    await startLongRunningTurn();
+    harness.session.editFollowUpQueue({
+      prompts: [
+        { message: "same text", images: [TINY_PNG] },
+        { message: "same text", images: [otherPng] },
+      ],
+    });
+    await harness.flush();
+
+    harness.mockInput.pressCtrlC();
+    await harness.flush();
+    expect(queuedMessages()).toEqual(["same text"]);
+
+    harness.session.editFollowUpQueue({ prompts: [] });
+    await harness.flush();
+    harness.inputField.clear();
+    await harness.flush();
+
+    const frame = await harness.captureCharFrame();
+    expect(frame).toContain("same text");
+  });
+});


### PR DESCRIPTION
## What

While a turn is running and the composer is **empty**, pressing **Ctrl+C** now lifts the most-recently-queued follow-up back into the composer instead of interrupting the turn. The turn keeps running, the entry leaves the follow-up panel, and exactly **one** entry is popped per press.

Requested by Walter.

## Behavior

On Ctrl+C, evaluated in order:
1. **Turn running + composer empty + queue has ≥1 entry** → pop the newest (last) queued follow-up into the composer. Does not interrupt. One entry per press.
2. **Otherwise** → unchanged existing behavior (running → interrupt; text in composer → clear; idle → arm/quit).

This satisfies the agreed rules: pop only when input is empty; if the input has text the pop is blocked (falls through to existing behavior); repeated Ctrl+C pops only one (after a pop the composer is non-empty, so the next press skips the pop branch).

Pop is also blocked when there are local pending attachments, so unrelated staged images can't get mixed with a popped queued prompt.

## Implementation

- `src/tui/app.ts` — new leading "pop" branch in `handleCtrlC()`; pops via `session.editFollowUpQueue({ prompts: queue.slice(0,-1) })` + `ui.inputField.insertText(...)`; re-stages popped `entry.images` before inserting text.
- `src/tui/session-subscription.ts` — new `FollowUpPopSuppression` signal wired through `bindSessionToUi`; skips exactly one matching removed entry in the `diffRemovedEntries` loop so a popped (never-delivered) entry isn't rendered as a `you:` block. Matches on the **full** entry (message + images), so duplicate-text follow-ups with different attachments suppress correctly.
- `src/tui/paste-controller.ts` — new `stageImages()` to re-stage popped image attachments onto the pending queue so they ride along on resubmit instead of being silently dropped.
- `examples/tui-playground.ts` — keep `state.followUpQueue` in sync on `follow_up_queue` events so `getState()` matches production.

## Tests

`test/tui-ctrl-c-pop.test.ts` (standard `testIfDocker` PTY harness): pop newest into empty composer without interrupting; only-one-pop-per-press; non-empty composer blocks pop; popped entry never renders as a `you:` block; popped images forwarded on resubmit; duplicate same-text follow-ups with different image payloads suppress the right entry; local pending attachments block pop.

- `bun run check-types` ✅
- `bun run lint` ✅
- `bun run format:check` ✅
- `bun run test` (Docker) — 902 pass, 0 fail ✅