### PR TITLE
feat(model-resolution): DUET_GATEWAY_BASE_URL override for the model gateway

### DIFF
--- a/src/lib/duet-app-url.ts
+++ b/src/lib/duet-app-url.ts
@@ -1,9 +1,10 @@
 /**
  * Resolve the base URL of the Duet web app.
  *
- * Single env var (`DUET_APP_BASE_URL`) for the app origin. Surface-specific
- * paths like the AI gateway's `/api/v1/ai-gateway` and the CLI's
- * `/api/v1/cli/*` are hardcoded by their callers.
+ * `DUET_APP_BASE_URL` controls the app origin used by login, skill sync,
+ * embeddings, analytics, and feedback. Model gateway traffic can use
+ * `DUET_GATEWAY_BASE_URL`; when unset, the gateway still falls back to this app
+ * origin plus `/api/v1/ai-gateway` for chat-app compatibility.
  */
 
 const DEFAULT_BASE_URL = "https://duet.so";

--- a/src/model-resolution/duet-gateway.ts
+++ b/src/model-resolution/duet-gateway.ts
@@ -12,9 +12,9 @@ const OPENAI_BASE_URL = "https://api.openai.com/v1";
  * parallel model registry, the `duet-gateway` provider piggybacks on upstream
  * model definitions and only swaps `baseUrl` to point at Duet.
  *
- * The base URL is `${DUET_APP_BASE_URL}${GATEWAY_PATH}`; users only need to
- * override the app origin via `DUET_APP_BASE_URL` (also used by `duet login`
- * and the CLI skill sync).
+ * `DUET_GATEWAY_BASE_URL` can point model traffic at a dedicated gateway
+ * origin. When it is unset, the base URL stays `${DUET_APP_BASE_URL}${GATEWAY_PATH}`
+ * for compatibility with the chat app route.
  *
  * Auth flows through pi-ai's existing vercel-ai-gateway path, which reads
  * `AI_GATEWAY_API_KEY` — the CLI shims that env var from `DUET_API_KEY` at
@@ -22,8 +22,11 @@ const OPENAI_BASE_URL = "https://api.openai.com/v1";
  */
 
 export const DUET_GATEWAY_API_KEY_ENV = "DUET_API_KEY";
+export const DUET_GATEWAY_BASE_URL_ENV = "DUET_GATEWAY_BASE_URL";
 
 export function getDuetGatewayBaseUrl(): string {
+  const override = process.env[DUET_GATEWAY_BASE_URL_ENV]?.trim();
+  if (override) return stripTrailingSlash(override);
   return `${resolveDuetAppBaseUrl()}${GATEWAY_PATH}`;
 }
 
@@ -141,6 +144,10 @@ function getDuetGatewayBaseUrlForModel(model: Model<any>): string {
     return `${getDuetGatewayBaseUrl()}/v1`;
   }
   return getDuetGatewayBaseUrl();
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
 }
 
 /**

--- a/test/duet-gateway-base-url.test.ts
+++ b/test/duet-gateway-base-url.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { fetchModelCatalog, createDuetModelGateway } from "../src/cli/model-gateway.js";
+import {
+  getDuetGatewayBaseUrl,
+  resolveDuetGatewayModel,
+} from "../src/model-resolution/duet-gateway.js";
+
+const ENV_KEYS = ["DUET_APP_BASE_URL", "DUET_GATEWAY_BASE_URL", "DUET_API_KEY"] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+let originalFetch: typeof fetch;
+
+for (const key of ENV_KEYS) {
+  originalEnv.set(key, process.env[key]);
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("getDuetGatewayBaseUrl", () => {
+  test("uses DUET_GATEWAY_BASE_URL verbatim after trimming and stripping a trailing slash", () => {
+    process.env.DUET_APP_BASE_URL = "https://app.example.com";
+    process.env.DUET_GATEWAY_BASE_URL = "  https://gateway.example.com/custom/  ";
+
+    expect(getDuetGatewayBaseUrl()).toBe("https://gateway.example.com/custom");
+  });
+
+  test("falls back to the app-derived chat gateway path when unset", () => {
+    expect(getDuetGatewayBaseUrl()).toBe("https://duet.so/api/v1/ai-gateway");
+
+    process.env.DUET_APP_BASE_URL = "https://staging.duet.so/";
+    expect(getDuetGatewayBaseUrl()).toBe("https://staging.duet.so/api/v1/ai-gateway");
+  });
+});
+
+describe("duet-gateway model routing", () => {
+  test("uses the dedicated base directly for anthropic transport models", () => {
+    process.env.DUET_GATEWAY_BASE_URL = "https://gateway.example.com/base";
+
+    const model = resolveDuetGatewayModel("anthropic/claude-opus-4.8");
+
+    expect(model.baseUrl).toBe("https://gateway.example.com/base");
+  });
+
+  test("appends /v1 to the dedicated base for OpenAI transport models", () => {
+    process.env.DUET_GATEWAY_BASE_URL = "https://gateway.example.com/base";
+
+    const model = resolveDuetGatewayModel("openai/gpt-5.5");
+
+    expect(model.baseUrl).toBe("https://gateway.example.com/base/v1");
+  });
+});
+
+describe("duet model gateway routing", () => {
+  test("fetches the model catalog from the dedicated base /v1/models path", async () => {
+    process.env.DUET_GATEWAY_BASE_URL = "https://gateway.example.com/base";
+    process.env.DUET_API_KEY = "duet_gt_test";
+    const calls: { url: string; authorization: string | undefined }[] = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({
+        url:
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+        authorization: new Headers(init?.headers).get("authorization") ?? undefined,
+      });
+      return new Response(JSON.stringify({ data: [{ id: "openai/gpt-5.5", type: "language" }] }));
+    }) as typeof fetch;
+
+    const catalog = await fetchModelCatalog();
+
+    expect(calls).toEqual([
+      {
+        url: "https://gateway.example.com/base/v1/models",
+        authorization: "Bearer duet_gt_test",
+      },
+    ]);
+    expect(catalog.get("openai/gpt-5.5")).toBe("language");
+  });
+
+  test("builds the AI SDK gateway on the dedicated base /v4/ai path", async () => {
+    process.env.DUET_GATEWAY_BASE_URL = "https://gateway.example.com/base/";
+    process.env.DUET_API_KEY = "duet_gt_test";
+    const calls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      calls.push(
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+      );
+      return new Response(JSON.stringify({ models: [] }));
+    }) as typeof fetch;
+
+    const gateway = createDuetModelGateway();
+    await gateway.getAvailableModels();
+
+    expect(calls).toEqual(["https://gateway.example.com/base/v4/ai/config"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `DUET_GATEWAY_BASE_URL` env var that points model gateway traffic at a dedicated gateway origin. When set, the value is used verbatim (trimmed, trailing slash stripped) as the gateway base — OpenAI transports still append `/v1`, the model catalog fetch appends `/v1/models`, and the AI SDK gateway appends `/v4/ai`.
- When unset, behavior is unchanged: the gateway base stays `DUET_APP_BASE_URL` + `/api/v1/ai-gateway`, keeping compatibility with the chat app route.
- `DUET_APP_BASE_URL` continues to own login, skill sync, embeddings, analytics, and feedback.

## Test plan
- New `test/duet-gateway-base-url.test.ts` covers the override (trim + trailing-slash strip), the unset fallback, per-transport base URL derivation (Anthropic vs OpenAI `/v1`), catalog fetch URL/auth header, and the AI SDK `/v4/ai/config` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)