### PR TITLE
[Walter] feat(tui): promote oldest queued follow-up as a steer on empty Ctrl+Enter

### DIFF
--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -379,9 +379,7 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   // Ctrl+Enter: behavior:"steer" so the runner calls agent.steer() at
   // the next inference boundary instead of queueing behind the full turn.
-  // When the composer is empty, Ctrl+Enter instead promotes the oldest
-  // queued follow-up (if any) into a steer; an empty composer with an empty
-  // queue stays a no-op.
+  // Empty-composer Ctrl+Enter promotes the oldest queued follow-up.
   function handleSteer(): void {
     const message = ui.inputField.plainText.trim();
     if (message.length === 0) {
@@ -392,14 +390,8 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
     void dispatchTurn(message, "steer").catch(reportError);
   }
 
-  // Promote the front (oldest) queued follow-up into a steer: dequeue it and
-  // re-dispatch its own payload with behavior:"steer" so it interrupts at the
-  // next inference boundary instead of waiting for the turn to settle.
-  // Dequeuing first is load-bearing — it stops the runner from delivering the
-  // same entry again when the turn naturally drains the queue. The
-  // `follow_up_queue` event the edit emits already renders the promoted
-  // entry's `you:` transcript block (via the delivered-entry diff in the
-  // session subscription), so this path deliberately does not append it.
+  // Dequeue before steering so the runner does not also deliver this entry
+  // when the original follow-up queue drains.
   function promoteQueuedFollowUpToSteer(): void {
     const [next, ...rest] = input.session.getState()?.followUpQueue ?? [];
     if (!next) return;

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -379,11 +379,35 @@ export async function runTui(input: RunTuiInput): Promise<TurnTerminalEvent | un
 
   // Ctrl+Enter: behavior:"steer" so the runner calls agent.steer() at
   // the next inference boundary instead of queueing behind the full turn.
+  // When the composer is empty, Ctrl+Enter instead promotes the oldest
+  // queued follow-up (if any) into a steer; an empty composer with an empty
+  // queue stays a no-op.
   function handleSteer(): void {
     const message = ui.inputField.plainText.trim();
-    if (message.length === 0) return;
+    if (message.length === 0) {
+      promoteQueuedFollowUpToSteer();
+      return;
+    }
     ui.inputField.clear();
     void dispatchTurn(message, "steer").catch(reportError);
+  }
+
+  // Promote the front (oldest) queued follow-up into a steer: dequeue it and
+  // re-dispatch its own payload with behavior:"steer" so it interrupts at the
+  // next inference boundary instead of waiting for the turn to settle.
+  // Dequeuing first is load-bearing — it stops the runner from delivering the
+  // same entry again when the turn naturally drains the queue. The
+  // `follow_up_queue` event the edit emits already renders the promoted
+  // entry's `you:` transcript block (via the delivered-entry diff in the
+  // session subscription), so this path deliberately does not append it.
+  function promoteQueuedFollowUpToSteer(): void {
+    const [next, ...rest] = input.session.getState()?.followUpQueue ?? [];
+    if (!next) return;
+    input.session.editFollowUpQueue({ prompts: rest });
+    void input.session
+      .prompt({ message: next.message, behavior: "steer", images: next.images })
+      .catch(reportError);
+    if (!statusController.isRunning()) statusController.markRunning();
   }
 
   // Plain Enter: slash-style local commands → shared dispatch (which

--- a/src/tui/session-subscription.ts
+++ b/src/tui/session-subscription.ts
@@ -206,26 +206,22 @@ function sameImages(
 }
 
 /**
- * Returns the entries that were in `prev` but are no longer in `next`,
- * treating the lists as message-text multisets. Used to detect deliveries
- * (queue → drain) so the corresponding `you:` blocks can be rendered into
- * the transcript at the point the runner actually hands them to the agent.
+ * Returns the entries that were in `prev` but are no longer in `next` so
+ * delivered follow-ups render exactly once, including duplicate text with
+ * different attachments.
  */
 function diffRemovedEntries(
   prev: readonly TurnFollowUpQueueEntry[],
   next: readonly TurnFollowUpQueueEntry[],
 ): TurnFollowUpQueueEntry[] {
-  const remaining = new Map<string, number>();
-  for (const entry of next) {
-    remaining.set(entry.message, (remaining.get(entry.message) ?? 0) + 1);
-  }
+  const remaining = [...next];
   const removed: TurnFollowUpQueueEntry[] = [];
   for (const entry of prev) {
-    const count = remaining.get(entry.message) ?? 0;
-    if (count > 0) {
-      remaining.set(entry.message, count - 1);
-    } else {
+    const index = remaining.findIndex((candidate) => sameFollowUpEntry(entry, candidate));
+    if (index === -1) {
       removed.push(entry);
+    } else {
+      remaining.splice(index, 1);
     }
   }
   return removed;

--- a/test/tui-ctrl-enter-steer.test.ts
+++ b/test/tui-ctrl-enter-steer.test.ts
@@ -91,8 +91,6 @@ describe("TUI Ctrl+Enter steer keystroke", () => {
       await startLongRunningTurn();
       const promptsBefore = harness.promptCalls.length;
 
-      // Seed a two-entry follow-up queue as if the user had soft-queued two
-      // prompts behind the in-flight turn.
       harness.session.editFollowUpQueue({
         prompts: [{ message: "first queued" }, { message: "second queued" }],
       });
@@ -101,14 +99,10 @@ describe("TUI Ctrl+Enter steer keystroke", () => {
       harness.mockInput.pressEnter({ ctrl: true });
       await harness.waitForPrompt({ count: promptsBefore + 1 });
 
-      // Exactly one entry (the oldest) is promoted, delivered as a steer.
       expect(harness.promptCalls.length).toBe(promptsBefore + 1);
       const steer = harness.promptCalls[promptsBefore]!;
       expect(steer.message).toBe("first queued");
       expect(steer.behavior).toBe("steer");
-
-      // The promoted entry is removed from the queue so the runner will not
-      // deliver it again; the untouched entry stays queued.
       expect(harness.session.getState()?.followUpQueue).toEqual([{ message: "second queued" }]);
     },
   );
@@ -151,6 +145,36 @@ describe("TUI Ctrl+Enter steer keystroke", () => {
       { message: "two" },
       { message: "three" },
     ]);
+  });
+
+  testIfDocker("Ctrl+Enter promotion renders duplicate-text attachments correctly", async () => {
+    await startLongRunningTurn();
+    const promptsBefore = harness.promptCalls.length;
+
+    const promotedImage = { data: "cHJvbW90ZWQ=", mimeType: "image/png" };
+    const remainingImage = { data: "cmVtYWluaW5n", mimeType: "image/png" };
+    harness.session.editFollowUpQueue({
+      prompts: [
+        { message: "same text", images: [promotedImage] },
+        { message: "same text", images: [remainingImage] },
+      ],
+    });
+    await harness.flush();
+
+    harness.mockInput.pressEnter({ ctrl: true });
+    await harness.waitForPrompt({ count: promptsBefore + 1 });
+
+    expect(harness.promptCalls[promptsBefore]).toMatchObject({
+      message: "same text",
+      behavior: "steer",
+      images: [promotedImage],
+    });
+    expect(harness.session.getState()?.followUpQueue).toEqual([
+      { message: "same text", images: [remainingImage] },
+    ]);
+
+    const frame = await harness.captureCharFrame();
+    expect(frame).toContain("📎 1 image attachment");
   });
 
   testIfDocker(

--- a/test/tui-ctrl-enter-steer.test.ts
+++ b/test/tui-ctrl-enter-steer.test.ts
@@ -18,8 +18,12 @@ import { testIfDocker } from "./helpers/docker-only.js";
  *
  *  - Ctrl+Enter with non-empty composer dispatches exactly one prompt
  *    call with `behavior: "steer"` and the snapshotted message text.
- *  - Ctrl+Enter with empty composer is a no-op (no prompt, no
- *    interrupt, nothing visible).
+ *  - Ctrl+Enter with an empty composer and an empty follow-up queue is a
+ *    no-op (no prompt, no interrupt, nothing visible).
+ *  - Ctrl+Enter with an empty composer and a non-empty follow-up queue
+ *    promotes the oldest (front) queued entry into a steer: it is
+ *    dequeued and re-dispatched with `behavior: "steer"`, carrying its
+ *    own multimodal payload, and only ever one entry per press.
  *  - Ctrl+Enter while idle is a valid send — kicks off a fresh turn
  *    flagged with `behavior: "steer"`, matching the rule that the
  *    keybind is composer-state-agnostic.
@@ -67,18 +71,86 @@ describe("TUI Ctrl+Enter steer keystroke", () => {
     },
   );
 
-  testIfDocker("Ctrl+Enter with empty composer mid-turn is a no-op", async () => {
+  testIfDocker("Ctrl+Enter with empty composer and empty queue mid-turn is a no-op", async () => {
     await startLongRunningTurn();
     const promptsBefore = harness.promptCalls.length;
 
-    // Composer is empty after the previous submit. Pressing Ctrl+Enter
-    // here should not dispatch anything; it is a dedicated send-with-
-    // steer keybind, not an alternative interrupt.
+    // Composer is empty after the previous submit and no follow-ups are
+    // queued. Pressing Ctrl+Enter here should not dispatch anything; with
+    // an empty queue it is neither a send nor an interrupt.
     harness.mockInput.pressEnter({ ctrl: true });
     await harness.flush();
     await harness.flush();
 
     expect(harness.promptCalls.length).toBe(promptsBefore);
+  });
+
+  testIfDocker(
+    "Ctrl+Enter with empty composer promotes the oldest queued follow-up as a steer",
+    async () => {
+      await startLongRunningTurn();
+      const promptsBefore = harness.promptCalls.length;
+
+      // Seed a two-entry follow-up queue as if the user had soft-queued two
+      // prompts behind the in-flight turn.
+      harness.session.editFollowUpQueue({
+        prompts: [{ message: "first queued" }, { message: "second queued" }],
+      });
+      await harness.flush();
+
+      harness.mockInput.pressEnter({ ctrl: true });
+      await harness.waitForPrompt({ count: promptsBefore + 1 });
+
+      // Exactly one entry (the oldest) is promoted, delivered as a steer.
+      expect(harness.promptCalls.length).toBe(promptsBefore + 1);
+      const steer = harness.promptCalls[promptsBefore]!;
+      expect(steer.message).toBe("first queued");
+      expect(steer.behavior).toBe("steer");
+
+      // The promoted entry is removed from the queue so the runner will not
+      // deliver it again; the untouched entry stays queued.
+      expect(harness.session.getState()?.followUpQueue).toEqual([{ message: "second queued" }]);
+    },
+  );
+
+  testIfDocker("Ctrl+Enter promotes the queued follow-up with its own image payload", async () => {
+    await startLongRunningTurn();
+    const promptsBefore = harness.promptCalls.length;
+
+    const images = [{ data: "ZmFrZQ==", mimeType: "image/png" }];
+    harness.session.editFollowUpQueue({
+      prompts: [{ message: "queued with image", images }],
+    });
+    await harness.flush();
+
+    harness.mockInput.pressEnter({ ctrl: true });
+    await harness.waitForPrompt({ count: promptsBefore + 1 });
+
+    const steer = harness.promptCalls[promptsBefore]!;
+    expect(steer.message).toBe("queued with image");
+    expect(steer.behavior).toBe("steer");
+    expect(steer.images).toEqual(images);
+    expect(harness.session.getState()?.followUpQueue).toEqual([]);
+  });
+
+  testIfDocker("Ctrl+Enter promotes only one queued entry per press", async () => {
+    await startLongRunningTurn();
+    const promptsBefore = harness.promptCalls.length;
+
+    harness.session.editFollowUpQueue({
+      prompts: [{ message: "one" }, { message: "two" }, { message: "three" }],
+    });
+    await harness.flush();
+
+    harness.mockInput.pressEnter({ ctrl: true });
+    await harness.waitForPrompt({ count: promptsBefore + 1 });
+
+    expect(harness.promptCalls.length).toBe(promptsBefore + 1);
+    expect(harness.promptCalls[promptsBefore]!.message).toBe("one");
+    expect(harness.session.getState()?.followUpQueue).toEqual([
+      { message: "two" },
+      { message: "three" },
+    ]);
   });
 
   testIfDocker(


### PR DESCRIPTION
## What
When the composer is empty and Ctrl+Enter (steer) is pressed:
- If a follow-up is queued, promote the **oldest** entry and deliver it as a **steer** (interrupt at next inference boundary), dequeuing it first so it isn't delivered a second time when the turn settles.
- If the queue is empty (including idle), stays a no-op — unchanged.
- Only one entry is promoted per press; remaining queued entries stay queued.

## Why
Previously, empty-composer Ctrl+Enter was always a no-op even with follow-ups queued, so there was no way to force an urgent queued follow-up in immediately instead of waiting for the turn to settle.

## Also fixed in review
`diffRemovedEntries` in `session-subscription.ts` compared queued follow-ups by message-text multiset, which broke rendering for duplicate-text entries with different image attachments. Now compares full entries via `sameFollowUpEntry`.

## Testing
- `bun run check-types`, `bun run lint`, `bun run format:check` all clean.
- `bun run test`: 931 pass, 0 fail (includes 4 new/updated Ctrl+Enter tests covering promotion, dequeue, image payload preservation, and duplicate-text/attachment rendering).