### PR TITLE
Add DeepSWE v1.1 pilot harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ coverage
 .next/
 next-env.d.ts
 out/
+outputs/
+__pycache__/
 build
 dist
 ts-traces

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark integrations that are intentionally separate from product tests."""

--- a/benchmarks/deepswe/.gitignore
+++ b/benchmarks/deepswe/.gitignore
@@ -1,0 +1,4 @@
+.cache/
+.venv/
+__pycache__/
+runtime/

--- a/benchmarks/deepswe/README.md
+++ b/benchmarks/deepswe/README.md
@@ -1,0 +1,90 @@
+# DeepSWE v1.1 pilot
+
+This folder is a self-contained adapter from Duet to the official
+[DeepSWE](https://github.com/datacurve-ai/deep-swe) v1.1 tasks and
+[Pier](https://github.com/datacurve-ai/pier) runner. Pier remains the owner of
+task containers, patch transfer, separate verifier containers, and rewards.
+
+The frozen pilot runs ten committed task IDs across four paired arms:
+
+- `glm-pure` and `glm-kimi-advisor`
+- `kimi-pure` and `kimi-fable-advisor`
+
+Within each pair, advisor availability is the only treatment. The classifier,
+memory, task prompt, model effort, limits, and official verifier remain the
+same. There are no benchmark-only advisor timing or call-count rules.
+
+## Setup
+
+Docker, Python 3.12 or 3.13, Bun 1.3.11, and Git are required. If the host
+Python is older, setup can create Python 3.12 through `uv`.
+
+```bash
+bun benchmarks/deepswe/cli.ts setup
+bun run test:deepswe
+bun benchmarks/deepswe/cli.ts smoke
+```
+
+`setup` checks out the pinned DeepSWE commit under `.cache/`, installs the
+pinned Pier source commit into `.venv/`, generates the four model configs, and
+builds the exact Linux Duet payload. `verify` rechecks all pinned identities.
+`smoke` runs Pier's no-op agent through one official task and its separate
+verifier container. Its expected reward is zero; the gate proves environment,
+artifact-transfer, and scoring mechanics without spending model tokens.
+
+## Run
+
+One official task across all arms is the paid acceptance gate:
+
+```bash
+bun benchmarks/deepswe/cli.ts run \
+  --task true-myth-iterable-collection-combinators \
+  --cost-limit-usd 20 \
+  --budget-usd 160 \
+  --concurrency 1
+```
+
+Remove `--task` for all ten tasks. The command loads `DUET_API_KEY` from the
+repository `.env` when it is not already exported. The minimum accepted budget
+is task count × four arms × (per-rollout soft stop + $20). The extra $20 covers
+one maximum-size request under the pinned model context, output, and price
+metadata. This is controller admission headroom, not a provider-side hard cap:
+normal Duet subagents may have multiple requests in flight when an interrupt
+arrives, so actual spend can exceed the authorization value. Expected spend is
+normally much lower. Use a concurrency appropriate for the host's Docker
+capacity.
+
+For the planned E2B run, build the immutable worker after the branch commit is
+pushed, then launch one task per sandbox. Each sandbox runs its four arms
+sequentially through Pier; the default outer concurrency is ten.
+
+```bash
+bun benchmarks/deepswe/e2b/template.ts
+bun benchmarks/deepswe/e2b/run.ts \
+  --cost-limit-usd 10 \
+  --budget-usd 1200 \
+  --concurrency 10 \
+  --campaign pilot-10
+```
+
+The controller rejects a budget smaller than the campaign admission minimum.
+The campaign name is stable: rerunning it restores partial Pier jobs into fresh
+sandboxes, skips finished arms, and resumes missing work after infrastructure
+loss. Model or verifier outcomes with completed Pier records are never retried
+into passes.
+
+Raw Duet events, stderr, Pier trial records, official rewards, and generated
+reports live under ignored `outputs/`. Summarize completed jobs with:
+
+```bash
+bun benchmarks/deepswe/cli.ts report \
+  --campaign pilot-10 \
+  --output benchmarks/deepswe/outputs/report.json
+```
+
+Omit `--campaign` to report a local Pier run under `outputs/jobs`, or pass
+`--jobs` for an explicit result root.
+
+Both-resolved is a successful tie. A pure-resolved/advised-unresolved row is an
+advisor regression and remains in the report; it is never retried until it
+passes.

--- a/benchmarks/deepswe/README.md
+++ b/benchmarks/deepswe/README.md
@@ -5,14 +5,20 @@ This folder is a self-contained adapter from Duet to the official
 [Pier](https://github.com/datacurve-ai/pier) runner. Pier remains the owner of
 task containers, patch transfer, separate verifier containers, and rewards.
 
-The frozen pilot runs ten committed task IDs across four paired arms:
+The frozen population contains ten committed task IDs. The first paid tranche
+runs the first five selected IDs across two advisor pairs and two standalone
+pure baselines:
 
 - `glm-pure` and `glm-kimi-advisor`
 - `kimi-pure` and `kimi-fable-advisor`
+- `opus-pure` on the current `opus-5` shorthand
+- `fable-pure`
 
 Within each pair, advisor availability is the only treatment. The classifier,
 memory, task prompt, model effort, limits, and official verifier remain the
-same. There are no benchmark-only advisor timing or call-count rules.
+same. Opus and Fable provide pure-model cost and resolve-rate baselines; they
+are not fabricated advisor pairs. There are no benchmark-only advisor timing
+or call-count rules.
 
 ## Setup
 
@@ -40,13 +46,14 @@ One official task across all arms is the paid acceptance gate:
 bun benchmarks/deepswe/cli.ts run \
   --task true-myth-iterable-collection-combinators \
   --cost-limit-usd 20 \
-  --budget-usd 160 \
+  --budget-usd 240 \
   --concurrency 1
 ```
 
 Remove `--task` for all ten tasks. The command loads `DUET_API_KEY` from the
-repository `.env` when it is not already exported. The minimum accepted budget
-is task count × four arms × (per-rollout soft stop + $20). The extra $20 covers
+repository `.env` when it is not already exported; Vercel AI Gateway and
+OpenRouter keys are supported fallbacks. The minimum accepted budget is task
+count × configured arms × (per-rollout soft stop + $20). The extra $20 covers
 one maximum-size request under the pinned model context, output, and price
 metadata. This is controller admission headroom, not a provider-side hard cap:
 normal Duet subagents may have multiple requests in flight when an interrupt
@@ -55,16 +62,21 @@ normally much lower. Use a concurrency appropriate for the host's Docker
 capacity.
 
 For the planned E2B run, build the immutable worker after the branch commit is
-pushed, then launch one task per sandbox. Each sandbox runs its four arms
+pushed, then launch one task per sandbox. Each sandbox runs its configured arms
 sequentially through Pier; the default outer concurrency is ten.
 
 ```bash
 bun benchmarks/deepswe/e2b/template.ts
 bun benchmarks/deepswe/e2b/run.ts \
+  --task true-myth-iterable-collection-combinators \
+  --task testem-per-launcher-reports \
+  --task tengo-callable-instance-isolation \
+  --task adaptix-name-mapping-aliases \
+  --task igel-persist-feature-schema \
   --cost-limit-usd 10 \
-  --budget-usd 1200 \
-  --concurrency 10 \
-  --campaign pilot-10
+  --budget-usd 1000 \
+  --concurrency 5 \
+  --campaign pilot-5-six-arm-v1
 ```
 
 The controller rejects a budget smaller than the campaign admission minimum.
@@ -78,7 +90,7 @@ reports live under ignored `outputs/`. Summarize completed jobs with:
 
 ```bash
 bun benchmarks/deepswe/cli.ts report \
-  --campaign pilot-10 \
+  --campaign pilot-5-six-arm-v1 \
   --output benchmarks/deepswe/outputs/report.json
 ```
 

--- a/benchmarks/deepswe/__init__.py
+++ b/benchmarks/deepswe/__init__.py
@@ -1,0 +1,1 @@
+"""Official DeepSWE v1.1 integration for Duet."""

--- a/benchmarks/deepswe/cli.ts
+++ b/benchmarks/deepswe/cli.ts
@@ -3,15 +3,22 @@ import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { parse as parseDotenv } from "dotenv";
 
+import { providerEnvironment, PROVIDER_ENV_NAMES } from "../shared/provider-environment.js";
 import { deepSweMinimumBudgetUsd, DEEPSWE_SINGLE_REQUEST_CUSHION_USD } from "./src/budget.js";
-import { DEEPSWE_ARMS, renderDeepSweConfigs, serializeDeepSweConfig } from "./src/config.js";
+import { DEEPSWE_ARM_NAMES, renderDeepSweConfigs, serializeDeepSweConfig } from "./src/config.js";
 import {
   loadDeepSweManifest,
   verifyDeepSweCheckout,
   verifyDeepSweSelection,
 } from "./src/manifest.js";
 import { prepareDeepSweArtifacts, verifyDeepSweArtifacts } from "./src/prepare.js";
-import { buildDeepSwePairedReport, buildDeepSweReport, loadDeepSweResults } from "./src/report.js";
+import {
+  buildDeepSwePairedReport,
+  buildDeepSweReport,
+  findMissingDeepSweArms,
+  loadDeepSweCampaignTaskIds,
+  loadDeepSweResults,
+} from "./src/report.js";
 import { DEEPSWE_AGENT_TIMEOUT_SEC, DEEPSWE_AGENT_WALL_CLOCK_MS } from "./src/timing.js";
 
 const ROOT = import.meta.dir;
@@ -61,7 +68,7 @@ async function writeConfigs(): Promise<void> {
   for (const [name, config] of Object.entries(renderDeepSweConfigs())) {
     await writeFile(join(CONFIG_ROOT, `${name}.models.json`), serializeDeepSweConfig(config));
   }
-  console.log(`Wrote ${Object.keys(DEEPSWE_ARMS).length} DeepSWE model configurations.`);
+  console.log(`Wrote ${DEEPSWE_ARM_NAMES.length} DeepSWE model configurations.`);
 }
 
 async function setup(): Promise<void> {
@@ -170,6 +177,9 @@ async function writeJob(args: string[]): Promise<void> {
       throw new Error(`Task is not in the pilot manifest: ${taskId}.`);
     }
   }
+  const agentEnv = Object.fromEntries(
+    Object.keys(providerEnvironment(process.env)).map((name) => [name, `\${${name}}`]),
+  );
   const job = {
     job_name: jobName,
     jobs_dir: JOBS_ROOT,
@@ -179,7 +189,7 @@ async function writeJob(args: string[]): Promise<void> {
     // Keeping in-process retries off avoids spending twice after a late crash.
     retry: { max_retries: 0 },
     environment: { type: "docker", delete: true },
-    agents: Object.keys(DEEPSWE_ARMS).map((arm) => ({
+    agents: DEEPSWE_ARM_NAMES.map((arm) => ({
       import_path: "benchmarks.deepswe.pier_agent:DuetAgent",
       model_name: arm,
       override_timeout_sec: DEEPSWE_AGENT_TIMEOUT_SEC,
@@ -189,7 +199,7 @@ async function writeJob(args: string[]): Promise<void> {
         cost_limit_usd: costLimitUsd,
         wall_clock_ms: DEEPSWE_AGENT_WALL_CLOCK_MS,
       },
-      env: { DUET_API_KEY: "${DUET_API_KEY}" },
+      env: agentEnv,
     })),
     datasets: [{ path: join(DEEPSWE_CHECKOUT, "tasks"), task_names: taskIds }],
   };
@@ -233,9 +243,7 @@ async function run(args: string[]): Promise<void> {
   const budgetUsd = positiveOption(args, "--budget-usd");
   const costLimitUsd = positiveOption(args, "--cost-limit-usd");
   await loadProviderEnvironment();
-  if (!process.env.DUET_API_KEY) {
-    throw new Error("DUET_API_KEY is required in the environment or repository .env.");
-  }
+  providerEnvironment(process.env);
   await verify();
   await requirePushedCleanCommit();
   const task = option(args, "--task");
@@ -301,7 +309,10 @@ async function requirePushedCleanCommit(): Promise<void> {
 
 async function loadProviderEnvironment(): Promise<void> {
   const values = parseDotenv(await readFile(join(REPO_ROOT, ".env"), "utf8").catch(() => ""));
-  for (const [key, value] of Object.entries(values)) process.env[key] ??= value;
+  for (const name of PROVIDER_ENV_NAMES) {
+    const value = values[name];
+    if (!process.env[name] && value) process.env[name] = value;
+  }
 }
 
 async function report(args: string[]): Promise<void> {
@@ -315,10 +326,11 @@ async function report(args: string[]): Promise<void> {
   const rows = await loadDeepSweResults(jobsRoot);
   const reportRows = buildDeepSweReport(rows);
   const manifest = await loadDeepSweManifest(MANIFEST_PATH);
-  const pairs = buildDeepSwePairedReport(
-    rows,
-    manifest.tasks.map((task) => task.taskId),
-  );
+  const manifestTaskIds = manifest.tasks.map((task) => task.taskId);
+  const expectedTaskIds = campaign
+    ? await loadDeepSweCampaignTaskIds(jobsRoot, manifestTaskIds)
+    : manifestTaskIds;
+  const pairs = buildDeepSwePairedReport(rows, expectedTaskIds);
   console.table(
     reportRows.map((row) => ({
       arm: row.arm,
@@ -347,11 +359,11 @@ async function report(args: string[]): Promise<void> {
       `${JSON.stringify({ schemaVersion: 1, rows, arms: reportRows, pairs }, null, 2)}\n`,
     );
   }
-  const missing = pairs.flatMap((pair) =>
-    pair.missingArms.map((entry) => `${pair.pair}/${entry.taskId}: ${entry.missing.join(", ")}`),
+  const missing = findMissingDeepSweArms(rows, expectedTaskIds).map(
+    (entry) => `${entry.taskId}: ${entry.missing.join(", ")}`,
   );
   if (missing.length > 0) {
-    throw new Error(`Paired headline is incomplete:\n${missing.join("\n")}`);
+    throw new Error(`DeepSWE headline is incomplete:\n${missing.join("\n")}`);
   }
 }
 

--- a/benchmarks/deepswe/cli.ts
+++ b/benchmarks/deepswe/cli.ts
@@ -1,0 +1,423 @@
+#!/usr/bin/env bun
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { parse as parseDotenv } from "dotenv";
+
+import { deepSweMinimumBudgetUsd, DEEPSWE_SINGLE_REQUEST_CUSHION_USD } from "./src/budget.js";
+import { DEEPSWE_ARMS, renderDeepSweConfigs, serializeDeepSweConfig } from "./src/config.js";
+import {
+  loadDeepSweManifest,
+  verifyDeepSweCheckout,
+  verifyDeepSweSelection,
+} from "./src/manifest.js";
+import { prepareDeepSweArtifacts, verifyDeepSweArtifacts } from "./src/prepare.js";
+import { buildDeepSwePairedReport, buildDeepSweReport, loadDeepSweResults } from "./src/report.js";
+import { DEEPSWE_AGENT_TIMEOUT_SEC, DEEPSWE_AGENT_WALL_CLOCK_MS } from "./src/timing.js";
+
+const ROOT = import.meta.dir;
+const REPO_ROOT = resolve(ROOT, "..", "..");
+const CACHE_ROOT = join(ROOT, ".cache");
+const DEEPSWE_CHECKOUT = join(CACHE_ROOT, "deep-swe");
+const VENV = join(ROOT, ".venv");
+const MANIFEST_PATH = join(ROOT, "manifests", "pilot-10-seed-0.json");
+const CONFIG_ROOT = join(ROOT, "configs");
+const ARTIFACT_ROOT = join(ROOT, "runtime", "build");
+const ARTIFACT_MANIFEST_PATH = join(ARTIFACT_ROOT, "artifact-manifest.json");
+const JOBS_ROOT = join(ROOT, "outputs", "jobs");
+
+async function main(argv: string[]): Promise<void> {
+  const [command, ...args] = argv;
+  switch (command) {
+    case "configs":
+      await writeConfigs();
+      return;
+    case "setup":
+      await setup();
+      return;
+    case "verify":
+      await verify();
+      return;
+    case "smoke":
+      await smoke();
+      return;
+    case "job":
+      await writeJob(args);
+      return;
+    case "run":
+      await run(args);
+      return;
+    case "report":
+      await report(args);
+      return;
+    default:
+      throw new Error(
+        "Usage: cli.ts <configs|setup|verify|smoke|job|run|report>. See benchmarks/deepswe/README.md.",
+      );
+  }
+}
+
+async function writeConfigs(): Promise<void> {
+  await mkdir(CONFIG_ROOT, { recursive: true });
+  for (const [name, config] of Object.entries(renderDeepSweConfigs())) {
+    await writeFile(join(CONFIG_ROOT, `${name}.models.json`), serializeDeepSweConfig(config));
+  }
+  console.log(`Wrote ${Object.keys(DEEPSWE_ARMS).length} DeepSWE model configurations.`);
+}
+
+async function setup(): Promise<void> {
+  const manifest = await loadDeepSweManifest(MANIFEST_PATH);
+  await mkdir(CACHE_ROOT, { recursive: true });
+  if (!(await exists(join(DEEPSWE_CHECKOUT, ".git")))) {
+    await runCommand(["git", "clone", manifest.upstream.repository, DEEPSWE_CHECKOUT]);
+  }
+  await runCommand(["git", "-C", DEEPSWE_CHECKOUT, "fetch", "origin", manifest.upstream.commit]);
+  await runCommand([
+    "git",
+    "-C",
+    DEEPSWE_CHECKOUT,
+    "checkout",
+    "--detach",
+    manifest.upstream.commit,
+  ]);
+  await runCommand(["git", "-C", DEEPSWE_CHECKOUT, "clean", "-ffd"]);
+
+  await ensurePierVenv();
+  await runCommand([
+    join(VENV, "bin", "pip"),
+    "install",
+    "--disable-pip-version-check",
+    `git+${manifest.pier.repository}@${manifest.pier.commit}`,
+  ]);
+  await writeConfigs();
+  await prepareDeepSweArtifacts(REPO_ROOT, ARTIFACT_ROOT);
+  await verify();
+}
+
+async function ensurePierVenv(): Promise<void> {
+  const venvPython = join(VENV, "bin", "python");
+  if (await exists(venvPython)) {
+    const compatible = await commandSucceeds([
+      venvPython,
+      "-c",
+      "import sys; raise SystemExit(not ((3, 12) <= sys.version_info[:2] < (3, 14)))",
+    ]);
+    if (compatible && (await exists(join(VENV, "bin", "pip")))) return;
+    await rm(VENV, { recursive: true, force: true });
+  }
+  const hostCompatible = await commandSucceeds([
+    "python3",
+    "-c",
+    "import sys; raise SystemExit(not ((3, 12) <= sys.version_info[:2] < (3, 14)))",
+  ]);
+  if (hostCompatible) {
+    await runCommand(["python3", "-m", "venv", VENV]);
+    return;
+  }
+  if (!(await commandSucceeds(["uv", "--version"]))) {
+    throw new Error("Pier requires Python 3.12 or 3.13; install one directly or install uv.");
+  }
+  await runCommand(["uv", "venv", "--python", "3.12", "--seed", VENV]);
+}
+
+async function verify(): Promise<void> {
+  const manifest = await loadDeepSweManifest(MANIFEST_PATH);
+  await verifyDeepSweCheckout(DEEPSWE_CHECKOUT, manifest);
+  await verifyDeepSweSelection(DEEPSWE_CHECKOUT, manifest, join(VENV, "bin", "python"));
+  const rendered = renderDeepSweConfigs();
+  for (const [name, expected] of Object.entries(rendered)) {
+    const actual = JSON.parse(
+      await readFile(join(CONFIG_ROOT, `${name}.models.json`), "utf8"),
+    ) as unknown;
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`${name}.models.json is stale; run the configs command.`);
+    }
+  }
+  const pierVersion = (
+    await runCommand([
+      join(VENV, "bin", "python"),
+      "-c",
+      "import importlib.metadata; print(importlib.metadata.version('datacurve-pier'))",
+    ])
+  ).stdout.trim();
+  if (pierVersion !== manifest.pier.version) {
+    throw new Error(`Pier is ${pierVersion}, expected ${manifest.pier.version}.`);
+  }
+  await runCommand([join(VENV, "bin", "python"), join(ROOT, "test", "pier_agent_seam.py")], {
+    env: pierEnvironment(),
+  });
+  const artifacts = await verifyDeepSweArtifacts(ARTIFACT_MANIFEST_PATH);
+  const repositoryCommit = (await runCommand(["git", "rev-parse", "HEAD"])).stdout.trim();
+  if (artifacts.duetCommit !== repositoryCommit) {
+    throw new Error(
+      `Prepared Duet commit is ${artifacts.duetCommit ?? "missing"}, expected ${repositoryCommit}.`,
+    );
+  }
+  console.log(`DeepSWE pilot setup verified at ${manifest.upstream.commit.slice(0, 12)}.`);
+}
+
+async function writeJob(args: string[]): Promise<void> {
+  const jobName = option(args, "--name") ?? `deepswe-pilot-${Date.now()}`;
+  const task = option(args, "--task");
+  const costLimitUsd = positiveOption(args, "--cost-limit-usd");
+  const concurrency = Number(option(args, "--concurrency") ?? "4");
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1 || concurrency > 16) {
+    throw new Error("--concurrency must be an integer from 1 to 16.");
+  }
+  const manifest = await loadDeepSweManifest(MANIFEST_PATH);
+  const taskIds = task ? [task] : manifest.tasks.map((entry) => entry.taskId);
+  for (const taskId of taskIds) {
+    if (!manifest.tasks.some((entry) => entry.taskId === taskId)) {
+      throw new Error(`Task is not in the pilot manifest: ${taskId}.`);
+    }
+  }
+  const job = {
+    job_name: jobName,
+    jobs_dir: JOBS_ROOT,
+    n_attempts: 1,
+    n_concurrent_trials: concurrency,
+    // The E2B controller resumes Pier's infrastructure exception classes.
+    // Keeping in-process retries off avoids spending twice after a late crash.
+    retry: { max_retries: 0 },
+    environment: { type: "docker", delete: true },
+    agents: Object.keys(DEEPSWE_ARMS).map((arm) => ({
+      import_path: "benchmarks.deepswe.pier_agent:DuetAgent",
+      model_name: arm,
+      override_timeout_sec: DEEPSWE_AGENT_TIMEOUT_SEC,
+      kwargs: {
+        routing_config_path: join(CONFIG_ROOT, `${arm}.models.json`),
+        artifact_manifest_path: ARTIFACT_MANIFEST_PATH,
+        cost_limit_usd: costLimitUsd,
+        wall_clock_ms: DEEPSWE_AGENT_WALL_CLOCK_MS,
+      },
+      env: { DUET_API_KEY: "${DUET_API_KEY}" },
+    })),
+    datasets: [{ path: join(DEEPSWE_CHECKOUT, "tasks"), task_names: taskIds }],
+  };
+  const output = resolve(option(args, "--output") ?? join(ROOT, "outputs", `${jobName}.json`));
+  await mkdir(dirname(output), { recursive: true });
+  await writeFile(output, `${JSON.stringify(job, null, 2)}\n`);
+  console.log(output);
+}
+
+async function smoke(): Promise<void> {
+  await verify();
+  const manifest = await loadDeepSweManifest(MANIFEST_PATH);
+  const taskId = manifest.tasks[0]!.taskId;
+  const output = join(ROOT, "outputs", "official-nop-smoke.json");
+  await mkdir(dirname(output), { recursive: true });
+  await writeFile(
+    output,
+    `${JSON.stringify(
+      {
+        job_name: "deepswe-official-nop-smoke",
+        jobs_dir: join(ROOT, "outputs", "smoke"),
+        n_attempts: 1,
+        n_concurrent_trials: 1,
+        retry: { max_retries: 0 },
+        environment: { type: "docker", delete: true },
+        agents: [{ name: "nop" }],
+        datasets: [{ path: join(DEEPSWE_CHECKOUT, "tasks"), task_names: [taskId] }],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await runCommand([join(VENV, "bin", "pier"), "run", "--config", output], {
+    cwd: REPO_ROOT,
+    env: pierEnvironment(),
+  });
+  console.log(`Official no-model smoke completed for ${taskId}; reward 0 is expected.`);
+}
+
+async function run(args: string[]): Promise<void> {
+  const budgetUsd = positiveOption(args, "--budget-usd");
+  const costLimitUsd = positiveOption(args, "--cost-limit-usd");
+  await loadProviderEnvironment();
+  if (!process.env.DUET_API_KEY) {
+    throw new Error("DUET_API_KEY is required in the environment or repository .env.");
+  }
+  await verify();
+  await requirePushedCleanCommit();
+  const task = option(args, "--task");
+  const manifest = await loadDeepSweManifest(MANIFEST_PATH);
+  const taskCount = task ? 1 : manifest.tasks.length;
+  const minimumBudgetUsd = deepSweMinimumBudgetUsd(taskCount, costLimitUsd);
+  if (minimumBudgetUsd > budgetUsd) {
+    throw new Error(
+      `The $${budgetUsd.toFixed(2)} budget is below the $${minimumBudgetUsd.toFixed(2)} campaign admission minimum, which includes one $${DEEPSWE_SINGLE_REQUEST_CUSHION_USD.toFixed(2)} in-flight request cushion per rollout.`,
+    );
+  }
+  const name = option(args, "--name") ?? `deepswe-pilot-${Date.now()}`;
+  const configPath = join(ROOT, "outputs", `${name}.json`);
+  await writeJob([
+    "--name",
+    name,
+    "--cost-limit-usd",
+    String(costLimitUsd),
+    "--concurrency",
+    option(args, "--concurrency") ?? "4",
+    "--output",
+    configPath,
+    ...(task ? ["--task", task] : []),
+  ]);
+  await writeFile(
+    join(ROOT, "outputs", `${name}.budget.json`),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        budgetUsd,
+        costLimitUsd,
+        singleRequestCushionUsd: DEEPSWE_SINGLE_REQUEST_CUSHION_USD,
+        minimumBudgetUsd,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  console.log(`Authorized campaign budget: $${budgetUsd.toFixed(2)}.`);
+  await runCommand([join(VENV, "bin", "pier"), "run", "--config", configPath], {
+    cwd: REPO_ROOT,
+    env: pierEnvironment(),
+  });
+}
+
+async function requirePushedCleanCommit(): Promise<void> {
+  const [status, head] = await Promise.all([
+    runCommand(["git", "status", "--porcelain"]),
+    runCommand(["git", "rev-parse", "HEAD"]),
+  ]);
+  if (status.stdout.trim()) throw new Error("Paid DeepSWE runs require a clean worktree.");
+  const remoteBranches = await runCommand([
+    "git",
+    "branch",
+    "--remotes",
+    "--contains",
+    head.stdout.trim(),
+  ]);
+  if (!remoteBranches.stdout.trim()) {
+    throw new Error("Paid DeepSWE runs require the current commit on an origin branch.");
+  }
+}
+
+async function loadProviderEnvironment(): Promise<void> {
+  const values = parseDotenv(await readFile(join(REPO_ROOT, ".env"), "utf8").catch(() => ""));
+  for (const [key, value] of Object.entries(values)) process.env[key] ??= value;
+}
+
+async function report(args: string[]): Promise<void> {
+  const jobs = option(args, "--jobs");
+  const campaign = option(args, "--campaign");
+  if (jobs && campaign) throw new Error("Use either --jobs or --campaign, not both.");
+  if (campaign && !/^[a-z0-9][a-z0-9-]{0,63}$/.test(campaign)) {
+    throw new Error("--campaign must be a lowercase, path-safe identifier.");
+  }
+  const jobsRoot = campaign ? join(ROOT, "outputs", "e2b", campaign) : resolve(jobs ?? JOBS_ROOT);
+  const rows = await loadDeepSweResults(jobsRoot);
+  const reportRows = buildDeepSweReport(rows);
+  const manifest = await loadDeepSweManifest(MANIFEST_PATH);
+  const pairs = buildDeepSwePairedReport(
+    rows,
+    manifest.tasks.map((task) => task.taskId),
+  );
+  console.table(
+    reportRows.map((row) => ({
+      arm: row.arm,
+      resolved: `${row.resolved}/${row.completed}`,
+      resolveRate: `${(row.resolveRate * 100).toFixed(1)}%`,
+      costPerTask: `$${row.costPerTaskUsd.toFixed(2)}`,
+      costPerResolved:
+        row.costPerResolvedUsd === null ? "—" : `$${row.costPerResolvedUsd.toFixed(2)}`,
+    })),
+  );
+  console.table(
+    pairs.map((pair) => ({
+      pair: pair.pair,
+      completed: pair.completedTasks,
+      bothResolved: pair.bothResolved,
+      advisorOnly: pair.advisorOnly,
+      pureOnlyRegression: pair.pureOnlyRegression,
+      neitherResolved: pair.neitherResolved,
+      missing: pair.missingArms.length,
+    })),
+  );
+  const output = option(args, "--output");
+  if (output) {
+    await writeFile(
+      resolve(output),
+      `${JSON.stringify({ schemaVersion: 1, rows, arms: reportRows, pairs }, null, 2)}\n`,
+    );
+  }
+  const missing = pairs.flatMap((pair) =>
+    pair.missingArms.map((entry) => `${pair.pair}/${entry.taskId}: ${entry.missing.join(", ")}`),
+  );
+  if (missing.length > 0) {
+    throw new Error(`Paired headline is incomplete:\n${missing.join("\n")}`);
+  }
+}
+
+function option(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index < 0 ? undefined : args[index + 1];
+}
+
+function positiveOption(args: string[], name: string): number {
+  const value = Number(option(args, name));
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be positive.`);
+  return value;
+}
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(
+    () => true,
+    () => false,
+  );
+}
+
+async function runCommand(
+  argv: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  const process = Bun.spawn(argv, {
+    cwd: options.cwd ?? REPO_ROOT,
+    env: options.env ?? processEnv(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`${argv.join(" ")} failed (${exitCode}):\n${stderr || stdout}`);
+  }
+  return { stdout, stderr };
+}
+
+async function commandSucceeds(argv: string[]): Promise<boolean> {
+  const child = Bun.spawn(argv, {
+    cwd: REPO_ROOT,
+    env: processEnv(),
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return (await child.exited) === 0;
+}
+
+function processEnv(): NodeJS.ProcessEnv {
+  return { ...process.env };
+}
+
+function pierEnvironment(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    // Python console scripts put their own bin directory on sys.path rather
+    // than the working directory; Pier's custom-agent import needs the repo.
+    PYTHONPATH: REPO_ROOT,
+  };
+}
+
+await main(process.argv.slice(2)).catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/benchmarks/deepswe/configs/fable-pure.models.json
+++ b/benchmarks/deepswe/configs/fable-pure.models.json
@@ -1,0 +1,33 @@
+{
+  "defaultTier": "deepswe",
+  "tiers": {
+    "deepswe": {
+      "routes": {
+        "general": {
+          "description": "Backend, systems, data, CLI, and other implementation or debugging work, including tests and code changes.",
+          "target": {
+            "modelName": "fable-5",
+            "thinkingLevel": "high"
+          },
+          "visionFallbackModelName": "kimi-k3"
+        }
+      },
+      "advisor": {
+        "enabled": false,
+        "target": {
+          "modelName": "fable-5",
+          "thinkingLevel": "high"
+        },
+        "minStepsBetween": 5
+      }
+    }
+  },
+  "classifier": {
+    "target": {
+      "modelName": "luna",
+      "thinkingLevel": "low"
+    },
+    "everySteps": 5,
+    "guidance": "Prefer continuity when the task has not materially changed, but switch routes when the work changes domains."
+  }
+}

--- a/benchmarks/deepswe/configs/glm-kimi-advisor.models.json
+++ b/benchmarks/deepswe/configs/glm-kimi-advisor.models.json
@@ -1,0 +1,33 @@
+{
+  "defaultTier": "deepswe",
+  "tiers": {
+    "deepswe": {
+      "routes": {
+        "general": {
+          "description": "Backend, systems, data, CLI, and other implementation or debugging work, including tests and code changes.",
+          "target": {
+            "modelName": "glm-5.2",
+            "thinkingLevel": "xhigh"
+          },
+          "visionFallbackModelName": "kimi-k3"
+        }
+      },
+      "advisor": {
+        "enabled": true,
+        "target": {
+          "modelName": "kimi-k3",
+          "thinkingLevel": "medium"
+        },
+        "minStepsBetween": 5
+      }
+    }
+  },
+  "classifier": {
+    "target": {
+      "modelName": "luna",
+      "thinkingLevel": "low"
+    },
+    "everySteps": 5,
+    "guidance": "Prefer continuity when the task has not materially changed, but switch routes when the work changes domains."
+  }
+}

--- a/benchmarks/deepswe/configs/glm-pure.models.json
+++ b/benchmarks/deepswe/configs/glm-pure.models.json
@@ -1,0 +1,33 @@
+{
+  "defaultTier": "deepswe",
+  "tiers": {
+    "deepswe": {
+      "routes": {
+        "general": {
+          "description": "Backend, systems, data, CLI, and other implementation or debugging work, including tests and code changes.",
+          "target": {
+            "modelName": "glm-5.2",
+            "thinkingLevel": "xhigh"
+          },
+          "visionFallbackModelName": "kimi-k3"
+        }
+      },
+      "advisor": {
+        "enabled": false,
+        "target": {
+          "modelName": "kimi-k3",
+          "thinkingLevel": "medium"
+        },
+        "minStepsBetween": 5
+      }
+    }
+  },
+  "classifier": {
+    "target": {
+      "modelName": "luna",
+      "thinkingLevel": "low"
+    },
+    "everySteps": 5,
+    "guidance": "Prefer continuity when the task has not materially changed, but switch routes when the work changes domains."
+  }
+}

--- a/benchmarks/deepswe/configs/kimi-fable-advisor.models.json
+++ b/benchmarks/deepswe/configs/kimi-fable-advisor.models.json
@@ -1,0 +1,33 @@
+{
+  "defaultTier": "deepswe",
+  "tiers": {
+    "deepswe": {
+      "routes": {
+        "general": {
+          "description": "Backend, systems, data, CLI, and other implementation or debugging work, including tests and code changes.",
+          "target": {
+            "modelName": "kimi-k3",
+            "thinkingLevel": "high"
+          },
+          "visionFallbackModelName": "kimi-k3"
+        }
+      },
+      "advisor": {
+        "enabled": true,
+        "target": {
+          "modelName": "fable-5",
+          "thinkingLevel": "high"
+        },
+        "minStepsBetween": 5
+      }
+    }
+  },
+  "classifier": {
+    "target": {
+      "modelName": "luna",
+      "thinkingLevel": "low"
+    },
+    "everySteps": 5,
+    "guidance": "Prefer continuity when the task has not materially changed, but switch routes when the work changes domains."
+  }
+}

--- a/benchmarks/deepswe/configs/kimi-pure.models.json
+++ b/benchmarks/deepswe/configs/kimi-pure.models.json
@@ -1,0 +1,33 @@
+{
+  "defaultTier": "deepswe",
+  "tiers": {
+    "deepswe": {
+      "routes": {
+        "general": {
+          "description": "Backend, systems, data, CLI, and other implementation or debugging work, including tests and code changes.",
+          "target": {
+            "modelName": "kimi-k3",
+            "thinkingLevel": "high"
+          },
+          "visionFallbackModelName": "kimi-k3"
+        }
+      },
+      "advisor": {
+        "enabled": false,
+        "target": {
+          "modelName": "fable-5",
+          "thinkingLevel": "high"
+        },
+        "minStepsBetween": 5
+      }
+    }
+  },
+  "classifier": {
+    "target": {
+      "modelName": "luna",
+      "thinkingLevel": "low"
+    },
+    "everySteps": 5,
+    "guidance": "Prefer continuity when the task has not materially changed, but switch routes when the work changes domains."
+  }
+}

--- a/benchmarks/deepswe/configs/opus-pure.models.json
+++ b/benchmarks/deepswe/configs/opus-pure.models.json
@@ -1,0 +1,33 @@
+{
+  "defaultTier": "deepswe",
+  "tiers": {
+    "deepswe": {
+      "routes": {
+        "general": {
+          "description": "Backend, systems, data, CLI, and other implementation or debugging work, including tests and code changes.",
+          "target": {
+            "modelName": "opus-5",
+            "thinkingLevel": "xhigh"
+          },
+          "visionFallbackModelName": "kimi-k3"
+        }
+      },
+      "advisor": {
+        "enabled": false,
+        "target": {
+          "modelName": "fable-5",
+          "thinkingLevel": "high"
+        },
+        "minStepsBetween": 5
+      }
+    }
+  },
+  "classifier": {
+    "target": {
+      "modelName": "luna",
+      "thinkingLevel": "low"
+    },
+    "everySteps": 5,
+    "guidance": "Prefer continuity when the task has not materially changed, but switch routes when the work changes domains."
+  }
+}

--- a/benchmarks/deepswe/e2b/run.ts
+++ b/benchmarks/deepswe/e2b/run.ts
@@ -208,8 +208,8 @@ async function runTask(input: {
       cwd: REMOTE_ROOT,
       user: "user",
       timeoutMs: DEEPSWE_WORKER_COMMAND_TIMEOUT_MS,
-      onStdout: (line) => console.log(`[${input.taskId}] ${line.line}`),
-      onStderr: (line) => console.error(`[${input.taskId}] ${line.line}`),
+      onStdout: (line) => console.log(`[${input.taskId}] ${line}`),
+      onStderr: (line) => console.error(`[${input.taskId}] ${line}`),
     });
     if (!(await remoteTaskHasAllOutcomes(sandbox, name, input.taskId))) {
       throw new Error(

--- a/benchmarks/deepswe/e2b/run.ts
+++ b/benchmarks/deepswe/e2b/run.ts
@@ -1,0 +1,421 @@
+#!/usr/bin/env bun
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { parse as parseDotenv } from "dotenv";
+import { Sandbox, Template } from "e2b";
+
+import { deepSweMinimumBudgetUsd, DEEPSWE_SINGLE_REQUEST_CUSHION_USD } from "../src/budget.js";
+import { loadDeepSweManifest } from "../src/manifest.js";
+import { isRetryableInfrastructureException, loadDeepSweResults } from "../src/report.js";
+import { DEEPSWE_WORKER_COMMAND_TIMEOUT_MS, DEEPSWE_WORKER_TIMEOUT_MS } from "../src/timing.js";
+import { deepSweTemplateName, shellQuote } from "./support.js";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const BENCH_ROOT = resolve(import.meta.dir, "..");
+const REMOTE_ROOT = "/work/duet-agent";
+const REMOTE_ARCHIVE = "/tmp/deepswe-results.tar";
+const REMOTE_RESUME_ARCHIVE = "/tmp/deepswe-resume.tar";
+const REQUEST_TIMEOUT_MS = 180_000;
+
+interface Options {
+  budgetUsd: number;
+  costLimitUsd: number;
+  concurrency: number;
+  taskIds: string[];
+  campaign: string;
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  await loadRepositoryEnv();
+  const duetApiKey = process.env.DUET_API_KEY;
+  const e2bApiKey = process.env.E2B_API_KEY;
+  if (!duetApiKey || !e2bApiKey) {
+    throw new Error("DUET_API_KEY and E2B_API_KEY are required.");
+  }
+  const [repositorySha, upstreamSha, status] = await Promise.all([
+    git(["rev-parse", "HEAD"]),
+    git(["rev-parse", "@{upstream}"]),
+    git(["status", "--porcelain"]),
+  ]);
+  if (status) throw new Error("E2B execution requires a clean committed worktree.");
+  if (repositorySha !== upstreamSha) {
+    throw new Error("E2B execution requires the current commit to be pushed.");
+  }
+  const manifest = await loadDeepSweManifest(join(BENCH_ROOT, "manifests", "pilot-10-seed-0.json"));
+  const taskIds =
+    options.taskIds.length === 0
+      ? manifest.tasks.map((task) => task.taskId)
+      : [...new Set(options.taskIds)];
+  for (const taskId of taskIds) {
+    if (!manifest.tasks.some((task) => task.taskId === taskId)) {
+      throw new Error(`Task is not in the pilot manifest: ${taskId}.`);
+    }
+  }
+  const minimumBudgetUsd = deepSweMinimumBudgetUsd(taskIds.length, options.costLimitUsd);
+  if (minimumBudgetUsd > options.budgetUsd) {
+    throw new Error(
+      `The $${options.budgetUsd.toFixed(2)} budget is below the $${minimumBudgetUsd.toFixed(2)} campaign admission minimum, which includes one $${DEEPSWE_SINGLE_REQUEST_CUSHION_USD.toFixed(2)} in-flight request cushion per rollout. Lower --cost-limit-usd or select fewer tasks.`,
+    );
+  }
+
+  const templateName = deepSweTemplateName(repositorySha);
+  if (!(await Template.exists(templateName, { requestTimeoutMs: REQUEST_TIMEOUT_MS }))) {
+    throw new Error(`Missing ${templateName}; run benchmarks/deepswe/e2b/template.ts first.`);
+  }
+  const outputRoot = join(BENCH_ROOT, "outputs", "e2b", options.campaign);
+  await mkdir(outputRoot, { recursive: true });
+  await writeCampaignProvenance(join(outputRoot, "campaign.json"), {
+    schemaVersion: 1,
+    repositorySha,
+    deepSweCommit: manifest.upstream.commit,
+    pierCommit: manifest.pier.commit,
+    taskIds,
+    budgetUsd: options.budgetUsd,
+    costLimitUsd: options.costLimitUsd,
+    singleRequestCushionUsd: DEEPSWE_SINGLE_REQUEST_CUSHION_USD,
+    minimumBudgetUsd,
+    concurrency: Math.min(options.concurrency, taskIds.length),
+  });
+
+  const failures = await runPool(taskIds, options.concurrency, async (taskId) => {
+    await runTask({
+      taskId,
+      campaign: options.campaign,
+      outputRoot,
+      templateName,
+      repositorySha,
+      duetApiKey,
+      costLimitUsd: options.costLimitUsd,
+    });
+  });
+  if (failures.length > 0) {
+    throw new Error(`DeepSWE workers failed:\n${failures.join("\n")}`);
+  }
+  console.log(`Completed ${taskIds.length} DeepSWE task shards under ${outputRoot}.`);
+}
+
+interface CampaignProvenance {
+  schemaVersion: 1;
+  repositorySha: string;
+  deepSweCommit: string;
+  pierCommit: string;
+  taskIds: string[];
+  budgetUsd: number;
+  costLimitUsd: number;
+  singleRequestCushionUsd: number;
+  minimumBudgetUsd: number;
+  concurrency: number;
+}
+
+async function writeCampaignProvenance(
+  path: string,
+  provenance: CampaignProvenance,
+): Promise<void> {
+  const existing = await readFile(path, "utf8")
+    .then((value) => JSON.parse(value) as CampaignProvenance)
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined;
+      throw error;
+    });
+  if (existing) {
+    const immutableExisting = {
+      ...existing,
+      budgetUsd: 0,
+      concurrency: 0,
+    };
+    const immutableNext = {
+      ...provenance,
+      budgetUsd: 0,
+      concurrency: 0,
+    };
+    if (JSON.stringify(immutableExisting) !== JSON.stringify(immutableNext)) {
+      throw new Error("Refusing to resume a DeepSWE campaign with changed frozen inputs.");
+    }
+    if (provenance.budgetUsd < existing.budgetUsd) {
+      throw new Error("A resumed DeepSWE campaign budget may increase but not decrease.");
+    }
+  }
+  await writeFile(path, `${JSON.stringify(provenance, null, 2)}\n`);
+}
+
+async function runTask(input: {
+  taskId: string;
+  campaign: string;
+  outputRoot: string;
+  templateName: string;
+  repositorySha: string;
+  duetApiKey: string;
+  costLimitUsd: number;
+}): Promise<void> {
+  const taskOutput = join(input.outputRoot, input.taskId);
+  const pruned = await pruneInfrastructureTrials(join(taskOutput, "jobs"));
+  if (pruned > 0) {
+    console.log(`[${input.taskId}] removed ${pruned} resumable infrastructure result(s).`);
+  }
+  if (await taskHasAllOutcomes(taskOutput, input.taskId)) {
+    console.log(`[${input.taskId}] already has all four arm outcomes; skipping.`);
+    return;
+  }
+  const sandbox = await Sandbox.create(input.templateName, {
+    timeoutMs: DEEPSWE_WORKER_TIMEOUT_MS,
+    requestTimeoutMs: REQUEST_TIMEOUT_MS,
+    envs: { DUET_API_KEY: input.duetApiKey },
+    metadata: {
+      purpose: "duet-deepswe-pilot",
+      campaign: input.campaign,
+      taskId: input.taskId,
+      repositorySha: input.repositorySha,
+    },
+  });
+  let failure: unknown;
+  try {
+    const name = `${input.campaign}-${input.taskId}`;
+    const resume = await createTaskArchive(taskOutput);
+    if (resume) {
+      await sandbox.files.write(REMOTE_RESUME_ARCHIVE, resume);
+      await sandbox.commands.run(
+        `mkdir -p ${shellQuote(`${REMOTE_ROOT}/benchmarks/deepswe/outputs`)} && tar -xf ${REMOTE_RESUME_ARCHIVE} -C ${shellQuote(`${REMOTE_ROOT}/benchmarks/deepswe/outputs`)}`,
+        { timeoutMs: 120_000 },
+      );
+    }
+    const command = [
+      "bun",
+      "benchmarks/deepswe/cli.ts",
+      "run",
+      "--task",
+      input.taskId,
+      "--name",
+      name,
+      "--cost-limit-usd",
+      String(input.costLimitUsd),
+      "--budget-usd",
+      String(deepSweMinimumBudgetUsd(1, input.costLimitUsd)),
+      "--concurrency",
+      "1",
+    ]
+      .map(shellQuote)
+      .join(" ");
+    await sandbox.commands.run(command, {
+      cwd: REMOTE_ROOT,
+      user: "user",
+      timeoutMs: DEEPSWE_WORKER_COMMAND_TIMEOUT_MS,
+      onStdout: (line) => console.log(`[${input.taskId}] ${line.line}`),
+      onStderr: (line) => console.error(`[${input.taskId}] ${line.line}`),
+    });
+    if (!(await remoteTaskHasAllOutcomes(sandbox, name, input.taskId))) {
+      throw new Error("Pier ended without four durable model/verifier outcomes.");
+    }
+  } catch (error) {
+    failure = error;
+  } finally {
+    try {
+      await downloadTaskArchive(sandbox, input.campaign, input.taskId, taskOutput);
+    } catch (downloadError) {
+      failure ??= downloadError;
+    }
+    await sandbox.kill().catch(() => false);
+  }
+  if (failure) throw failure;
+}
+
+async function remoteTaskHasAllOutcomes(
+  sandbox: Sandbox,
+  name: string,
+  taskId: string,
+): Promise<boolean> {
+  const result = await sandbox.commands.run(
+    [
+      "bun",
+      "-e",
+      [
+        `import { loadDeepSweResults } from "./benchmarks/deepswe/src/report.ts";`,
+        `const rows = await loadDeepSweResults(${JSON.stringify(
+          `${REMOTE_ROOT}/benchmarks/deepswe/outputs/jobs/${name}`,
+        )});`,
+        `process.exit(rows.filter((row) => row.taskId === ${JSON.stringify(taskId)}).length === 4 ? 0 : 1);`,
+      ].join(" "),
+    ]
+      .map(shellQuote)
+      .join(" "),
+    { cwd: REMOTE_ROOT, user: "user", timeoutMs: 120_000 },
+  );
+  return result.exitCode === 0;
+}
+
+async function downloadTaskArchive(
+  sandbox: Sandbox,
+  campaign: string,
+  taskId: string,
+  destination: string,
+): Promise<void> {
+  const name = `${campaign}-${taskId}`;
+  await sandbox.commands.run(
+    `cd ${shellQuote(`${REMOTE_ROOT}/benchmarks/deepswe/outputs`)} && tar -cf ${REMOTE_ARCHIVE} ${shellQuote(`${name}.json`)} ${shellQuote(`${name}.budget.json`)} ${shellQuote(`jobs/${name}`)}`,
+    { timeoutMs: 120_000 },
+  );
+  const bytes = await sandbox.files.read(REMOTE_ARCHIVE, { format: "bytes" });
+  await extractTaskArchive(bytes, destination);
+}
+
+async function createTaskArchive(root: string): Promise<Uint8Array | undefined> {
+  if (!(await exists(root))) return undefined;
+  const temporary = await mkdtemp(join(tmpdir(), "duet-deepswe-resume-"));
+  const archive = join(temporary, "resume.tar");
+  try {
+    await execFileAsync("tar", ["-cf", archive, "-C", root, "."]);
+    return await readFile(archive);
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+async function taskHasAllOutcomes(root: string, taskId: string): Promise<boolean> {
+  const rows = await loadDeepSweResults(join(root, "jobs"));
+  return rows.filter((row) => row.taskId === taskId).length === 4;
+}
+
+/** Remove only Pier exceptions that its pinned retry policy treats as resumable. */
+export async function pruneInfrastructureTrials(jobsRoot: string): Promise<number> {
+  const resultPaths = await findResultPaths(jobsRoot);
+  let pruned = 0;
+  for (const path of resultPaths) {
+    const result = JSON.parse(await readFile(path, "utf8")) as {
+      task_name?: string;
+      agent_info?: { model_info?: { name?: string } };
+      exception_info?: { exception_type?: string };
+    };
+    if (
+      result.task_name &&
+      result.agent_info?.model_info?.name &&
+      isRetryableInfrastructureException(result.exception_info?.exception_type)
+    ) {
+      await rm(dirname(path), { recursive: true, force: true });
+      pruned += 1;
+    }
+  }
+  return pruned;
+}
+
+async function findResultPaths(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true }).catch(
+    (error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return [];
+      throw error;
+    },
+  );
+  return (
+    await Promise.all(
+      entries.map((entry) => {
+        const path = join(root, entry.name);
+        if (entry.isDirectory()) return findResultPaths(path);
+        return entry.name === "result.json" ? [path] : [];
+      }),
+    )
+  ).flat();
+}
+
+async function extractTaskArchive(bytes: Uint8Array, destination: string): Promise<void> {
+  const temporary = await mkdtemp(join(tmpdir(), "duet-deepswe-result-"));
+  const archive = join(temporary, "result.tar");
+  try {
+    await writeFile(archive, bytes);
+    const { stdout } = await execFileAsync("tar", ["-tf", archive]);
+    for (const entry of stdout.trim().split("\n").filter(Boolean)) {
+      if (entry.startsWith("/") || entry.split("/").includes("..")) {
+        throw new Error(`Unsafe E2B archive entry: ${entry}`);
+      }
+    }
+    await mkdir(destination, { recursive: true });
+    await execFileAsync("tar", ["-xf", archive, "-C", destination]);
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+async function runPool<T>(
+  values: readonly T[],
+  concurrency: number,
+  run: (value: T) => Promise<void>,
+): Promise<string[]> {
+  const pending = [...values];
+  const failures: string[] = [];
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, pending.length) }, async () => {
+      while (pending.length > 0) {
+        const value = pending.shift();
+        if (value === undefined) return;
+        try {
+          await run(value);
+        } catch (error) {
+          failures.push(`${String(value)}: ${error instanceof Error ? error.message : error}`);
+        }
+      }
+    }),
+  );
+  return failures;
+}
+
+function parseOptions(args: string[]): Options {
+  const value = (name: string): string | undefined => {
+    const index = args.indexOf(name);
+    return index < 0 ? undefined : args[index + 1];
+  };
+  const positive = (name: string): number => {
+    const parsed = Number(value(name));
+    if (!Number.isFinite(parsed) || parsed <= 0) throw new Error(`${name} must be positive.`);
+    return parsed;
+  };
+  const concurrency = Number(value("--concurrency") ?? "10");
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1 || concurrency > 10) {
+    throw new Error("--concurrency must be an integer from 1 to 10.");
+  }
+  const taskIds: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--task" && args[index + 1]) taskIds.push(args[index + 1]!);
+  }
+  return {
+    budgetUsd: positive("--budget-usd"),
+    costLimitUsd: positive("--cost-limit-usd"),
+    concurrency,
+    taskIds,
+    campaign: validateCampaign(value("--campaign") ?? "pilot-10"),
+  };
+}
+
+function validateCampaign(value: string): string {
+  if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(value)) {
+    throw new Error("--campaign must be a lowercase, path-safe identifier.");
+  }
+  return value;
+}
+
+async function loadRepositoryEnv(): Promise<void> {
+  const path = join(REPO_ROOT, ".env");
+  const parsed = parseDotenv(await readFile(path, "utf8").catch(() => ""));
+  for (const [key, value] of Object.entries(parsed)) process.env[key] ??= value;
+}
+
+async function git(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd: REPO_ROOT });
+  return stdout.trim();
+}
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(
+    () => true,
+    () => false,
+  );
+}
+
+if (import.meta.main) {
+  await main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/benchmarks/deepswe/e2b/run.ts
+++ b/benchmarks/deepswe/e2b/run.ts
@@ -8,9 +8,15 @@ import { promisify } from "node:util";
 import { parse as parseDotenv } from "dotenv";
 import { Sandbox, Template } from "e2b";
 
+import { providerEnvironment, PROVIDER_ENV_NAMES } from "../../shared/provider-environment.js";
 import { deepSweMinimumBudgetUsd, DEEPSWE_SINGLE_REQUEST_CUSHION_USD } from "../src/budget.js";
+import { DEEPSWE_ARM_NAMES } from "../src/config.js";
 import { loadDeepSweManifest } from "../src/manifest.js";
-import { isRetryableInfrastructureException, loadDeepSweResults } from "../src/report.js";
+import {
+  hasEveryDeepSweArm,
+  isRetryableInfrastructureException,
+  loadDeepSweResults,
+} from "../src/report.js";
 import { DEEPSWE_WORKER_COMMAND_TIMEOUT_MS, DEEPSWE_WORKER_TIMEOUT_MS } from "../src/timing.js";
 import { deepSweTemplateName, shellQuote } from "./support.js";
 
@@ -33,11 +39,8 @@ interface Options {
 async function main(): Promise<void> {
   const options = parseOptions(process.argv.slice(2));
   await loadRepositoryEnv();
-  const duetApiKey = process.env.DUET_API_KEY;
-  const e2bApiKey = process.env.E2B_API_KEY;
-  if (!duetApiKey || !e2bApiKey) {
-    throw new Error("DUET_API_KEY and E2B_API_KEY are required.");
-  }
+  if (!process.env.E2B_API_KEY) throw new Error("E2B_API_KEY is required.");
+  const providerEnv = providerEnvironment(process.env);
   const [repositorySha, upstreamSha, status] = await Promise.all([
     git(["rev-parse", "HEAD"]),
     git(["rev-parse", "@{upstream}"]),
@@ -90,7 +93,7 @@ async function main(): Promise<void> {
       outputRoot,
       templateName,
       repositorySha,
-      duetApiKey,
+      providerEnv,
       costLimitUsd: options.costLimitUsd,
     });
   });
@@ -150,7 +153,7 @@ async function runTask(input: {
   outputRoot: string;
   templateName: string;
   repositorySha: string;
-  duetApiKey: string;
+  providerEnv: Record<string, string>;
   costLimitUsd: number;
 }): Promise<void> {
   const taskOutput = join(input.outputRoot, input.taskId);
@@ -159,13 +162,13 @@ async function runTask(input: {
     console.log(`[${input.taskId}] removed ${pruned} resumable infrastructure result(s).`);
   }
   if (await taskHasAllOutcomes(taskOutput, input.taskId)) {
-    console.log(`[${input.taskId}] already has all four arm outcomes; skipping.`);
+    console.log(`[${input.taskId}] already has every arm outcome; skipping.`);
     return;
   }
   const sandbox = await Sandbox.create(input.templateName, {
     timeoutMs: DEEPSWE_WORKER_TIMEOUT_MS,
     requestTimeoutMs: REQUEST_TIMEOUT_MS,
-    envs: { DUET_API_KEY: input.duetApiKey },
+    envs: input.providerEnv,
     metadata: {
       purpose: "duet-deepswe-pilot",
       campaign: input.campaign,
@@ -209,7 +212,9 @@ async function runTask(input: {
       onStderr: (line) => console.error(`[${input.taskId}] ${line.line}`),
     });
     if (!(await remoteTaskHasAllOutcomes(sandbox, name, input.taskId))) {
-      throw new Error("Pier ended without four durable model/verifier outcomes.");
+      throw new Error(
+        `Pier ended without all ${DEEPSWE_ARM_NAMES.length} durable model/verifier outcomes.`,
+      );
     }
   } catch (error) {
     failure = error;
@@ -234,11 +239,11 @@ async function remoteTaskHasAllOutcomes(
       "bun",
       "-e",
       [
-        `import { loadDeepSweResults } from "./benchmarks/deepswe/src/report.ts";`,
+        `import { hasEveryDeepSweArm, loadDeepSweResults } from "./benchmarks/deepswe/src/report.ts";`,
         `const rows = await loadDeepSweResults(${JSON.stringify(
           `${REMOTE_ROOT}/benchmarks/deepswe/outputs/jobs/${name}`,
         )});`,
-        `process.exit(rows.filter((row) => row.taskId === ${JSON.stringify(taskId)}).length === 4 ? 0 : 1);`,
+        `process.exit(hasEveryDeepSweArm(rows, ${JSON.stringify(taskId)}) ? 0 : 1);`,
       ].join(" "),
     ]
       .map(shellQuote)
@@ -275,9 +280,9 @@ async function createTaskArchive(root: string): Promise<Uint8Array | undefined> 
   }
 }
 
-async function taskHasAllOutcomes(root: string, taskId: string): Promise<boolean> {
+export async function taskHasAllOutcomes(root: string, taskId: string): Promise<boolean> {
   const rows = await loadDeepSweResults(join(root, "jobs"));
-  return rows.filter((row) => row.taskId === taskId).length === 4;
+  return hasEveryDeepSweArm(rows, taskId);
 }
 
 /** Remove only Pier exceptions that its pinned retry policy treats as resumable. */
@@ -384,7 +389,7 @@ function parseOptions(args: string[]): Options {
     costLimitUsd: positive("--cost-limit-usd"),
     concurrency,
     taskIds,
-    campaign: validateCampaign(value("--campaign") ?? "pilot-10"),
+    campaign: validateCampaign(value("--campaign") ?? "pilot-10-six-arm"),
   };
 }
 
@@ -398,7 +403,10 @@ function validateCampaign(value: string): string {
 async function loadRepositoryEnv(): Promise<void> {
   const path = join(REPO_ROOT, ".env");
   const parsed = parseDotenv(await readFile(path, "utf8").catch(() => ""));
-  for (const [key, value] of Object.entries(parsed)) process.env[key] ??= value;
+  for (const name of ["E2B_API_KEY", ...PROVIDER_ENV_NAMES]) {
+    const value = parsed[name];
+    if (!process.env[name] && value) process.env[name] = value;
+  }
 }
 
 async function git(args: string[]): Promise<string> {

--- a/benchmarks/deepswe/e2b/support.ts
+++ b/benchmarks/deepswe/e2b/support.ts
@@ -1,0 +1,12 @@
+/** POSIX shell quoting for immutable paths and task ids sent to E2B workers. */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/** Template identity includes the exact Duet commit under evaluation. */
+export function deepSweTemplateName(repositorySha: string): string {
+  if (!/^[0-9a-f]{40}$/.test(repositorySha)) {
+    throw new Error(`Invalid repository SHA: ${repositorySha}`);
+  }
+  return `duet-deepswe-${repositorySha.slice(0, 12)}`;
+}

--- a/benchmarks/deepswe/e2b/template.ts
+++ b/benchmarks/deepswe/e2b/template.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+import { execFile } from "node:child_process";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { defaultBuildLogger, Template } from "e2b";
+
+import { deepSweTemplateName, shellQuote } from "./support.js";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const REPOSITORY_URL = "https://github.com/dzhng/duet-agent.git";
+const REQUEST_TIMEOUT_MS = 180_000;
+
+/** Build one immutable Docker-in-Docker worker image for the DeepSWE pilot. */
+export async function buildDeepSweTemplate(): Promise<{
+  name: string;
+  templateId?: string;
+  repositorySha: string;
+}> {
+  const [{ stdout: sha }, { stdout: status }] = await Promise.all([
+    execFileAsync("git", ["rev-parse", "HEAD"], { cwd: REPO_ROOT }),
+    execFileAsync("git", ["status", "--porcelain"], { cwd: REPO_ROOT }),
+  ]);
+  if (status.trim()) throw new Error("E2B template build requires a clean committed worktree.");
+  const repositorySha = sha.trim();
+  const name = deepSweTemplateName(repositorySha);
+  if (await Template.exists(name, { requestTimeoutMs: REQUEST_TIMEOUT_MS })) {
+    return { name, repositorySha };
+  }
+
+  const worktree = "/work/duet-agent";
+  const template = Template()
+    .fromUbuntuImage("24.04")
+    .aptInstall(["ca-certificates", "curl", "git", "python3", "python3-pip", "python3-venv"])
+    .runCmd("curl -fsSL https://get.docker.com | sh")
+    .runCmd("sudo systemctl disable --now docker.service docker.socket")
+    .runCmd(
+      "curl -fsSL https://bun.sh/install | bash -s 'bun-v1.3.11' && sudo ln -sf /home/user/.bun/bin/bun /usr/local/bin/bun",
+    )
+    .runCmd(
+      `sudo mkdir -p /work && sudo chown user:user /work && git clone ${shellQuote(REPOSITORY_URL)} ${worktree} && git -C ${worktree} checkout ${shellQuote(repositorySha)}`,
+    )
+    .runCmd(`cd ${worktree} && bun install --frozen-lockfile`)
+    .runCmd(`cd ${worktree} && bun benchmarks/deepswe/cli.ts setup`)
+    .runCmd(`sudo usermod -aG docker user && sudo chown -R user:user ${worktree}`)
+    .setStartCmd(
+      "sudo dockerd --host=unix:///var/run/docker.sock >/tmp/duet-deepswe-dockerd.log 2>&1",
+      "sudo docker info >/dev/null",
+    );
+
+  const built = await Template.build(template, name, {
+    cpuCount: 8,
+    memoryMB: 16_384,
+    requestTimeoutMs: REQUEST_TIMEOUT_MS,
+    onBuildLogs: defaultBuildLogger(),
+  });
+  return { name, templateId: built.templateId, repositorySha };
+}
+
+if (import.meta.main) {
+  const built = await buildDeepSweTemplate();
+  console.log(`E2B template ${built.name} is ready for Duet ${built.repositorySha.slice(0, 12)}.`);
+}

--- a/benchmarks/deepswe/e2b/template.ts
+++ b/benchmarks/deepswe/e2b/template.ts
@@ -11,6 +11,15 @@ const execFileAsync = promisify(execFile);
 const REPO_ROOT = resolve(import.meta.dir, "../../..");
 const REPOSITORY_URL = "https://github.com/dzhng/duet-agent.git";
 const REQUEST_TIMEOUT_MS = 180_000;
+export const DEEPSWE_TEMPLATE_APT_PACKAGES = [
+  "ca-certificates",
+  "curl",
+  "git",
+  "python3",
+  "python3-pip",
+  "python3-venv",
+  "unzip",
+] as const;
 
 /** Build one immutable Docker-in-Docker worker image for the DeepSWE pilot. */
 export async function buildDeepSweTemplate(): Promise<{
@@ -32,7 +41,7 @@ export async function buildDeepSweTemplate(): Promise<{
   const worktree = "/work/duet-agent";
   const template = Template()
     .fromUbuntuImage("24.04")
-    .aptInstall(["ca-certificates", "curl", "git", "python3", "python3-pip", "python3-venv"])
+    .aptInstall([...DEEPSWE_TEMPLATE_APT_PACKAGES])
     .runCmd("curl -fsSL https://get.docker.com | sh")
     .runCmd("sudo systemctl disable --now docker.service docker.socket")
     .runCmd(

--- a/benchmarks/deepswe/manifests/pilot-10-seed-0.json
+++ b/benchmarks/deepswe/manifests/pilot-10-seed-0.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": 1,
+  "upstream": {
+    "repository": "https://github.com/datacurve-ai/deep-swe.git",
+    "commit": "e016041a6ccf8da29906afc9a3f5a8df940a1f78"
+  },
+  "pier": {
+    "version": "0.3.0",
+    "repository": "https://github.com/datacurve-ai/pier.git",
+    "commit": "fefa7475a32bb05271abdea378e8083c83eb5c35"
+  },
+  "selection": {
+    "corpusSize": 113,
+    "size": 10,
+    "seed": 0,
+    "algorithm": "sort task ids; Python random.Random(seed).shuffle; take prefix"
+  },
+  "tasks": [
+    {
+      "taskId": "true-myth-iterable-collection-combinators",
+      "language": "typescript",
+      "repositoryUrl": "https://github.com/true-myth/true-myth",
+      "baseCommit": "d8fbebc75de4991a32354518beff1abf628d0b07",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh74r2t7kdnt7h2efdk0hf5asx82zr0s-v1.1"
+    },
+    {
+      "taskId": "testem-per-launcher-reports",
+      "language": "javascript",
+      "repositoryUrl": "https://github.com/testem/testem",
+      "baseCommit": "158f61ea91c9613d2011c41ee9be40ada1d7a307",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh7322qjz1xfjspavxy0kamf9h83277p-v1.1"
+    },
+    {
+      "taskId": "tengo-callable-instance-isolation",
+      "language": "go",
+      "repositoryUrl": "https://github.com/d5/tengo",
+      "baseCommit": "3cad0da7a51b1206c6f01e3f4fbb44b976d5275c",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh77n9t7ybdq9387d08jzdp1y183ffe6-v1.1"
+    },
+    {
+      "taskId": "adaptix-name-mapping-aliases",
+      "language": "python",
+      "repositoryUrl": "https://github.com/reagento/adaptix",
+      "baseCommit": "a691069fcadf9131e5f7a5a130a022dc678f3e1d",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh73dq4n55jdxasppe6jjmth4183d47n-v1.1"
+    },
+    {
+      "taskId": "igel-persist-feature-schema",
+      "language": "python",
+      "repositoryUrl": "https://github.com/nidhaloff/igel",
+      "baseCommit": "bf4544d6c86ab4ace21254cb38a011ce3e845700",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh7brwh7cv23ggeshkz85ac5fx831x5k-v1.1"
+    },
+    {
+      "taskId": "koota-query-predicates",
+      "language": "typescript",
+      "repositoryUrl": "https://github.com/pmndrs/koota",
+      "baseCommit": "9c434858b2b522002f8c5eb4a554fa8836a7cf3c",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh7dkes3xb054yt1fd3g6nym5s83bz2h-v1.1"
+    },
+    {
+      "taskId": "opa-template-string-reconstruction",
+      "language": "go",
+      "repositoryUrl": "https://github.com/open-policy-agent/opa",
+      "baseCommit": "1ac64ef1a57a531c2723c59848890b88e816d777",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh7eq7eek21pjhv1zx8c2cmmed82yd7v-v1.1"
+    },
+    {
+      "taskId": "dynamodb-toolbox-conditional-attribute-requirements",
+      "language": "typescript",
+      "repositoryUrl": "https://github.com/dynamodb-toolbox/dynamodb-toolbox",
+      "baseCommit": "1f2a18664f8aded292707fcafb01ff15ea33d3b8",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh79xyw12drtaz3reht4enc2hs83ef6v-v1.1"
+    },
+    {
+      "taskId": "fd-deterministic-multi-key-sorting",
+      "language": "rust",
+      "repositoryUrl": "https://github.com/sharkdp/fd",
+      "baseCommit": "227883606023d62275fb48701aeac90f2b604143",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh79s1ny2ab454f8caet44rv5n82za06-v1.1"
+    },
+    {
+      "taskId": "eicrud-keyset-pagination-cursor",
+      "language": "typescript",
+      "repositoryUrl": "https://github.com/eicrud/eicrud",
+      "baseCommit": "68dafce",
+      "dockerImage": "public.ecr.aws/d3j8x8q7/swe-bench-202605:kh79vgnwnp3wfz0b63ft8zbs81822re8-v1.1"
+    }
+  ]
+}

--- a/benchmarks/deepswe/pier_agent.py
+++ b/benchmarks/deepswe/pier_agent.py
@@ -70,7 +70,13 @@ class DuetAgent(BaseInstalledAgent):
         )
 
     def network_allowlist(self) -> NetworkAllowlist:
-        return NetworkAllowlist(domains=["gateway.duet.so"])
+        return NetworkAllowlist(
+            domains=[
+                "gateway.duet.so",
+                "ai-gateway.vercel.sh",
+                "openrouter.ai",
+            ]
+        )
 
     async def setup(self, environment: BaseEnvironment) -> None:
         directory_result = await environment.exec(

--- a/benchmarks/deepswe/pier_agent.py
+++ b/benchmarks/deepswe/pier_agent.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import shlex
+from pathlib import Path
+from typing import Any
+
+from pier.agents.installed.base import BaseInstalledAgent
+from pier.environments.base import BaseEnvironment
+from pier.models.agent.context import AgentContext
+from pier.models.agent.install import AgentInstallSpec, InstallStep
+from pier.models.agent.network import NetworkAllowlist
+
+
+class DuetAgent(BaseInstalledAgent):
+    """Pier adapter that installs and drives one immutable Duet build."""
+
+    def __init__(
+        self,
+        logs_dir: Path,
+        routing_config_path: str,
+        artifact_manifest_path: str,
+        cost_limit_usd: float,
+        wall_clock_ms: int = 5_300_000,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        self.routing_config_path = Path(routing_config_path).resolve()
+        self.artifact_manifest_path = Path(artifact_manifest_path).resolve()
+        self.artifact_dir = self.artifact_manifest_path.parent
+        self.artifact_manifest = json.loads(
+            self.artifact_manifest_path.read_text(encoding="utf-8")
+        )
+        self.cost_limit_usd = float(cost_limit_usd)
+        self.wall_clock_ms = int(wall_clock_ms)
+        if self.cost_limit_usd <= 0:
+            raise ValueError("cost_limit_usd must be positive")
+        if self.wall_clock_ms <= 0:
+            raise ValueError("wall_clock_ms must be positive")
+        for file_info in [
+            self.artifact_manifest["duet"],
+            self.artifact_manifest["driver"],
+            *self.artifact_manifest["runtimeAssets"],
+        ]:
+            source = self.artifact_dir / file_info["path"]
+            actual = hashlib.sha256(source.read_bytes()).hexdigest()
+            if actual != file_info["sha256"]:
+                raise ValueError(f"Artifact hash changed: {file_info['path']}")
+        super().__init__(
+            logs_dir,
+            version=self.artifact_manifest["duetCommit"],
+            *args,
+            **kwargs,
+        )
+
+    @staticmethod
+    def name() -> str:
+        return "duet"
+
+    def install_spec(self) -> AgentInstallSpec:
+        # The binary is uploaded in setup. A stable no-op spec lets Pier include
+        # the exact Duet payload in its environment build/cache identity.
+        return AgentInstallSpec(
+            agent_name=self.name(),
+            version=self.version(),
+            steps=[InstallStep(run="true", user="root")],
+            cache_key=self.artifact_manifest["duet"]["sha256"],
+        )
+
+    def network_allowlist(self) -> NetworkAllowlist:
+        return NetworkAllowlist(domains=["gateway.duet.so"])
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        directory_result = await environment.exec(
+            command=(
+                "mkdir -p /opt/duet/home/.duet /logs/agent "
+                "&& chmod 777 /opt/duet /opt/duet/home /opt/duet/home/.duet /logs/agent"
+            ),
+            user="root",
+        )
+        if directory_result.return_code != 0:
+            raise RuntimeError(
+                f"Failed to prepare Duet directories: {directory_result.stderr}"
+            )
+        await self._upload_manifest_file(environment, "duet", "/opt/duet/duet")
+        await self._upload_manifest_file(
+            environment, "driver", "/opt/duet/deepswe-agent-driver"
+        )
+        for asset in self.artifact_manifest["runtimeAssets"]:
+            await environment.upload_file(
+                self.artifact_dir / asset["path"], f"/opt/duet/{asset['path']}"
+            )
+        await environment.upload_file(
+            self.routing_config_path, "/opt/duet/home/.duet/models.json"
+        )
+        setup_result = await environment.exec(
+            command=(
+                "chmod 755 /opt/duet/duet /opt/duet/deepswe-agent-driver "
+                "&& chmod 644 /opt/duet/home/.duet/models.json "
+                "/opt/duet/pglite.wasm /opt/duet/pglite.data "
+                "/opt/duet/initdb.wasm /opt/duet/vector.tar.gz"
+            ),
+            user="root",
+        )
+        if setup_result.return_code != 0:
+            raise RuntimeError(f"Failed to install Duet: {setup_result.stderr}")
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        encoded_instruction = base64.b64encode(instruction.encode("utf-8")).decode(
+            "ascii"
+        )
+        command = " ".join(
+            [
+                "/opt/duet/deepswe-agent-driver",
+                "--duet",
+                "/opt/duet/duet",
+                "--instruction-base64",
+                shlex.quote(encoded_instruction),
+                "--events",
+                "/logs/agent/events.ndjson",
+                "--stderr",
+                "/logs/agent/stderr.log",
+                "--summary",
+                "/logs/agent/summary.json",
+                "--cost-usd",
+                shlex.quote(str(self.cost_limit_usd)),
+                "--wall-clock-ms",
+                shlex.quote(str(self.wall_clock_ms)),
+            ]
+        )
+        run_result = None
+        try:
+            run_result = await environment.exec(
+                command=command,
+                cwd="/app",
+                env=environment.agent_process_env(
+                    self.build_process_env(
+                        {
+                            "HOME": "/opt/duet/home",
+                            "CI": "1",
+                            "NO_COLOR": "1",
+                        }
+                    )
+                ),
+            )
+        finally:
+            # DeepSWE's pre_artifacts.sh deliberately captures BASE..HEAD, so
+            # uncommitted changes would otherwise grade as an empty submission.
+            commit_result = await environment.exec(
+                command=(
+                    "git config user.name 'Duet Benchmark' "
+                    "&& git config user.email 'benchmark@duet.so' "
+                    "&& git add -A "
+                    "&& git commit --allow-empty -m 'DeepSWE agent result'"
+                ),
+                cwd="/app",
+            )
+            if commit_result.return_code != 0:
+                raise RuntimeError(
+                    f"Failed to commit DeepSWE agent result: {commit_result.stderr}"
+                )
+        if run_result is None or run_result.return_code != 0:
+            stderr = run_result.stderr if run_result is not None else "driver did not start"
+            raise RuntimeError(f"Duet driver failed: {stderr}")
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        summary_path = self.logs_dir / "summary.json"
+        if not summary_path.exists():
+            self.logger.warning("Duet summary was not collected from the task container")
+            return
+        try:
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            telemetry = summary["telemetry"]
+            tokens = telemetry["tokens"]
+            context.n_input_tokens = int(tokens["input"]) + int(tokens["cacheRead"])
+            context.n_cache_tokens = int(tokens["cacheRead"])
+            context.n_output_tokens = int(tokens["output"])
+            context.cost_usd = float(telemetry["costUsdTotal"])
+            context.n_agent_steps = int(telemetry["steps"])
+            context.metadata = {
+                "terminal": summary["terminal"],
+                "timedOut": summary["timedOut"],
+                "wallClockMs": summary["wallClockMs"],
+                "usageByModel": telemetry["usageByModel"],
+                "advisorCalls": telemetry["advisorCalls"],
+                "routerSwitches": telemetry["routerSwitches"],
+            }
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            # Accounting failure cannot invalidate an otherwise gradeable patch.
+            self.logger.exception("Failed to read Duet usage summary")
+
+    async def _upload_manifest_file(
+        self, environment: BaseEnvironment, key: str, target: str
+    ) -> None:
+        file_info = self.artifact_manifest[key]
+        await environment.upload_file(self.artifact_dir / file_info["path"], target)

--- a/benchmarks/deepswe/src/agent-driver.ts
+++ b/benchmarks/deepswe/src/agent-driver.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env bun
+import { spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { createInterface } from "node:readline";
+import { once } from "node:events";
+
+import {
+  runDuetTurn,
+  type ExecTransport,
+  type RolloutOutcome,
+} from "../../shared/duet-rpc-client.js";
+import { assertGradeableDeepSweOutcome, summarizeDeepSweRun } from "./summary.js";
+
+const args = parseArgs(process.argv.slice(2));
+const instruction = Buffer.from(args.instructionBase64, "base64").toString("utf8");
+await Promise.all([
+  mkdir(dirname(args.eventsPath), { recursive: true }),
+  mkdir(dirname(args.stderrPath), { recursive: true }),
+  mkdir(dirname(args.summaryPath), { recursive: true }),
+]);
+
+const rawEvents = createWriteStream(args.eventsPath, { flags: "a" });
+const rawStderr = createWriteStream(args.stderrPath, { flags: "a" });
+const transport = spawnRpc(
+  [
+    args.duetPath,
+    "--rpc",
+    "--model",
+    "deepswe",
+    "--session",
+    "deepswe",
+    "--workdir",
+    "/app",
+    "--system-prompt",
+    "Resolve the task in the repository and leave the working tree with the complete solution. Work unattended.",
+  ],
+  rawEvents,
+  rawStderr,
+);
+
+let outcome: RolloutOutcome | undefined;
+try {
+  outcome = await runDuetTurn(
+    transport,
+    {
+      limits: {
+        costUsd: args.costLimitUsd,
+        wallClockMs: args.wallClockMs,
+        interruptGraceMs: 90_000,
+      },
+    },
+    instruction,
+  );
+} finally {
+  if (!outcome) await transport.kill();
+  await transport.exited;
+  rawEvents.end();
+  rawStderr.end();
+  await Promise.all([once(rawEvents, "close"), once(rawStderr, "close")]);
+}
+if (!outcome) throw new Error("Duet RPC run ended without an outcome.");
+assertGradeableDeepSweOutcome(outcome);
+await writeFile(args.summaryPath, `${JSON.stringify(summarizeDeepSweRun(outcome), null, 2)}\n`);
+
+interface DriverArgs {
+  duetPath: string;
+  instructionBase64: string;
+  eventsPath: string;
+  stderrPath: string;
+  summaryPath: string;
+  costLimitUsd: number;
+  wallClockMs: number;
+}
+
+function parseArgs(argv: string[]): DriverArgs {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`Malformed agent-driver arguments near ${key ?? "<end>"}.`);
+    }
+    values.set(key, value);
+  }
+  const required = (name: string): string => {
+    const value = values.get(name);
+    if (!value) throw new Error(`Missing ${name}.`);
+    return value;
+  };
+  const positiveNumber = (name: string): number => {
+    const value = Number(required(name));
+    if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be positive.`);
+    return value;
+  };
+  return {
+    duetPath: required("--duet"),
+    instructionBase64: required("--instruction-base64"),
+    eventsPath: required("--events"),
+    stderrPath: required("--stderr"),
+    summaryPath: required("--summary"),
+    costLimitUsd: positiveNumber("--cost-usd"),
+    wallClockMs: positiveNumber("--wall-clock-ms"),
+  };
+}
+
+function spawnRpc(
+  argv: readonly string[],
+  stdoutLog: NodeJS.WritableStream,
+  stderrLog: NodeJS.WritableStream,
+): ExecTransport {
+  const [command, ...commandArgs] = argv;
+  if (!command) throw new Error("Missing Duet executable.");
+  const child = spawn(command, commandArgs, {
+    cwd: "/app",
+    env: {
+      ...process.env,
+      HOME: "/opt/duet/home",
+      CI: "1",
+      NO_COLOR: "1",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stderr.pipe(stderrLog, { end: false });
+  return {
+    stdin: {
+      write: (line) =>
+        new Promise<void>((resolve, reject) => {
+          child.stdin.write(line, (error) => (error ? reject(error) : resolve()));
+        }),
+    },
+    stdoutLines: teeLines(child.stdout, stdoutLog),
+    kill: () => child.kill("SIGKILL"),
+    exited: new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code, signal) => resolve({ code, signal }));
+    }),
+  };
+}
+
+async function* teeLines(
+  stream: NodeJS.ReadableStream,
+  output: NodeJS.WritableStream,
+): AsyncGenerator<string> {
+  const lines = createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) {
+      if (!output.write(`${line}\n`)) await once(output, "drain");
+      yield line;
+    }
+  } finally {
+    lines.close();
+  }
+}

--- a/benchmarks/deepswe/src/budget.ts
+++ b/benchmarks/deepswe/src/budget.ts
@@ -1,0 +1,25 @@
+import { DEEPSWE_ARMS } from "./config.js";
+
+/**
+ * Cushion for one request that finishes after a rollout crosses its soft stop.
+ * This covers the most expensive possible request among the four pinned
+ * configurations: Fable 5 at its 1M context and 128k output ceilings. It is
+ * admission headroom, not a provider-side hard cap: normal Duet subagents can
+ * have more than one request in flight.
+ */
+export const DEEPSWE_SINGLE_REQUEST_CUSHION_USD = 20;
+
+/** Minimum campaign authorization for every soft rollout stop plus a cushion. */
+export function deepSweMinimumBudgetUsd(taskCount: number, costLimitUsd: number): number {
+  if (!Number.isSafeInteger(taskCount) || taskCount < 1) {
+    throw new RangeError("taskCount must be a positive integer.");
+  }
+  if (!Number.isFinite(costLimitUsd) || costLimitUsd <= 0) {
+    throw new RangeError("costLimitUsd must be positive.");
+  }
+  return (
+    taskCount *
+    Object.keys(DEEPSWE_ARMS).length *
+    (costLimitUsd + DEEPSWE_SINGLE_REQUEST_CUSHION_USD)
+  );
+}

--- a/benchmarks/deepswe/src/budget.ts
+++ b/benchmarks/deepswe/src/budget.ts
@@ -2,7 +2,7 @@ import { DEEPSWE_ARMS } from "./config.js";
 
 /**
  * Cushion for one request that finishes after a rollout crosses its soft stop.
- * This covers the most expensive possible request among the four pinned
+ * This covers the most expensive possible request among the pinned
  * configurations: Fable 5 at its 1M context and 128k output ceilings. It is
  * admission headroom, not a provider-side hard cap: normal Duet subagents can
  * have more than one request in flight.

--- a/benchmarks/deepswe/src/config.ts
+++ b/benchmarks/deepswe/src/config.ts
@@ -1,0 +1,113 @@
+import type { ThinkingLevel } from "@earendil-works/pi-ai";
+
+import {
+  BUILT_IN_ROUTING_TABLE,
+  validateRoutingTable,
+  type RoutingTable,
+} from "../../../src/model-routing/table.js";
+import { routingCatalogAdapter } from "../../../src/model-resolution/resolver.js";
+
+export const DEEPSWE_TIER = "deepswe";
+
+export const DEEPSWE_ARMS = {
+  "glm-pure": {
+    executorModel: "glm-5.2",
+    executorThinkingLevel: "xhigh",
+    advisorModel: "kimi-k3",
+    advisorThinkingLevel: "medium",
+    advisorEnabled: false,
+  },
+  "glm-kimi-advisor": {
+    executorModel: "glm-5.2",
+    executorThinkingLevel: "xhigh",
+    advisorModel: "kimi-k3",
+    advisorThinkingLevel: "medium",
+    advisorEnabled: true,
+  },
+  "kimi-pure": {
+    executorModel: "kimi-k3",
+    executorThinkingLevel: "high",
+    advisorModel: "fable-5",
+    advisorThinkingLevel: "high",
+    advisorEnabled: false,
+  },
+  "kimi-fable-advisor": {
+    executorModel: "kimi-k3",
+    executorThinkingLevel: "high",
+    advisorModel: "fable-5",
+    advisorThinkingLevel: "high",
+    advisorEnabled: true,
+  },
+} as const satisfies Record<string, DeepSweArm>;
+
+export type DeepSweArmName = keyof typeof DEEPSWE_ARMS;
+
+export interface DeepSweArm {
+  /** Main coding model used for the complete repository task. */
+  executorModel: "glm-5.2" | "kimi-k3";
+  /** Reasoning effort sent to the executor on every turn. */
+  executorThinkingLevel: ThinkingLevel;
+  /** Advisor target retained unchanged in both members of a pair. */
+  advisorModel: "kimi-k3" | "fable-5";
+  /** Advisor effort retained unchanged in both members of a pair. */
+  advisorThinkingLevel: ThinkingLevel;
+  /** The only treatment variable within a pure/advised pair. */
+  advisorEnabled: boolean;
+}
+
+/**
+ * Build a complete benchmark-owned routing table. Only executor and advisor
+ * targets differ from the product table; classifier and memory behavior remain
+ * the product defaults.
+ */
+export function renderDeepSweConfig(arm: DeepSweArm): RoutingTable {
+  const productRoute = structuredClone(BUILT_IN_ROUTING_TABLE.tiers.economy.routes.implement);
+  const productAdvisor = structuredClone(BUILT_IN_ROUTING_TABLE.tiers.frontier.advisor);
+  const table: RoutingTable = {
+    defaultTier: DEEPSWE_TIER,
+    tiers: {
+      [DEEPSWE_TIER]: {
+        routes: {
+          general: {
+            ...productRoute,
+            target: {
+              modelName: arm.executorModel,
+              thinkingLevel: arm.executorThinkingLevel,
+            },
+            visionFallbackModelName: "kimi-k3",
+          },
+        },
+        advisor: {
+          ...productAdvisor,
+          enabled: arm.advisorEnabled,
+          target: {
+            modelName: arm.advisorModel,
+            thinkingLevel: arm.advisorThinkingLevel,
+          },
+        },
+      },
+    },
+    classifier: structuredClone(BUILT_IN_ROUTING_TABLE.classifier),
+  };
+
+  const issues = validateRoutingTable(table, routingCatalogAdapter);
+  if (issues.length > 0) {
+    throw new Error(
+      `Invalid DeepSWE routing table:\n${issues
+        .map((issue) => `- ${issue.path}: ${issue.message}`)
+        .join("\n")}`,
+    );
+  }
+  return table;
+}
+
+/** Materialize all four arms in their stable experiment order. */
+export function renderDeepSweConfigs(): Record<DeepSweArmName, RoutingTable> {
+  return Object.fromEntries(
+    Object.entries(DEEPSWE_ARMS).map(([name, arm]) => [name, renderDeepSweConfig(arm)]),
+  ) as Record<DeepSweArmName, RoutingTable>;
+}
+
+export function serializeDeepSweConfig(table: RoutingTable): string {
+  return `${JSON.stringify(table, null, 2)}\n`;
+}

--- a/benchmarks/deepswe/src/config.ts
+++ b/benchmarks/deepswe/src/config.ts
@@ -38,13 +38,29 @@ export const DEEPSWE_ARMS = {
     advisorThinkingLevel: "high",
     advisorEnabled: true,
   },
+  "opus-pure": {
+    executorModel: "opus-5",
+    executorThinkingLevel: "xhigh",
+    advisorModel: "fable-5",
+    advisorThinkingLevel: "high",
+    advisorEnabled: false,
+  },
+  "fable-pure": {
+    executorModel: "fable-5",
+    executorThinkingLevel: "high",
+    advisorModel: "fable-5",
+    advisorThinkingLevel: "high",
+    advisorEnabled: false,
+  },
 } as const satisfies Record<string, DeepSweArm>;
 
 export type DeepSweArmName = keyof typeof DEEPSWE_ARMS;
+/** Canonical arm order shared by job generation, completion checks, and reports. */
+export const DEEPSWE_ARM_NAMES = Object.keys(DEEPSWE_ARMS) as DeepSweArmName[];
 
 export interface DeepSweArm {
   /** Main coding model used for the complete repository task. */
-  executorModel: "glm-5.2" | "kimi-k3";
+  executorModel: "fable-5" | "glm-5.2" | "kimi-k3" | "opus-5";
   /** Reasoning effort sent to the executor on every turn. */
   executorThinkingLevel: ThinkingLevel;
   /** Advisor target retained unchanged in both members of a pair. */
@@ -101,10 +117,10 @@ export function renderDeepSweConfig(arm: DeepSweArm): RoutingTable {
   return table;
 }
 
-/** Materialize all four arms in their stable experiment order. */
+/** Materialize all six arms in their stable experiment order. */
 export function renderDeepSweConfigs(): Record<DeepSweArmName, RoutingTable> {
   return Object.fromEntries(
-    Object.entries(DEEPSWE_ARMS).map(([name, arm]) => [name, renderDeepSweConfig(arm)]),
+    DEEPSWE_ARM_NAMES.map((name) => [name, renderDeepSweConfig(DEEPSWE_ARMS[name])]),
   ) as Record<DeepSweArmName, RoutingTable>;
 }
 

--- a/benchmarks/deepswe/src/manifest.ts
+++ b/benchmarks/deepswe/src/manifest.ts
@@ -1,0 +1,138 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+export interface DeepSweTask {
+  /** Stable directory name in the pinned DeepSWE task corpus. */
+  taskId: string;
+  /** Primary implementation language declared by DeepSWE. */
+  language: string;
+  /** Upstream repository whose checked-out base is present in the task image. */
+  repositoryUrl: string;
+  /** Repository revision the agent receives. */
+  baseCommit: string;
+  /** Official v1.1 agent image reference used by Pier. */
+  dockerImage: string;
+}
+
+export interface DeepSweManifest {
+  schemaVersion: 1;
+  upstream: { repository: string; commit: string };
+  pier: { version: string; repository: string; commit: string };
+  selection: { corpusSize: number; size: number; seed: number; algorithm: string };
+  tasks: DeepSweTask[];
+}
+
+/** Read and structurally validate the committed pilot population. */
+export async function loadDeepSweManifest(path: string): Promise<DeepSweManifest> {
+  const value = JSON.parse(await readFile(path, "utf8")) as DeepSweManifest;
+  validateManifest(value);
+  return value;
+}
+
+/**
+ * Prove the pinned checkout still contains the exact task identities selected
+ * for the pilot. DeepSWE remains the owner of task bodies and verifiers.
+ */
+export async function verifyDeepSweCheckout(
+  checkoutRoot: string,
+  manifest: DeepSweManifest,
+): Promise<void> {
+  validateManifest(manifest);
+  const gitSha = (await Bun.$`git -C ${checkoutRoot} rev-parse HEAD`.text()).trim();
+  if (gitSha !== manifest.upstream.commit) {
+    throw new Error(`DeepSWE checkout is ${gitSha}, expected ${manifest.upstream.commit}.`);
+  }
+
+  for (const task of manifest.tasks) {
+    const taskTomlPath = join(resolve(checkoutRoot), "tasks", task.taskId, "task.toml");
+    const taskToml = await readFile(taskTomlPath, "utf8");
+    const actual = {
+      language: tomlString(taskToml, "language"),
+      repositoryUrl: tomlString(taskToml, "repository_url"),
+      baseCommit: tomlString(taskToml, "base_commit_hash"),
+      dockerImage: tomlString(taskToml, "docker_image"),
+    };
+    for (const [field, expected] of Object.entries({
+      language: task.language,
+      repositoryUrl: task.repositoryUrl,
+      baseCommit: task.baseCommit,
+      dockerImage: task.dockerImage,
+    })) {
+      if (actual[field as keyof typeof actual] !== expected) {
+        throw new Error(
+          `${task.taskId} ${field} is ${actual[field as keyof typeof actual]}, expected ${expected}.`,
+        );
+      }
+    }
+  }
+}
+
+/** Re-run the documented Python population selector against the pinned corpus. */
+export async function verifyDeepSweSelection(
+  checkoutRoot: string,
+  manifest: DeepSweManifest,
+  pythonPath: string,
+): Promise<void> {
+  validateManifest(manifest);
+  const script = [
+    "import json, pathlib, random, sys",
+    "root = pathlib.Path(sys.argv[1]) / 'tasks'",
+    "seed, size = int(sys.argv[2]), int(sys.argv[3])",
+    "task_ids = sorted(path.name for path in root.iterdir() if path.is_dir())",
+    "random.Random(seed).shuffle(task_ids)",
+    "print(json.dumps({'corpusSize': len(task_ids), 'taskIds': task_ids[:size]}))",
+  ].join("; ");
+  const child = Bun.spawn(
+    [
+      pythonPath,
+      "-c",
+      script,
+      resolve(checkoutRoot),
+      String(manifest.selection.seed),
+      String(manifest.selection.size),
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  if (exitCode !== 0) throw new Error(`DeepSWE population selection failed:\n${stderr}`);
+  const selected = JSON.parse(stdout) as { corpusSize: number; taskIds: string[] };
+  if (selected.corpusSize !== manifest.selection.corpusSize) {
+    throw new Error(
+      `DeepSWE corpus has ${selected.corpusSize} tasks, expected ${manifest.selection.corpusSize}.`,
+    );
+  }
+  const expected = manifest.tasks.map((task) => task.taskId);
+  if (JSON.stringify(selected.taskIds) !== JSON.stringify(expected)) {
+    throw new Error("Committed DeepSWE pilot ids do not match the documented seeded selector.");
+  }
+}
+
+function validateManifest(manifest: DeepSweManifest): void {
+  if (manifest.schemaVersion !== 1) throw new Error("Unsupported DeepSWE manifest schema.");
+  if (manifest.tasks.length !== manifest.selection.size || manifest.tasks.length !== 10) {
+    throw new Error("The DeepSWE pilot manifest must contain exactly ten tasks.");
+  }
+  const ids = manifest.tasks.map((task) => task.taskId);
+  if (new Set(ids).size !== ids.length) throw new Error("DeepSWE task ids must be unique.");
+  for (const task of manifest.tasks) {
+    if (!/^[a-z0-9-]+$/.test(task.taskId)) throw new Error(`Unsafe task id: ${task.taskId}`);
+    if (
+      !task.language ||
+      !task.repositoryUrl ||
+      !task.baseCommit ||
+      !task.dockerImage.endsWith("-v1.1")
+    ) {
+      throw new Error(`Incomplete DeepSWE task identity: ${task.taskId}`);
+    }
+  }
+}
+
+function tomlString(source: string, name: string): string {
+  const match = source.match(new RegExp(`^${name} = "([^"]+)"$`, "m"));
+  if (!match?.[1]) throw new Error(`task.toml is missing ${name}.`);
+  return match[1];
+}

--- a/benchmarks/deepswe/src/prepare.ts
+++ b/benchmarks/deepswe/src/prepare.ts
@@ -1,0 +1,105 @@
+import { createReadStream } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+
+import { LocalCommandRunner } from "../../shared/command-runner.js";
+import { prepareDuetArtifact } from "../../shared/duet-packaging.js";
+
+export interface DeepSweArtifactManifest {
+  schemaVersion: 1;
+  duetCommit: string;
+  duet: ArtifactFile;
+  driver: ArtifactFile;
+  runtimeAssets: ArtifactFile[];
+}
+
+export interface ArtifactFile {
+  /** Path relative to the artifact manifest directory. */
+  path: string;
+  sha256: string;
+}
+
+/** Build the immutable Linux payload uploaded by the Pier agent adapter. */
+export async function prepareDeepSweArtifacts(
+  repoRoot: string,
+  outputDir: string,
+): Promise<DeepSweArtifactManifest> {
+  const resolvedRoot = resolve(repoRoot);
+  const resolvedOutput = resolve(outputDir);
+  const commands = new LocalCommandRunner();
+  const status = await commands.run(["git", "status", "--porcelain", "--untracked-files=all"], {
+    cwd: resolvedRoot,
+  });
+  if (status.exitCode !== 0) {
+    throw new Error(`Failed to inspect repository state:\n${status.stderr || status.stdout}`);
+  }
+  assertCleanRepositoryStatus(status.stdout);
+  await mkdir(resolvedOutput, { recursive: true });
+  const artifact = await prepareDuetArtifact({
+    repoRoot: resolvedRoot,
+    outputDir: resolvedOutput,
+  });
+  const driverPath = join(resolvedOutput, "deepswe-agent-driver-linux-x64");
+  const compile = await commands.run(
+    [
+      "bun",
+      "build",
+      join(resolvedRoot, "benchmarks", "deepswe", "src", "agent-driver.ts"),
+      "--compile",
+      "--target=bun-linux-x64",
+      "--outfile",
+      driverPath,
+    ],
+    { cwd: resolvedRoot },
+  );
+  if (compile.exitCode !== 0) {
+    throw new Error(`Failed to compile DeepSWE agent driver:\n${compile.stderr || compile.stdout}`);
+  }
+
+  const manifest: DeepSweArtifactManifest = {
+    schemaVersion: 1,
+    duetCommit: (
+      await commands.run(["git", "rev-parse", "HEAD"], { cwd: resolvedRoot })
+    ).stdout.trim(),
+    duet: await fileIdentity(artifact.localPath, resolvedOutput),
+    driver: await fileIdentity(driverPath, resolvedOutput),
+    runtimeAssets: await Promise.all(
+      artifact.runtimeAssets.map((asset) => fileIdentity(asset.localPath, resolvedOutput)),
+    ),
+  };
+  await writeFile(
+    join(resolvedOutput, "artifact-manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  return manifest;
+}
+
+/** Reject source that cannot be reconstructed from the recorded commit. */
+export function assertCleanRepositoryStatus(status: string): void {
+  if (status.trim()) {
+    throw new Error("DeepSWE artifacts must be prepared from a clean worktree.");
+  }
+}
+
+/** Re-hash every prepared file before a job is allowed to start. */
+export async function verifyDeepSweArtifacts(
+  manifestPath: string,
+): Promise<DeepSweArtifactManifest> {
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as DeepSweArtifactManifest;
+  if (manifest.schemaVersion !== 1) throw new Error("Unsupported DeepSWE artifact manifest.");
+  const root = dirname(resolve(manifestPath));
+  for (const file of [manifest.duet, manifest.driver, ...manifest.runtimeAssets]) {
+    const actual = await fileIdentity(join(root, file.path), root);
+    if (actual.sha256 !== file.sha256) {
+      throw new Error(`Prepared artifact hash changed: ${file.path}.`);
+    }
+  }
+  return manifest;
+}
+
+async function fileIdentity(path: string, root: string): Promise<ArtifactFile> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return { path: relative(root, path), sha256: hash.digest("hex") };
+}

--- a/benchmarks/deepswe/src/report.ts
+++ b/benchmarks/deepswe/src/report.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { DeepSweArmName } from "./config.js";
+import { DEEPSWE_ARM_NAMES, type DeepSweArmName } from "./config.js";
 
 export interface DeepSweResultRow {
   arm: DeepSweArmName;
@@ -30,6 +30,63 @@ export interface DeepSwePairReport {
   neitherResolved: number;
   /** Tasks that cannot enter the paired denominator until both arms finish. */
   missingArms: Array<{ taskId: string; missing: DeepSweArmName[] }>;
+}
+
+export interface DeepSweMissingArms {
+  taskId: string;
+  missing: DeepSweArmName[];
+}
+
+/** Enumerate every absent configured arm before publishing campaign headlines. */
+export function findMissingDeepSweArms(
+  rows: readonly DeepSweResultRow[],
+  expectedTaskIds: readonly string[],
+): DeepSweMissingArms[] {
+  return [...new Set(expectedTaskIds)].flatMap((taskId) => {
+    const completedArms = new Set(
+      rows.filter((row) => row.taskId === taskId).map((row) => row.arm),
+    );
+    const missing = DEEPSWE_ARM_NAMES.filter((arm) => !completedArms.has(arm));
+    return missing.length === 0 ? [] : [{ taskId, missing }];
+  });
+}
+
+/** A task is complete only after every configured arm has one durable outcome. */
+export function hasEveryDeepSweArm(rows: readonly DeepSweResultRow[], taskId: string): boolean {
+  return findMissingDeepSweArms(rows, [taskId]).length === 0;
+}
+
+/** Use the campaign's frozen subset instead of inventing missing rows for the full manifest. */
+export async function loadDeepSweCampaignTaskIds(
+  campaignRoot: string,
+  manifestTaskIds: readonly string[],
+): Promise<string[]> {
+  const path = join(campaignRoot, "campaign.json");
+  const campaign = await readFile(path, "utf8")
+    .then((value) => JSON.parse(value) as { taskIds?: unknown })
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined;
+      throw error;
+    });
+  if (!campaign) return [...manifestTaskIds];
+  if (
+    !Array.isArray(campaign.taskIds) ||
+    campaign.taskIds.length === 0 ||
+    !campaign.taskIds.every((taskId): taskId is string => typeof taskId === "string")
+  ) {
+    throw new Error(`Invalid DeepSWE campaign taskIds in ${path}.`);
+  }
+  const taskIds = [...new Set(campaign.taskIds)];
+  if (taskIds.length !== campaign.taskIds.length) {
+    throw new Error(`Duplicate DeepSWE campaign taskId in ${path}.`);
+  }
+  const manifestSet = new Set(manifestTaskIds);
+  for (const taskId of taskIds) {
+    if (!manifestSet.has(taskId)) {
+      throw new Error(`DeepSWE campaign task is not in the frozen manifest: ${taskId}.`);
+    }
+  }
+  return taskIds;
 }
 
 /** Load Pier's official trial records without reproducing its scoring logic. */
@@ -74,7 +131,7 @@ export function isRetryableInfrastructureException(exception: string | undefined
 /** Aggregate resolve rate and cost efficiency from official Pier trial rows. */
 export function buildDeepSweReport(rows: readonly DeepSweResultRow[]): DeepSweArmReport[] {
   assertCompleteCostAccounting(rows);
-  const arms = [...new Set(rows.map((row) => row.arm))];
+  const arms = DEEPSWE_ARM_NAMES.filter((arm) => rows.some((row) => row.arm === arm));
   return arms.map((arm) => {
     const armRows = rows.filter((row) => row.arm === arm);
     const resolved = armRows.filter((row) => row.resolved).length;
@@ -186,10 +243,5 @@ async function walk(root: string): Promise<string[]> {
 }
 
 function isArmName(value: string | undefined): value is DeepSweArmName {
-  return (
-    value === "glm-pure" ||
-    value === "glm-kimi-advisor" ||
-    value === "kimi-pure" ||
-    value === "kimi-fable-advisor"
-  );
+  return value !== undefined && DEEPSWE_ARM_NAMES.some((arm) => arm === value);
 }

--- a/benchmarks/deepswe/src/report.ts
+++ b/benchmarks/deepswe/src/report.ts
@@ -1,0 +1,195 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { DeepSweArmName } from "./config.js";
+
+export interface DeepSweResultRow {
+  arm: DeepSweArmName;
+  taskId: string;
+  resolved: boolean;
+  costUsd: number | null;
+  exception?: string;
+}
+
+export interface DeepSweArmReport {
+  arm: DeepSweArmName;
+  completed: number;
+  resolved: number;
+  resolveRate: number;
+  totalCostUsd: number;
+  costPerTaskUsd: number;
+  costPerResolvedUsd: number | null;
+}
+
+export interface DeepSwePairReport {
+  pair: "glm" | "kimi";
+  completedTasks: number;
+  bothResolved: number;
+  advisorOnly: number;
+  pureOnlyRegression: number;
+  neitherResolved: number;
+  /** Tasks that cannot enter the paired denominator until both arms finish. */
+  missingArms: Array<{ taskId: string; missing: DeepSweArmName[] }>;
+}
+
+/** Load Pier's official trial records without reproducing its scoring logic. */
+export async function loadDeepSweResults(jobsRoot: string): Promise<DeepSweResultRow[]> {
+  const resultPaths = (await walk(jobsRoot)).filter((path) => path.endsWith("/result.json"));
+  const rows = await Promise.all(
+    resultPaths.map(async (path): Promise<DeepSweResultRow | undefined> => {
+      const result = JSON.parse(await readFile(path, "utf8")) as PierTrialResult;
+      if (!result.task_name || !result.agent_info?.model_info?.name) return undefined;
+      const arm = result.agent_info.model_info?.name;
+      if (!isArmName(arm)) throw new Error(`Unknown DeepSWE arm in ${path}: ${arm ?? "missing"}`);
+      const exception = result.exception_info?.exception_type;
+      if (isRetryableInfrastructureException(exception)) return undefined;
+      return {
+        arm,
+        taskId: result.task_name.replace(/^datacurve\//, ""),
+        resolved: result.verifier_result?.rewards?.reward === 1,
+        costUsd: result.agent_result?.cost_usd ?? null,
+        ...(exception ? { exception } : {}),
+      };
+    }),
+  );
+  return rows.filter((row): row is DeepSweResultRow => row !== undefined);
+}
+
+const NON_RETRYABLE_OUTCOME_EXCEPTIONS = new Set([
+  "AgentTimeoutError",
+  "VerifierTimeoutError",
+  "RewardFileNotFoundError",
+  "RewardFileEmptyError",
+  "VerifierOutputParseError",
+]);
+
+/**
+ * Match Pier 0.3.0's retry policy: model/verifier outcomes stay final while
+ * environment, setup, adapter, and process failures remain resumable.
+ */
+export function isRetryableInfrastructureException(exception: string | undefined): boolean {
+  return exception !== undefined && !NON_RETRYABLE_OUTCOME_EXCEPTIONS.has(exception);
+}
+
+/** Aggregate resolve rate and cost efficiency from official Pier trial rows. */
+export function buildDeepSweReport(rows: readonly DeepSweResultRow[]): DeepSweArmReport[] {
+  assertCompleteCostAccounting(rows);
+  const arms = [...new Set(rows.map((row) => row.arm))];
+  return arms.map((arm) => {
+    const armRows = rows.filter((row) => row.arm === arm);
+    const resolved = armRows.filter((row) => row.resolved).length;
+    const totalCostUsd = armRows.reduce((total, row) => total + row.costUsd!, 0);
+    return {
+      arm,
+      completed: armRows.length,
+      resolved,
+      resolveRate: armRows.length === 0 ? 0 : resolved / armRows.length,
+      totalCostUsd,
+      costPerTaskUsd: armRows.length === 0 ? 0 : totalCostUsd / armRows.length,
+      costPerResolvedUsd: resolved === 0 ? null : totalCostUsd / resolved,
+    };
+  });
+}
+
+/** Cost headlines are invalid if any completed Pier row lacks Duet accounting. */
+export function assertCompleteCostAccounting(rows: readonly DeepSweResultRow[]): void {
+  const missing = rows.filter((row) => row.costUsd === null);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing DeepSWE cost accounting:\n${missing
+        .map((row) => `- ${row.taskId}/${row.arm}`)
+        .join("\n")}`,
+    );
+  }
+}
+
+/** Build paired outcome categories without admitting incomplete task pairs. */
+export function buildDeepSwePairedReport(
+  rows: readonly DeepSweResultRow[],
+  expectedTaskIds: readonly string[] = [...new Set(rows.map((row) => row.taskId))],
+): DeepSwePairReport[] {
+  const identities = new Set<string>();
+  for (const row of rows) {
+    const identity = `${row.taskId}\0${row.arm}`;
+    if (identities.has(identity)) {
+      throw new Error(`Duplicate DeepSWE result for ${row.taskId}/${row.arm}.`);
+    }
+    identities.add(identity);
+  }
+  return [
+    paired(rows, expectedTaskIds, "glm", "glm-pure", "glm-kimi-advisor"),
+    paired(rows, expectedTaskIds, "kimi", "kimi-pure", "kimi-fable-advisor"),
+  ];
+}
+
+interface PierTrialResult {
+  task_name?: string;
+  agent_info?: { model_info?: { name?: string } };
+  agent_result?: { cost_usd?: number | null };
+  verifier_result?: { rewards?: { reward?: number } };
+  exception_info?: { exception_type?: string };
+}
+
+function paired(
+  rows: readonly DeepSweResultRow[],
+  expectedTaskIds: readonly string[],
+  pair: DeepSwePairReport["pair"],
+  pureArm: DeepSweArmName,
+  advisedArm: DeepSweArmName,
+): DeepSwePairReport {
+  const relevant = rows.filter((row) => row.arm === pureArm || row.arm === advisedArm);
+  const taskIds = [...new Set(expectedTaskIds)].sort();
+  const report: DeepSwePairReport = {
+    pair,
+    completedTasks: 0,
+    bothResolved: 0,
+    advisorOnly: 0,
+    pureOnlyRegression: 0,
+    neitherResolved: 0,
+    missingArms: [],
+  };
+  for (const taskId of taskIds) {
+    const pure = relevant.find((row) => row.taskId === taskId && row.arm === pureArm);
+    const advised = relevant.find((row) => row.taskId === taskId && row.arm === advisedArm);
+    const missing = [
+      ...(!pure ? [pureArm] : []),
+      ...(!advised ? [advisedArm] : []),
+    ] as DeepSweArmName[];
+    if (missing.length > 0) {
+      report.missingArms.push({ taskId, missing });
+      continue;
+    }
+    report.completedTasks += 1;
+    if (pure.resolved && advised.resolved) report.bothResolved += 1;
+    else if (!pure.resolved && advised.resolved) report.advisorOnly += 1;
+    else if (pure.resolved && !advised.resolved) report.pureOnlyRegression += 1;
+    else report.neitherResolved += 1;
+  }
+  return report;
+}
+
+async function walk(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true }).catch(
+    (error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return [];
+      throw error;
+    },
+  );
+  return (
+    await Promise.all(
+      entries.map((entry) => {
+        const path = join(root, entry.name);
+        return entry.isDirectory() ? walk(path) : [path];
+      }),
+    )
+  ).flat();
+}
+
+function isArmName(value: string | undefined): value is DeepSweArmName {
+  return (
+    value === "glm-pure" ||
+    value === "glm-kimi-advisor" ||
+    value === "kimi-pure" ||
+    value === "kimi-fable-advisor"
+  );
+}

--- a/benchmarks/deepswe/src/summary.ts
+++ b/benchmarks/deepswe/src/summary.ts
@@ -1,0 +1,52 @@
+import type { TurnEvent } from "../../../src/types/protocol.js";
+import { deriveTelemetry, type RolloutTelemetry } from "../../shared/rollout-telemetry.js";
+import type { RolloutOutcome } from "../../shared/duet-rpc-client.js";
+
+/** Compact metrics Pier records beside DeepSWE's authoritative reward. */
+export interface DeepSweRunSummary {
+  schemaVersion: 1;
+  terminal: RolloutTelemetry["terminalStatus"] | "killed";
+  timedOut: boolean;
+  killedReason?: RolloutOutcome["killedReason"];
+  wallClockMs: number;
+  telemetry: RolloutTelemetry;
+}
+
+/**
+ * Derive accounting from the latest cumulative wire usage. The raw NDJSON
+ * remains the source of truth and is retained independently.
+ */
+export function summarizeDeepSweRun(outcome: RolloutOutcome): DeepSweRunSummary {
+  const telemetry = deriveTelemetry(outcome.events);
+  return {
+    schemaVersion: 1,
+    terminal: outcome.terminal === "killed" ? "killed" : telemetry.terminalStatus,
+    timedOut: outcome.timedOut,
+    ...(outcome.killedReason ? { killedReason: outcome.killedReason } : {}),
+    wallClockMs: outcome.wallClockMs,
+    telemetry,
+  };
+}
+
+/** A crashed RPC process is infrastructure, while deliberate limit stops remain gradeable. */
+export function assertGradeableDeepSweOutcome(outcome: RolloutOutcome): void {
+  if (outcome.killedReason === "process_exit") {
+    throw new Error("Duet RPC process exited before emitting a terminal event.");
+  }
+}
+
+/** Parse an append-only RPC ledger without rejecting unknown event variants. */
+export function parseKnownEvents(lines: readonly string[]): TurnEvent[] {
+  return lines.flatMap((line) => {
+    try {
+      const value: unknown = JSON.parse(line);
+      return value &&
+        typeof value === "object" &&
+        typeof (value as { type?: unknown }).type === "string"
+        ? [value as TurnEvent]
+        : [];
+    } catch {
+      return [];
+    }
+  });
+}

--- a/benchmarks/deepswe/src/summary.ts
+++ b/benchmarks/deepswe/src/summary.ts
@@ -17,7 +17,7 @@ export interface DeepSweRunSummary {
  * remains the source of truth and is retained independently.
  */
 export function summarizeDeepSweRun(outcome: RolloutOutcome): DeepSweRunSummary {
-  const telemetry = deriveTelemetry(outcome.events);
+  const telemetry = deriveTelemetry(outcome.events, { repositoryRoot: "/app" });
   return {
     schemaVersion: 1,
     terminal: outcome.terminal === "killed" ? "killed" : telemetry.terminalStatus,

--- a/benchmarks/deepswe/src/timing.ts
+++ b/benchmarks/deepswe/src/timing.ts
@@ -1,0 +1,24 @@
+import { DEEPSWE_ARMS } from "./config.js";
+
+/** Pier ceiling for one Duet agent invocation. */
+export const DEEPSWE_AGENT_TIMEOUT_SEC = 5_400;
+/** Driver stop requested before Pier's outer agent timeout. */
+export const DEEPSWE_AGENT_WALL_CLOCK_MS = 5_300_000;
+/** Official pilot tasks give their separate verifier up to 30 minutes. */
+export const DEEPSWE_VERIFIER_TIMEOUT_SEC = 1_800;
+/** Official task and separate-verifier environment build ceilings. */
+export const DEEPSWE_ENVIRONMENT_BUILD_TIMEOUT_SEC = 1_800;
+export const DEEPSWE_VERIFIER_ENVIRONMENT_BUILD_TIMEOUT_SEC = 1_800;
+/** Agent setup, artifact collection, and commit allowance per trial. */
+const DEEPSWE_TRIAL_OVERHEAD_MS = 15 * 60_000;
+/** Four arms run sequentially within one task sandbox. */
+export const DEEPSWE_WORKER_COMMAND_TIMEOUT_MS =
+  Object.keys(DEEPSWE_ARMS).length *
+  ((DEEPSWE_AGENT_TIMEOUT_SEC +
+    DEEPSWE_VERIFIER_TIMEOUT_SEC +
+    DEEPSWE_ENVIRONMENT_BUILD_TIMEOUT_SEC +
+    DEEPSWE_VERIFIER_ENVIRONMENT_BUILD_TIMEOUT_SEC) *
+    1_000 +
+    DEEPSWE_TRIAL_OVERHEAD_MS);
+/** E2B lifetime includes controller-side archive transfer and teardown headroom. */
+export const DEEPSWE_WORKER_TIMEOUT_MS = DEEPSWE_WORKER_COMMAND_TIMEOUT_MS + 10 * 60_000;

--- a/benchmarks/deepswe/src/timing.ts
+++ b/benchmarks/deepswe/src/timing.ts
@@ -11,7 +11,7 @@ export const DEEPSWE_ENVIRONMENT_BUILD_TIMEOUT_SEC = 1_800;
 export const DEEPSWE_VERIFIER_ENVIRONMENT_BUILD_TIMEOUT_SEC = 1_800;
 /** Agent setup, artifact collection, and commit allowance per trial. */
 const DEEPSWE_TRIAL_OVERHEAD_MS = 15 * 60_000;
-/** Four arms run sequentially within one task sandbox. */
+/** All configured arms run sequentially within one task sandbox. */
 export const DEEPSWE_WORKER_COMMAND_TIMEOUT_MS =
   Object.keys(DEEPSWE_ARMS).length *
   ((DEEPSWE_AGENT_TIMEOUT_SEC +

--- a/benchmarks/deepswe/test.sh
+++ b/benchmarks/deepswe/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+docker run --rm \
+  -v "$REPO_ROOT:/src:ro" \
+  -w /work \
+  -e HOME=/tmp/home \
+  -e DUET_TEST_IN_DOCKER=1 \
+  oven/bun:1.3.11 \
+  sh -lc '
+    apt-get update -qq
+    apt-get install -y -qq git python3 >/dev/null
+    tar -C /src \
+      --exclude="./.env*" \
+      --exclude=./.git \
+      --exclude=./benchmarks/deepswe/.cache \
+      --exclude=./benchmarks/deepswe/.venv \
+      --exclude=./benchmarks/deepswe/outputs \
+      --exclude=./benchmarks/deepswe/runtime \
+      --exclude=./benchmarks/swebench/.cache \
+      --exclude=./benchmarks/swebench/.venv \
+      --exclude=./benchmarks/swebench/runs \
+      --exclude=./dist \
+      --exclude=./node_modules \
+      -cf - . |
+      tar -C /work -xf -
+    bun install --frozen-lockfile >/dev/null
+    bun test ./benchmarks/deepswe/test/*.test.ts
+  '

--- a/benchmarks/deepswe/test/agent-driver.test.ts
+++ b/benchmarks/deepswe/test/agent-driver.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect } from "bun:test";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { testIfDocker } from "../../../test/helpers/docker-only.js";
+
+describe("DeepSWE in-container driver", () => {
+  testIfDocker("preserves raw wire lines and derives final cumulative usage", async () => {
+    const root = await mkdtemp(join(tmpdir(), "deepswe-driver-"));
+    const fakeDuet = join(root, "fake-duet");
+    const events = join(root, "events.ndjson");
+    const stderr = join(root, "stderr.log");
+    const summary = join(root, "summary.json");
+    await mkdir("/app", { recursive: true });
+    await writeFile(
+      fakeDuet,
+      [
+        "#!/bin/sh",
+        "read start",
+        "read prompt",
+        "echo 'banner' >&2",
+        `echo '{"type":"future_protocol_event","kept":true}'`,
+        `echo '{"type":"complete","status":"completed","turnUsage":{"input":10,"output":2,"cacheRead":3,"cacheWrite":0,"totalTokens":15,"cost":{"input":1,"output":0.5,"cacheRead":0.1,"cacheWrite":0,"total":1.6}},"usageByModel":[{"model":"executor","usage":{"input":10,"output":2,"cacheRead":3,"cacheWrite":0,"totalTokens":15,"cost":{"input":1,"output":0.5,"cacheRead":0.1,"cacheWrite":0,"total":1.6}}}]}'`,
+        "",
+      ].join("\n"),
+    );
+    await chmod(fakeDuet, 0o755);
+    const child = Bun.spawn(
+      [
+        "bun",
+        join(import.meta.dir, "../src/agent-driver.ts"),
+        "--duet",
+        fakeDuet,
+        "--instruction-base64",
+        Buffer.from("fix it").toString("base64"),
+        "--events",
+        events,
+        "--stderr",
+        stderr,
+        "--summary",
+        summary,
+        "--cost-usd",
+        "10",
+        "--wall-clock-ms",
+        "10000",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const [exitCode, processStderr] = await Promise.all([
+      child.exited,
+      new Response(child.stderr).text(),
+    ]);
+    expect(exitCode, processStderr).toBe(0);
+    expect(await readFile(events, "utf8")).toContain(
+      '{"type":"future_protocol_event","kept":true}',
+    );
+    expect(await readFile(stderr, "utf8")).toContain("banner");
+    expect(JSON.parse(await readFile(summary, "utf8"))).toMatchObject({
+      terminal: "completed",
+      telemetry: {
+        costUsdTotal: 1.6,
+        usageByModel: [{ model: "executor" }],
+      },
+    });
+  });
+});

--- a/benchmarks/deepswe/test/budget.test.ts
+++ b/benchmarks/deepswe/test/budget.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveDuetGatewayModel } from "../../../src/model-resolution/duet-gateway.js";
+import { deepSweMinimumBudgetUsd, DEEPSWE_SINGLE_REQUEST_CUSHION_USD } from "../src/budget.js";
+import {
+  DEEPSWE_AGENT_TIMEOUT_SEC,
+  DEEPSWE_ENVIRONMENT_BUILD_TIMEOUT_SEC,
+  DEEPSWE_VERIFIER_TIMEOUT_SEC,
+  DEEPSWE_VERIFIER_ENVIRONMENT_BUILD_TIMEOUT_SEC,
+  DEEPSWE_WORKER_COMMAND_TIMEOUT_MS,
+  DEEPSWE_WORKER_TIMEOUT_MS,
+} from "../src/timing.js";
+
+describe("DeepSWE paid-run admission", () => {
+  test("reserves one bounded request beyond every soft rollout stop", () => {
+    expect(deepSweMinimumBudgetUsd(10, 10)).toBe(1_200);
+  });
+
+  test("covers the maximum catalog-priced request in every pilot model", () => {
+    for (const modelId of [
+      "zai/glm-5.2",
+      "moonshotai/kimi-k3",
+      "anthropic/claude-fable-5",
+      "openai/gpt-5.6-luna",
+    ]) {
+      const model = resolveDuetGatewayModel(modelId);
+      const highestInputRate = Math.max(
+        model.cost.input,
+        model.cost.cacheRead,
+        model.cost.cacheWrite,
+      );
+      const conservativeRequestCost =
+        (model.contextWindow * highestInputRate + model.maxTokens * model.cost.output) / 1_000_000;
+      expect(conservativeRequestCost).toBeLessThanOrEqual(DEEPSWE_SINGLE_REQUEST_CUSHION_USD);
+    }
+  });
+
+  test("allows all four agent and verifier ceilings plus setup and transfer headroom", () => {
+    const bareTrialCeilingsMs =
+      4 *
+      (DEEPSWE_AGENT_TIMEOUT_SEC +
+        DEEPSWE_VERIFIER_TIMEOUT_SEC +
+        DEEPSWE_ENVIRONMENT_BUILD_TIMEOUT_SEC +
+        DEEPSWE_VERIFIER_ENVIRONMENT_BUILD_TIMEOUT_SEC) *
+      1_000;
+    expect(DEEPSWE_WORKER_COMMAND_TIMEOUT_MS).toBeGreaterThan(bareTrialCeilingsMs);
+    expect(DEEPSWE_WORKER_TIMEOUT_MS).toBeGreaterThan(DEEPSWE_WORKER_COMMAND_TIMEOUT_MS);
+  });
+});

--- a/benchmarks/deepswe/test/budget.test.ts
+++ b/benchmarks/deepswe/test/budget.test.ts
@@ -13,13 +13,14 @@ import {
 
 describe("DeepSWE paid-run admission", () => {
   test("reserves one bounded request beyond every soft rollout stop", () => {
-    expect(deepSweMinimumBudgetUsd(10, 10)).toBe(1_200);
+    expect(deepSweMinimumBudgetUsd(5, 10)).toBe(900);
   });
 
   test("covers the maximum catalog-priced request in every pilot model", () => {
     for (const modelId of [
       "zai/glm-5.2",
       "moonshotai/kimi-k3",
+      "anthropic/claude-opus-5",
       "anthropic/claude-fable-5",
       "openai/gpt-5.6-luna",
     ]) {
@@ -35,9 +36,9 @@ describe("DeepSWE paid-run admission", () => {
     }
   });
 
-  test("allows all four agent and verifier ceilings plus setup and transfer headroom", () => {
+  test("allows all six agent and verifier ceilings plus setup and transfer headroom", () => {
     const bareTrialCeilingsMs =
-      4 *
+      6 *
       (DEEPSWE_AGENT_TIMEOUT_SEC +
         DEEPSWE_VERIFIER_TIMEOUT_SEC +
         DEEPSWE_ENVIRONMENT_BUILD_TIMEOUT_SEC +

--- a/benchmarks/deepswe/test/config.test.ts
+++ b/benchmarks/deepswe/test/config.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { BUILT_IN_ROUTING_TABLE } from "../../../src/model-routing/table.js";
+import { DEEPSWE_TIER, renderDeepSweConfigs, type DeepSweArmName } from "../src/config.js";
+
+describe("DeepSWE model arms", () => {
+  test("pure and advised pairs differ only in advisor availability", () => {
+    const configs = renderDeepSweConfigs();
+    expect(normalize(configs["glm-pure"])).toEqual(normalize(configs["glm-kimi-advisor"]));
+    expect(normalize(configs["kimi-pure"])).toEqual(normalize(configs["kimi-fable-advisor"]));
+  });
+
+  test("keeps product classifier defaults and changes no memory model", () => {
+    for (const config of Object.values(renderDeepSweConfigs())) {
+      expect(config.classifier).toEqual(BUILT_IN_ROUTING_TABLE.classifier);
+      expect(config.defaultTier).toBe(DEEPSWE_TIER);
+      expect(config.tiers[DEEPSWE_TIER]?.routes.general?.visionFallbackModelName).toBe("kimi-k3");
+      expect("memory" in config).toBe(false);
+    }
+  });
+});
+
+function normalize(
+  config: ReturnType<typeof renderDeepSweConfigs>[DeepSweArmName],
+): ReturnType<typeof renderDeepSweConfigs>[DeepSweArmName] {
+  const value = structuredClone(config);
+  const advisor = value.tiers[DEEPSWE_TIER]?.advisor;
+  if (!advisor) throw new Error("Missing DeepSWE advisor.");
+  advisor.enabled = false;
+  return value;
+}

--- a/benchmarks/deepswe/test/config.test.ts
+++ b/benchmarks/deepswe/test/config.test.ts
@@ -4,6 +4,27 @@ import { BUILT_IN_ROUTING_TABLE } from "../../../src/model-routing/table.js";
 import { DEEPSWE_TIER, renderDeepSweConfigs, type DeepSweArmName } from "../src/config.js";
 
 describe("DeepSWE model arms", () => {
+  test("materializes the six requested executor treatments", () => {
+    const configs = renderDeepSweConfigs();
+
+    expect(Object.keys(configs)).toEqual([
+      "glm-pure",
+      "glm-kimi-advisor",
+      "kimi-pure",
+      "kimi-fable-advisor",
+      "opus-pure",
+      "fable-pure",
+    ]);
+    expect(configs["opus-pure"].tiers[DEEPSWE_TIER]?.routes.general?.target).toEqual({
+      modelName: "opus-5",
+      thinkingLevel: "xhigh",
+    });
+    expect(configs["fable-pure"].tiers[DEEPSWE_TIER]?.routes.general?.target).toEqual({
+      modelName: "fable-5",
+      thinkingLevel: "high",
+    });
+  });
+
   test("pure and advised pairs differ only in advisor availability", () => {
     const configs = renderDeepSweConfigs();
     expect(normalize(configs["glm-pure"])).toEqual(normalize(configs["glm-kimi-advisor"]));

--- a/benchmarks/deepswe/test/job.test.ts
+++ b/benchmarks/deepswe/test/job.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect } from "bun:test";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { testIfDocker } from "../../../test/helpers/docker-only.js";
+
+describe("DeepSWE Pier job generation", () => {
+  testIfDocker("forwards the available model gateway credential into every arm", async () => {
+    const root = await mkdtemp(join(tmpdir(), "deepswe-job-"));
+    const output = join(root, "job.json");
+    const child = Bun.spawn(
+      [
+        "bun",
+        "benchmarks/deepswe/cli.ts",
+        "job",
+        "--name",
+        "credential-fixture",
+        "--cost-limit-usd",
+        "1",
+        "--output",
+        output,
+      ],
+      {
+        cwd: join(import.meta.dir, "../../.."),
+        env: {
+          ...process.env,
+          DUET_API_KEY: undefined,
+          OPENROUTER_API_KEY: undefined,
+          AI_GATEWAY_API_KEY: "fixture-vercel-key",
+        },
+        stdout: "ignore",
+        stderr: "pipe",
+      },
+    );
+    const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+    expect(exitCode, stderr).toBe(0);
+
+    const job = JSON.parse(await readFile(output, "utf8")) as {
+      agents: Array<{ env: Record<string, string> }>;
+    };
+    expect(job.agents.map((agent) => agent.env)).toEqual(
+      Array.from({ length: 6 }, () => ({
+        AI_GATEWAY_API_KEY: "${AI_GATEWAY_API_KEY}",
+      })),
+    );
+  });
+});

--- a/benchmarks/deepswe/test/manifest.test.ts
+++ b/benchmarks/deepswe/test/manifest.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { testIfDocker } from "../../../test/helpers/docker-only.js";
+import {
+  loadDeepSweManifest,
+  verifyDeepSweCheckout,
+  type DeepSweManifest,
+} from "../src/manifest.js";
+
+const MANIFEST_PATH = join(import.meta.dir, "../manifests/pilot-10-seed-0.json");
+
+describe("DeepSWE pilot manifest", () => {
+  testIfDocker("pins ten distinct official v1.1 task identities", async () => {
+    const manifest = await loadDeepSweManifest(MANIFEST_PATH);
+    expect(manifest.tasks).toHaveLength(10);
+    expect(new Set(manifest.tasks.map((task) => task.taskId)).size).toBe(10);
+    expect(new Set(manifest.tasks.map((task) => task.language))).toEqual(
+      new Set(["typescript", "javascript", "go", "python", "rust"]),
+    );
+    expect(manifest.tasks.every((task) => task.dockerImage.endsWith("-v1.1"))).toBe(true);
+  });
+
+  testIfDocker("verifies task values rather than only directory counts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "deepswe-manifest-"));
+    const source = await loadDeepSweManifest(MANIFEST_PATH);
+    const manifest: DeepSweManifest = {
+      ...source,
+      tasks: source.tasks.map((task) => ({ ...task })),
+    };
+    await Bun.$`git -C ${root} init -q`;
+    await Bun.$`git -C ${root} config user.email test@example.com`;
+    await Bun.$`git -C ${root} config user.name Test`;
+    for (const task of manifest.tasks) {
+      const taskRoot = join(root, "tasks", task.taskId);
+      await mkdir(taskRoot, { recursive: true });
+      await writeFile(
+        join(taskRoot, "task.toml"),
+        [
+          `[metadata]`,
+          `language = "${task.language}"`,
+          `repository_url = "${task.repositoryUrl}"`,
+          `base_commit_hash = "${task.baseCommit}"`,
+          `[environment]`,
+          `docker_image = "${task.dockerImage}"`,
+          "",
+        ].join("\n"),
+      );
+    }
+    await Bun.$`git -C ${root} add .`;
+    await Bun.$`git -C ${root} commit -qm fixture`;
+    manifest.upstream = {
+      ...manifest.upstream,
+      commit: (await Bun.$`git -C ${root} rev-parse HEAD`.text()).trim(),
+    };
+
+    await expect(verifyDeepSweCheckout(root, manifest)).resolves.toBeUndefined();
+    const first = manifest.tasks[0]!;
+    await writeFile(
+      join(root, "tasks", first.taskId, "task.toml"),
+      [
+        `[metadata]`,
+        `language = "wrong"`,
+        `repository_url = "${first.repositoryUrl}"`,
+        `base_commit_hash = "${first.baseCommit}"`,
+        `[environment]`,
+        `docker_image = "${first.dockerImage}"`,
+        "",
+      ].join("\n"),
+    );
+    await expect(verifyDeepSweCheckout(root, manifest)).rejects.toThrow(
+      `${first.taskId} language is wrong`,
+    );
+  });
+});

--- a/benchmarks/deepswe/test/pier_agent_seam.py
+++ b/benchmarks/deepswe/test/pier_agent_seam.py
@@ -80,6 +80,12 @@ async def main() -> None:
             cost_limit_usd=1,
             model_name="seam",
         )
+        if set(agent.network_allowlist().domains) != {
+            "ai-gateway.vercel.sh",
+            "gateway.duet.so",
+            "openrouter.ai",
+        }:
+            raise AssertionError("Pier egress does not cover every supported gateway")
         environment = FakeEnvironment()
         await agent.setup(environment)
         await agent.run("test", environment, AgentContext())

--- a/benchmarks/deepswe/test/pier_agent_seam.py
+++ b/benchmarks/deepswe/test/pier_agent_seam.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from benchmarks.deepswe.pier_agent import DuetAgent
+from pier.models.agent.context import AgentContext
+
+
+class FakeEnvironment:
+    """Minimal Pier seam proving artifact, workdir, commit, and egress behavior."""
+
+    def __init__(self) -> None:
+        self.run_env: dict[str, str] | None = None
+        self.run_cwd: str | None = None
+        self.commands: list[tuple[str, str | None]] = []
+        self.uploads: list[tuple[str, str]] = []
+
+    def agent_process_env(
+        self, env: dict[str, str] | None
+    ) -> dict[str, str] | None:
+        return {**(env or {}), "HTTPS_PROXY": "http://pier-filtered-egress"}
+
+    async def exec(self, command: str, **kwargs):
+        self.commands.append((command, kwargs.get("cwd")))
+        if command.startswith("/opt/duet/deepswe-agent-driver"):
+            self.run_env = kwargs.get("env")
+            self.run_cwd = kwargs.get("cwd")
+        return SimpleNamespace(return_code=0, stdout="", stderr="")
+
+    async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        self.uploads.append((str(source_path), target_path))
+
+
+async def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="duet-deepswe-pier-seam-") as temp:
+        root = Path(temp)
+        logs = root / "logs"
+        logs.mkdir()
+        config = root / "models.json"
+        config.write_text("{}\n", encoding="utf-8")
+        files = []
+        for name in [
+            "duet",
+            "driver",
+            "pglite.wasm",
+            "pglite.data",
+            "initdb.wasm",
+            "vector.tar.gz",
+        ]:
+            path = root / name
+            path.write_text(name, encoding="utf-8")
+            files.append(
+                {
+                    "path": name,
+                    "sha256": hashlib.sha256(name.encode("utf-8")).hexdigest(),
+                }
+            )
+        manifest = root / "artifact-manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "duetCommit": "a" * 40,
+                    "duet": files[0],
+                    "driver": files[1],
+                    "runtimeAssets": files[2:],
+                }
+            ),
+            encoding="utf-8",
+        )
+        agent = DuetAgent(
+            logs,
+            routing_config_path=str(config),
+            artifact_manifest_path=str(manifest),
+            cost_limit_usd=1,
+            model_name="seam",
+        )
+        environment = FakeEnvironment()
+        await agent.setup(environment)
+        await agent.run("test", environment, AgentContext())
+        expected_targets = {
+            "/opt/duet/duet",
+            "/opt/duet/deepswe-agent-driver",
+            "/opt/duet/pglite.wasm",
+            "/opt/duet/pglite.data",
+            "/opt/duet/initdb.wasm",
+            "/opt/duet/vector.tar.gz",
+            "/opt/duet/home/.duet/models.json",
+        }
+        if {target for _, target in environment.uploads} != expected_targets:
+            raise AssertionError("Pier adapter did not upload the exact runtime payload")
+        if environment.run_env is None:
+            raise AssertionError("Duet command did not execute")
+        if environment.run_cwd != "/app":
+            raise AssertionError("Duet did not run in the official task workdir")
+        if environment.run_env.get("HTTPS_PROXY") != "http://pier-filtered-egress":
+            raise AssertionError("Pier filtered-egress proxy did not reach Duet")
+        if environment.run_env.get("HOME") != "/opt/duet/home":
+            raise AssertionError("Duet runtime environment was not retained")
+        if not any(
+            "git commit --allow-empty" in command and cwd == "/app"
+            for command, cwd in environment.commands
+        ):
+            raise AssertionError("Agent work was not committed for pre_artifacts.sh")
+
+
+asyncio.run(main())

--- a/benchmarks/deepswe/test/prepare.test.ts
+++ b/benchmarks/deepswe/test/prepare.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { testIfDocker } from "../../../test/helpers/docker-only.js";
+import { assertCleanRepositoryStatus, verifyDeepSweArtifacts } from "../src/prepare.js";
+
+describe("DeepSWE artifact identity", () => {
+  testIfDocker("rejects source changes that the recorded commit cannot reproduce", () => {
+    expect(() => assertCleanRepositoryStatus(" M src/example.ts\n")).toThrow(
+      "must be prepared from a clean worktree",
+    );
+    expect(() => assertCleanRepositoryStatus("")).not.toThrow();
+  });
+
+  testIfDocker("rejects a prepared file that changed after manifest creation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "deepswe-artifact-"));
+    const paths = ["duet", "driver", "pglite.data"];
+    for (const path of paths) await writeFile(join(root, path), path);
+    const identity = (path: string) => ({
+      path,
+      sha256: createHash("sha256").update(path).digest("hex"),
+    });
+    const manifestPath = join(root, "artifact-manifest.json");
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        duetCommit: "a".repeat(40),
+        duet: identity("duet"),
+        driver: identity("driver"),
+        runtimeAssets: [identity("pglite.data")],
+      }),
+    );
+    await expect(verifyDeepSweArtifacts(manifestPath)).resolves.toBeDefined();
+    await writeFile(join(root, "driver"), "changed");
+    await expect(verifyDeepSweArtifacts(manifestPath)).rejects.toThrow(
+      "Prepared artifact hash changed: driver",
+    );
+  });
+});

--- a/benchmarks/deepswe/test/report.test.ts
+++ b/benchmarks/deepswe/test/report.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { testIfDocker } from "../../../test/helpers/docker-only.js";
+import {
+  buildDeepSwePairedReport,
+  buildDeepSweReport,
+  isRetryableInfrastructureException,
+  loadDeepSweResults,
+  type DeepSweResultRow,
+} from "../src/report.js";
+
+describe("DeepSWE reporting", () => {
+  test("retries infrastructure without retrying model or verifier outcomes", () => {
+    expect(isRetryableInfrastructureException("EnvironmentStartTimeoutError")).toBe(true);
+    expect(isRetryableInfrastructureException("RuntimeError")).toBe(true);
+    expect(isRetryableInfrastructureException("AgentTimeoutError")).toBe(false);
+    expect(isRetryableInfrastructureException("VerifierTimeoutError")).toBe(false);
+    expect(isRetryableInfrastructureException(undefined)).toBe(false);
+  });
+
+  test("treats both-resolved as a tie and preserves pure-only regressions", () => {
+    const rows: DeepSweResultRow[] = [
+      { arm: "glm-pure", taskId: "tie", resolved: true, costUsd: 2 },
+      { arm: "glm-kimi-advisor", taskId: "tie", resolved: true, costUsd: 1 },
+      { arm: "glm-pure", taskId: "regression", resolved: true, costUsd: 2 },
+      { arm: "glm-kimi-advisor", taskId: "regression", resolved: false, costUsd: 1 },
+    ];
+    const report = buildDeepSweReport(rows);
+    expect(report.find((row) => row.arm === "glm-pure")).toMatchObject({
+      resolved: 2,
+      completed: 2,
+      costPerResolvedUsd: 2,
+    });
+    expect(report.find((row) => row.arm === "glm-kimi-advisor")).toMatchObject({
+      resolved: 1,
+      completed: 2,
+      costPerResolvedUsd: 2,
+    });
+    expect(buildDeepSwePairedReport(rows)[0]).toMatchObject({
+      pair: "glm",
+      completedTasks: 2,
+      bothResolved: 1,
+      advisorOnly: 0,
+      pureOnlyRegression: 1,
+      neitherResolved: 0,
+      missingArms: [],
+    });
+  });
+
+  test("excludes incomplete pairs from the denominator and reports their missing arm", () => {
+    const rows: DeepSweResultRow[] = [
+      { arm: "kimi-pure", taskId: "complete", resolved: false, costUsd: 1 },
+      { arm: "kimi-fable-advisor", taskId: "complete", resolved: true, costUsd: 2 },
+      { arm: "kimi-pure", taskId: "incomplete", resolved: true, costUsd: 1 },
+    ];
+    expect(buildDeepSwePairedReport(rows)[1]).toEqual({
+      pair: "kimi",
+      completedTasks: 1,
+      bothResolved: 0,
+      advisorOnly: 1,
+      pureOnlyRegression: 0,
+      neitherResolved: 0,
+      missingArms: [{ taskId: "incomplete", missing: ["kimi-fable-advisor"] }],
+    });
+  });
+
+  test("rejects a cost headline when a completed row has no accounting", () => {
+    expect(() =>
+      buildDeepSweReport([
+        { arm: "glm-pure", taskId: "missing-cost", resolved: false, costUsd: null },
+      ]),
+    ).toThrow("missing-cost/glm-pure");
+  });
+
+  testIfDocker("ignores Pier's job-level result and loads only trial records", async () => {
+    const root = await mkdtemp(join(tmpdir(), "deepswe-report-"));
+    const trialRoot = join(root, "job", "trial");
+    const infrastructureRoot = join(root, "job", "infrastructure");
+    await mkdir(trialRoot, { recursive: true });
+    await mkdir(infrastructureRoot, { recursive: true });
+    await writeFile(join(root, "job", "result.json"), JSON.stringify({ n_trials: 1 }));
+    await writeFile(
+      join(trialRoot, "result.json"),
+      JSON.stringify({
+        task_name: "datacurve/example-task",
+        agent_info: { model_info: { name: "glm-pure" } },
+        agent_result: { cost_usd: 1.25 },
+        verifier_result: { rewards: { reward: 1 } },
+      }),
+    );
+    await writeFile(
+      join(infrastructureRoot, "result.json"),
+      JSON.stringify({
+        task_name: "datacurve/example-task",
+        agent_info: { model_info: { name: "glm-kimi-advisor" } },
+        exception_info: { exception_type: "EnvironmentStartTimeoutError" },
+      }),
+    );
+    expect(await loadDeepSweResults(root)).toEqual([
+      {
+        arm: "glm-pure",
+        taskId: "example-task",
+        resolved: true,
+        costUsd: 1.25,
+      },
+    ]);
+  });
+});

--- a/benchmarks/deepswe/test/report.test.ts
+++ b/benchmarks/deepswe/test/report.test.ts
@@ -7,12 +7,40 @@ import { testIfDocker } from "../../../test/helpers/docker-only.js";
 import {
   buildDeepSwePairedReport,
   buildDeepSweReport,
+  findMissingDeepSweArms,
   isRetryableInfrastructureException,
+  loadDeepSweCampaignTaskIds,
   loadDeepSweResults,
   type DeepSweResultRow,
 } from "../src/report.js";
 
 describe("DeepSWE reporting", () => {
+  test("rejects a headline when standalone pure baselines are missing", () => {
+    const rows: DeepSweResultRow[] = [
+      { arm: "glm-pure", taskId: "task", resolved: true, costUsd: 1 },
+      { arm: "glm-kimi-advisor", taskId: "task", resolved: true, costUsd: 1 },
+      { arm: "kimi-pure", taskId: "task", resolved: true, costUsd: 1 },
+      { arm: "kimi-fable-advisor", taskId: "task", resolved: true, costUsd: 1 },
+    ];
+
+    expect(findMissingDeepSweArms(rows, ["task"])).toEqual([
+      { taskId: "task", missing: ["opus-pure", "fable-pure"] },
+    ]);
+  });
+
+  testIfDocker("uses the frozen campaign subset as the paired denominator", async () => {
+    const root = await mkdtemp(join(tmpdir(), "deepswe-campaign-"));
+    await writeFile(
+      join(root, "campaign.json"),
+      JSON.stringify({ taskIds: ["task-one", "task-two"] }),
+    );
+
+    expect(await loadDeepSweCampaignTaskIds(root, ["task-one", "task-two", "task-three"])).toEqual([
+      "task-one",
+      "task-two",
+    ]);
+  });
+
   test("retries infrastructure without retrying model or verifier outcomes", () => {
     expect(isRetryableInfrastructureException("EnvironmentStartTimeoutError")).toBe(true);
     expect(isRetryableInfrastructureException("RuntimeError")).toBe(true);
@@ -78,8 +106,12 @@ describe("DeepSWE reporting", () => {
   testIfDocker("ignores Pier's job-level result and loads only trial records", async () => {
     const root = await mkdtemp(join(tmpdir(), "deepswe-report-"));
     const trialRoot = join(root, "job", "trial");
+    const opusRoot = join(root, "job", "opus");
+    const fableRoot = join(root, "job", "fable");
     const infrastructureRoot = join(root, "job", "infrastructure");
     await mkdir(trialRoot, { recursive: true });
+    await mkdir(opusRoot, { recursive: true });
+    await mkdir(fableRoot, { recursive: true });
     await mkdir(infrastructureRoot, { recursive: true });
     await writeFile(join(root, "job", "result.json"), JSON.stringify({ n_trials: 1 }));
     await writeFile(
@@ -99,13 +131,47 @@ describe("DeepSWE reporting", () => {
         exception_info: { exception_type: "EnvironmentStartTimeoutError" },
       }),
     );
-    expect(await loadDeepSweResults(root)).toEqual([
-      {
-        arm: "glm-pure",
-        taskId: "example-task",
-        resolved: true,
-        costUsd: 1.25,
-      },
-    ]);
+    await writeFile(
+      join(opusRoot, "result.json"),
+      JSON.stringify({
+        task_name: "datacurve/example-task",
+        agent_info: { model_info: { name: "opus-pure" } },
+        agent_result: { cost_usd: 3.5 },
+        verifier_result: { rewards: { reward: 1 } },
+      }),
+    );
+    await writeFile(
+      join(fableRoot, "result.json"),
+      JSON.stringify({
+        task_name: "datacurve/example-task",
+        agent_info: { model_info: { name: "fable-pure" } },
+        agent_result: { cost_usd: 2.5 },
+        verifier_result: { rewards: { reward: 0 } },
+      }),
+    );
+    const rows = await loadDeepSweResults(root);
+    expect(rows).toHaveLength(3);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        {
+          arm: "glm-pure",
+          taskId: "example-task",
+          resolved: true,
+          costUsd: 1.25,
+        },
+        {
+          arm: "fable-pure",
+          taskId: "example-task",
+          resolved: false,
+          costUsd: 2.5,
+        },
+        {
+          arm: "opus-pure",
+          taskId: "example-task",
+          resolved: true,
+          costUsd: 3.5,
+        },
+      ]),
+    );
   });
 });

--- a/benchmarks/deepswe/test/resume.test.ts
+++ b/benchmarks/deepswe/test/resume.test.ts
@@ -4,9 +4,45 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { testIfDocker } from "../../../test/helpers/docker-only.js";
-import { pruneInfrastructureTrials } from "../e2b/run.js";
+import { DEEPSWE_ARM_NAMES } from "../src/config.js";
+import { pruneInfrastructureTrials, taskHasAllOutcomes } from "../e2b/run.js";
 
 describe("DeepSWE infrastructure resume", () => {
+  testIfDocker("requires one durable outcome from every configured arm", async () => {
+    const root = await mkdtemp(join(tmpdir(), "deepswe-completion-"));
+    const jobsRoot = join(root, "jobs");
+    for (const arm of DEEPSWE_ARM_NAMES.slice(0, -1)) {
+      const trial = join(jobsRoot, arm);
+      await mkdir(trial, { recursive: true });
+      await writeFile(
+        join(trial, "result.json"),
+        JSON.stringify({
+          task_name: "datacurve/task",
+          agent_info: { model_info: { name: arm } },
+          agent_result: { cost_usd: 1 },
+          verifier_result: { rewards: { reward: 0 } },
+        }),
+      );
+    }
+
+    expect(await taskHasAllOutcomes(root, "task")).toBe(false);
+
+    const finalArm = DEEPSWE_ARM_NAMES.at(-1)!;
+    const finalTrial = join(jobsRoot, finalArm);
+    await mkdir(finalTrial, { recursive: true });
+    await writeFile(
+      join(finalTrial, "result.json"),
+      JSON.stringify({
+        task_name: "datacurve/task",
+        agent_info: { model_info: { name: finalArm } },
+        agent_result: { cost_usd: 1 },
+        verifier_result: { rewards: { reward: 1 } },
+      }),
+    );
+
+    expect(await taskHasAllOutcomes(root, "task")).toBe(true);
+  });
+
   testIfDocker("removes resumable Pier trials without deleting model outcomes", async () => {
     const root = await mkdtemp(join(tmpdir(), "deepswe-resume-"));
     const infrastructure = join(root, "job", "infrastructure");

--- a/benchmarks/deepswe/test/resume.test.ts
+++ b/benchmarks/deepswe/test/resume.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect } from "bun:test";
+import { access, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { testIfDocker } from "../../../test/helpers/docker-only.js";
+import { pruneInfrastructureTrials } from "../e2b/run.js";
+
+describe("DeepSWE infrastructure resume", () => {
+  testIfDocker("removes resumable Pier trials without deleting model outcomes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "deepswe-resume-"));
+    const infrastructure = join(root, "job", "infrastructure");
+    const modelTimeout = join(root, "job", "model-timeout");
+    await Promise.all([
+      mkdir(infrastructure, { recursive: true }),
+      mkdir(modelTimeout, { recursive: true }),
+    ]);
+    const base = {
+      task_name: "datacurve/task",
+      agent_info: { model_info: { name: "glm-pure" } },
+    };
+    await Promise.all([
+      writeFile(
+        join(infrastructure, "result.json"),
+        JSON.stringify({
+          ...base,
+          exception_info: { exception_type: "EnvironmentStartTimeoutError" },
+        }),
+      ),
+      writeFile(
+        join(modelTimeout, "result.json"),
+        JSON.stringify({
+          ...base,
+          exception_info: { exception_type: "AgentTimeoutError" },
+        }),
+      ),
+    ]);
+
+    expect(await pruneInfrastructureTrials(root)).toBe(1);
+    expect(await exists(infrastructure)).toBe(false);
+    expect(await exists(modelTimeout)).toBe(true);
+  });
+});
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(
+    () => true,
+    () => false,
+  );
+}

--- a/benchmarks/deepswe/test/summary.test.ts
+++ b/benchmarks/deepswe/test/summary.test.ts
@@ -51,6 +51,49 @@ describe("DeepSWE wire accounting", () => {
     expect(events).toEqual([{ type: "future_protocol_event", payload: { stable: true } }]);
   });
 
+  test("locates advisor calls relative to explicit mutations under DeepSWE's /app root", () => {
+    const terminal = {
+      type: "complete",
+      status: "completed",
+      turnUsage: usage(1, 0),
+      usageByModel: [],
+    } as unknown as TurnTerminalEvent;
+    const summary = summarizeDeepSweRun({
+      terminal,
+      events: [
+        {
+          type: "step",
+          step: {
+            type: "tool_call",
+            toolName: "edit",
+            toolCallId: "edit-1",
+            input: { path: "/app/src/index.js" },
+            isError: false,
+          },
+        },
+        {
+          type: "step",
+          step: {
+            type: "tool_call",
+            toolName: "ask_advisor",
+            toolCallId: "advisor-1",
+            input: {},
+            isError: false,
+            details: { type: "ask_advisor", model: "moonshotai/kimi-k3" },
+          },
+        },
+        terminal,
+      ] as TurnEvent[],
+      timedOut: false,
+      wallClockMs: 123,
+    });
+
+    expect(summary.telemetry.advisorCalls.firstExplicitRepositoryMutationStep).toBe(1);
+    expect(
+      summary.telemetry.advisorCalls.attempts[0]?.relativeToFirstExplicitRepositoryMutation,
+    ).toBe("after");
+  });
+
   test("classifies a pre-terminal process exit as infrastructure", () => {
     const processExit = {
       terminal: "killed",

--- a/benchmarks/deepswe/test/summary.test.ts
+++ b/benchmarks/deepswe/test/summary.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+import type { TurnEvent, TurnTerminalEvent } from "../../../src/types/protocol.js";
+import {
+  assertGradeableDeepSweOutcome,
+  parseKnownEvents,
+  summarizeDeepSweRun,
+} from "../src/summary.js";
+
+describe("DeepSWE wire accounting", () => {
+  test("uses final cumulative totals and retains classifier/advisor model attribution", () => {
+    const terminal = {
+      type: "complete",
+      status: "completed",
+      turnUsage: usage(30, 3),
+      usageByModel: [
+        { model: "executor", usage: usage(10, 1) },
+        { model: "classifier", usage: usage(10, 1) },
+        { model: "advisor", usage: usage(10, 1) },
+      ],
+    } as unknown as TurnTerminalEvent;
+    const summary = summarizeDeepSweRun({
+      terminal,
+      events: [
+        {
+          type: "usage",
+          turnUsage: usage(10, 1),
+          usageByModel: [{ model: "executor", usage: usage(10, 1) }],
+        },
+        terminal,
+      ] as TurnEvent[],
+      timedOut: false,
+      wallClockMs: 123,
+    });
+
+    expect(summary.telemetry.costUsdTotal).toBe(3);
+    expect(summary.telemetry.usageByModel.map((entry) => entry.model)).toEqual([
+      "executor",
+      "classifier",
+      "advisor",
+    ]);
+    expect(summary.wallClockMs).toBe(123);
+  });
+
+  test("keeps future event variants in the parsed ledger and ignores malformed lines", () => {
+    const events = parseKnownEvents([
+      JSON.stringify({ type: "future_protocol_event", payload: { stable: true } }),
+      "not-json",
+    ]);
+    expect(events).toEqual([{ type: "future_protocol_event", payload: { stable: true } }]);
+  });
+
+  test("classifies a pre-terminal process exit as infrastructure", () => {
+    const processExit = {
+      terminal: "killed",
+      events: [],
+      timedOut: false,
+      killedReason: "process_exit",
+      wallClockMs: 10,
+    } as const;
+    expect(() => assertGradeableDeepSweOutcome(processExit)).toThrow(
+      "before emitting a terminal event",
+    );
+    expect(() =>
+      assertGradeableDeepSweOutcome({
+        ...processExit,
+        timedOut: true,
+        killedReason: "wall_clock",
+      }),
+    ).not.toThrow();
+  });
+
+  test("reads the repository RPC fixture without changing its cumulative cost", async () => {
+    const lines = (
+      await Bun.file(
+        join(import.meta.dir, "../../swebench/fixtures/economy-rpc.sanitized.ndjson"),
+      ).text()
+    )
+      .trim()
+      .split("\n");
+    const events = parseKnownEvents(lines);
+    const terminal = events.at(-1) as TurnTerminalEvent;
+    const summary = summarizeDeepSweRun({
+      terminal,
+      events,
+      timedOut: false,
+      wallClockMs: 10,
+    });
+    expect(summary.telemetry.costUsdTotal).toBe(0.006905);
+    expect(summary.telemetry.usageByModel[0]?.model).toBe("openai/gpt-5.6-luna");
+  });
+});
+
+function usage(input: number, cost: number) {
+  return {
+    input,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: input + 1,
+    cost: { input: cost, output: 0, cacheRead: 0, cacheWrite: 0, total: cost },
+  };
+}

--- a/benchmarks/deepswe/test/template.test.ts
+++ b/benchmarks/deepswe/test/template.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test";
+
+import { DEEPSWE_TEMPLATE_APT_PACKAGES } from "../e2b/template.js";
+
+describe("DeepSWE E2B template", () => {
+  test("installs Bun's archive extractor before running its installer", () => {
+    expect(DEEPSWE_TEMPLATE_APT_PACKAGES).toContain("unzip");
+  });
+});

--- a/benchmarks/shared/command-runner.ts
+++ b/benchmarks/shared/command-runner.ts
@@ -1,0 +1,91 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+import type { ExecTransport } from "./duet-rpc-client.js";
+
+/** Result of one bounded host command. */
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Injectable process boundary used by benchmark packaging and containers. */
+export interface CommandRunner {
+  run(
+    argv: readonly string[],
+    options?: { cwd?: string; env?: NodeJS.ProcessEnv; stdin?: string },
+  ): Promise<CommandResult>;
+  /** Start a line-oriented command whose stdin remains open for RPC. */
+  stream(
+    argv: readonly string[],
+    options?: { cwd?: string; env?: NodeJS.ProcessEnv },
+  ): ExecTransport;
+}
+
+/** Node child-process implementation shared by benchmark integrations. */
+export class LocalCommandRunner implements CommandRunner {
+  async run(
+    argv: readonly string[],
+    options: { cwd?: string; env?: NodeJS.ProcessEnv; stdin?: string } = {},
+  ): Promise<CommandResult> {
+    const [command, ...args] = argv;
+    if (!command) throw new Error("Cannot run an empty command.");
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => (stdout += chunk));
+    child.stderr.on("data", (chunk: string) => (stderr += chunk));
+    if (options.stdin !== undefined) child.stdin.end(options.stdin);
+    else child.stdin.end();
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code) => resolve(code ?? 1));
+    });
+    return { stdout, stderr, exitCode };
+  }
+
+  stream(
+    argv: readonly string[],
+    options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+  ): ExecTransport {
+    const [command, ...args] = argv;
+    if (!command) throw new Error("Cannot stream an empty command.");
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return {
+      stdin: {
+        write: (line) =>
+          new Promise<void>((resolve, reject) => {
+            child.stdin.write(line, (error) => (error ? reject(error) : resolve()));
+          }),
+      },
+      stdoutLines: readLines(child.stdout),
+      stderrLines: readLines(child.stderr),
+      kill: () => {
+        child.kill("SIGKILL");
+      },
+      exited: new Promise((resolve) => {
+        child.once("close", (code, signal) => resolve({ code, signal }));
+      }),
+    };
+  }
+}
+
+async function* readLines(stream: NodeJS.ReadableStream): AsyncGenerator<string> {
+  const lines = createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) yield line;
+  } finally {
+    lines.close();
+  }
+}

--- a/benchmarks/shared/duet-packaging.ts
+++ b/benchmarks/shared/duet-packaging.ts
@@ -7,9 +7,9 @@ import { tmpdir } from "node:os";
 import {
   PGLITE_RUNTIME_ASSET_NAMES,
   type PGliteRuntimeAssetName,
-} from "../../../src/memory/pglite.js";
+} from "../../src/memory/pglite.js";
 
-import { LocalCommandRunner, type CommandRunner } from "./container.js";
+import { LocalCommandRunner, type CommandRunner } from "./command-runner.js";
 
 /** Linux artifact installed into every official instance image. */
 export interface DuetArtifact {
@@ -63,7 +63,7 @@ export async function prepareDuetArtifact(
   options: PrepareDuetArtifactOptions,
 ): Promise<DuetArtifact> {
   const commands = options.commands ?? new LocalCommandRunner();
-  const buildRoot = await mkdtemp(join(tmpdir(), "duet-swebench-package-"));
+  const buildRoot = await mkdtemp(join(tmpdir(), "duet-benchmark-package-"));
   const outputDir = resolve(options.outputDir);
   const localPath = join(outputDir, "duet-linux-x64");
 

--- a/benchmarks/shared/duet-rpc-client.ts
+++ b/benchmarks/shared/duet-rpc-client.ts
@@ -1,12 +1,12 @@
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
-import { SystemRuntimeClock, type RuntimeClock } from "../../../src/turn-runner/runtime-clock.js";
+import { SystemRuntimeClock, type RuntimeClock } from "../../src/turn-runner/runtime-clock.js";
 import type {
   RpcRunnerCommand,
   TurnEvent,
   TurnStartCommand,
   TurnTerminalEvent,
-} from "../../../src/types/protocol.js";
+} from "../../src/types/protocol.js";
 
 /** Writable stdin half of a running duet RPC process. */
 export interface ExecTransportStdin {
@@ -91,7 +91,7 @@ export async function runDuetTurn(
   });
   await writeCommand(transport, {
     type: "prompt",
-    requestId: "swebench-rollout-prompt",
+    requestId: "benchmark-rollout-prompt",
     message: prompt,
     behavior: "follow_up",
   });

--- a/benchmarks/shared/provider-environment.ts
+++ b/benchmarks/shared/provider-environment.ts
@@ -1,0 +1,17 @@
+import { SUPPORTED_API_KEYS } from "../../src/cli/shared.js";
+
+/** Product-owned provider credential names used by benchmark workers. */
+export const PROVIDER_ENV_NAMES = SUPPORTED_API_KEYS;
+
+/** Select only model-gateway credentials; sandbox control keys stay on the host. */
+export function providerEnvironment(source: NodeJS.ProcessEnv): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const name of PROVIDER_ENV_NAMES) {
+    const value = source[name];
+    if (value) result[name] = value;
+  }
+  if (Object.keys(result).length === 0) {
+    throw new Error("No supported model gateway key is available for benchmark workers.");
+  }
+  return result;
+}

--- a/benchmarks/shared/rollout-telemetry.ts
+++ b/benchmarks/shared/rollout-telemetry.ts
@@ -98,8 +98,16 @@ export interface RolloutTelemetry {
     | "missing";
 }
 
+export interface DeriveTelemetryOptions {
+  /** Absolute repository root used to recognize explicit `edit` and `write` mutations. */
+  repositoryRoot?: string;
+}
+
 /** Derive all campaign telemetry from a raw, append-only RPC event ledger. */
-export function deriveTelemetry(events: readonly TurnEvent[]): RolloutTelemetry {
+export function deriveTelemetry(
+  events: readonly TurnEvent[],
+  options: DeriveTelemetryOptions = {},
+): RolloutTelemetry {
   let latestUsage: Pick<TurnTokenUsageHolder, "turnUsage" | "usageByModel"> | undefined;
   let terminal: TurnTerminalEvent | undefined;
   let steps = 0;
@@ -140,7 +148,11 @@ export function deriveTelemetry(events: readonly TurnEvent[]): RolloutTelemetry 
       advisorCalls.firstExplicitRepositoryMutationStep === null &&
       event.step.type === "tool_call" &&
       !event.step.isError &&
-      isExplicitRepositoryMutation(event.step.toolName, event.step.input)
+      isExplicitRepositoryMutation(
+        event.step.toolName,
+        event.step.input,
+        options.repositoryRoot ?? "/testbed",
+      )
     ) {
       advisorCalls.firstExplicitRepositoryMutationStep = steps;
     }
@@ -323,11 +335,12 @@ function positiveInteger(value: unknown): number | undefined {
 function isExplicitRepositoryMutation(
   toolName: string,
   input: Record<string, unknown> | undefined,
+  repositoryRoot: string,
 ): boolean {
   if (toolName !== "edit" && toolName !== "write") return false;
   const path = input?.path;
   if (typeof path !== "string") return false;
-  return !path.startsWith("/") || path === "/testbed" || path.startsWith("/testbed/");
+  return !path.startsWith("/") || path === repositoryRoot || path.startsWith(`${repositoryRoot}/`);
 }
 
 function isTerminal(event: TurnEvent): event is TurnTerminalEvent {

--- a/benchmarks/shared/rollout-telemetry.ts
+++ b/benchmarks/shared/rollout-telemetry.ts
@@ -3,7 +3,7 @@ import type {
   TurnEvent,
   TurnTerminalEvent,
   TurnTokenUsage,
-} from "../../../src/types/protocol.js";
+} from "../../src/types/protocol.js";
 
 export type AdvisorCallOutcome = "success" | "rate_limited" | "unavailable" | "failed";
 

--- a/benchmarks/swebench/cli.ts
+++ b/benchmarks/swebench/cli.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { parse as parseDotenv } from "dotenv";
 
+import { PROVIDER_ENV_NAMES } from "../shared/provider-environment.js";
 import {
   CAMPAIGN_CONFIGS,
   renderCampaignConfigs,
@@ -412,7 +413,7 @@ async function loadProviderEnv(): Promise<Record<string, string>> {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
   const result: Record<string, string> = {};
-  for (const name of ["DUET_API_KEY", "AI_GATEWAY_API_KEY", "OPENROUTER_API_KEY"] as const) {
+  for (const name of PROVIDER_ENV_NAMES) {
     const value = process.env[name] ?? fileValues[name];
     if (value) result[name] = value;
   }

--- a/benchmarks/swebench/cli.ts
+++ b/benchmarks/swebench/cli.ts
@@ -9,7 +9,7 @@ import {
   serializeModelsJson,
   type CampaignConfigName,
 } from "./src/config-override.js";
-import { runDuetTurn, spawnLocalDuetRpc } from "./src/duet-client.js";
+import { runDuetTurn, spawnLocalDuetRpc } from "../shared/duet-rpc-client.js";
 import { PINNED_DATASET_REVISION, fetchDataset, writeDatasetCache } from "./src/fetch-dataset.js";
 import {
   CAMPAIGN_GOLD_EXCLUSIONS,
@@ -20,7 +20,7 @@ import {
 } from "./src/manifest.js";
 import { loadRolloutAttempts } from "./src/artifacts.js";
 import { runCampaign, type CampaignRuntime, type CampaignSpec } from "./src/orchestrator.js";
-import { loadPrebuiltDuetArtifact, prepareDuetArtifact } from "./src/packaging.js";
+import { loadPrebuiltDuetArtifact, prepareDuetArtifact } from "../shared/duet-packaging.js";
 import { buildPredictions, serializePredictions } from "./src/predictions.js";
 import { ensureCampaignProvenance } from "./src/provenance.js";
 import {
@@ -32,7 +32,7 @@ import {
 } from "./src/report.js";
 import { hashConfigFile } from "./src/rollout.js";
 import { runContainerSmoke } from "./src/smoke.js";
-import { deriveTelemetry } from "./src/telemetry.js";
+import { deriveTelemetry } from "../shared/rollout-telemetry.js";
 import {
   ContainerHandle,
   removeOfficialImage,

--- a/benchmarks/swebench/e2b/run.ts
+++ b/benchmarks/swebench/e2b/run.ts
@@ -21,13 +21,13 @@ import { Sandbox, Template, type SandboxMetrics } from "e2b";
 import { parse as parseDotenv } from "dotenv";
 
 import { PGLITE_RUNTIME_ASSET_NAMES } from "../../../src/memory/pglite.js";
+import { providerEnvironment } from "../../shared/provider-environment.js";
 import { loadRolloutAttempts, type RolloutAttempt } from "../src/artifacts.js";
 import type { InstanceManifest } from "../src/manifest.js";
 import type { CampaignSpec } from "../src/orchestrator.js";
 import {
   buildE2BEnvironmentLock,
   e2bTemplateName,
-  providerEnvironment,
   shellQuote,
   type E2BEnvironmentProbe,
 } from "./support.js";

--- a/benchmarks/swebench/e2b/support.ts
+++ b/benchmarks/swebench/e2b/support.ts
@@ -8,19 +8,6 @@ export function e2bTemplateName(repositorySha: string): string {
   return `duet-swebench-${repositorySha.slice(0, 12).toLowerCase()}`;
 }
 
-/** Select only model-gateway credentials; the E2B control key stays on the host. */
-export function providerEnvironment(source: NodeJS.ProcessEnv): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const name of ["DUET_API_KEY", "AI_GATEWAY_API_KEY", "OPENROUTER_API_KEY"] as const) {
-    const value = source[name];
-    if (value) result[name] = value;
-  }
-  if (Object.keys(result).length === 0) {
-    throw new Error("No supported model gateway key is available for E2B workers.");
-  }
-  return result;
-}
-
 export interface E2BEnvironmentProbe {
   /** Immutable E2B template name derived from the repository SHA. */
   templateName: string;

--- a/benchmarks/swebench/src/artifacts.ts
+++ b/benchmarks/swebench/src/artifacts.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 
 import type { TurnEvent } from "../../../src/types/protocol.js";
 import type { CampaignConfigName } from "./config-override.js";
-import type { RolloutTelemetry } from "./telemetry.js";
+import type { RolloutTelemetry } from "../../shared/rollout-telemetry.js";
 
 /** Logical rollout identity shared by immutable retry attempts. */
 export interface RolloutIdentity {

--- a/benchmarks/swebench/src/container.ts
+++ b/benchmarks/swebench/src/container.ts
@@ -1,27 +1,9 @@
-import { spawn } from "node:child_process";
-import { createInterface } from "node:readline";
-
-import type { ExecTransport } from "./duet-client.js";
-
-/** Result of one bounded host command. */
-export interface CommandResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
-
-/** Injectable process boundary; production uses {@link LocalCommandRunner}. */
-export interface CommandRunner {
-  run(
-    argv: readonly string[],
-    options?: { cwd?: string; env?: NodeJS.ProcessEnv; stdin?: string },
-  ): Promise<CommandResult>;
-  /** Start a line-oriented command whose stdin remains open for RPC. */
-  stream(
-    argv: readonly string[],
-    options?: { cwd?: string; env?: NodeJS.ProcessEnv },
-  ): ExecTransport;
-}
+import type { ExecTransport } from "../../shared/duet-rpc-client.js";
+import {
+  LocalCommandRunner,
+  type CommandResult,
+  type CommandRunner,
+} from "../../shared/command-runner.js";
 
 /** Official image identity returned by the pinned Python harness. */
 export interface OfficialImage {
@@ -29,64 +11,6 @@ export interface OfficialImage {
   platform: "linux/amd64";
   sizeBytes: number;
   imageId: string;
-}
-
-/** Node child-process implementation shared by packaging and Docker orchestration. */
-export class LocalCommandRunner implements CommandRunner {
-  async run(
-    argv: readonly string[],
-    options: { cwd?: string; env?: NodeJS.ProcessEnv; stdin?: string } = {},
-  ): Promise<CommandResult> {
-    const [command, ...args] = argv;
-    if (!command) throw new Error("Cannot run an empty command.");
-    const child = spawn(command, args, {
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => (stdout += chunk));
-    child.stderr.on("data", (chunk: string) => (stderr += chunk));
-    if (options.stdin !== undefined) child.stdin.end(options.stdin);
-    else child.stdin.end();
-    const exitCode = await new Promise<number>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("close", (code) => resolve(code ?? 1));
-    });
-    return { stdout, stderr, exitCode };
-  }
-
-  stream(
-    argv: readonly string[],
-    options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
-  ): ExecTransport {
-    const [command, ...args] = argv;
-    if (!command) throw new Error("Cannot stream an empty command.");
-    const child = spawn(command, args, {
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    return {
-      stdin: {
-        write: (line) =>
-          new Promise<void>((resolve, reject) => {
-            child.stdin.write(line, (error) => (error ? reject(error) : resolve()));
-          }),
-      },
-      stdoutLines: readLines(child.stdout),
-      stderrLines: readLines(child.stderr),
-      kill: () => {
-        child.kill("SIGKILL");
-      },
-      exited: new Promise((resolve) => {
-        child.once("close", (code, signal) => resolve({ code, signal }));
-      }),
-    };
-  }
 }
 
 /** Docker CLI owner for one isolated official SWE-bench instance container. */
@@ -250,13 +174,4 @@ function commandError(argv: readonly string[], result: CommandResult): Error {
   return new Error(
     `Command failed (${result.exitCode}): ${argv.join(" ")}\n${result.stderr || result.stdout}`,
   );
-}
-
-async function* readLines(stream: NodeJS.ReadableStream): AsyncGenerator<string> {
-  const lines = createInterface({ input: stream, crlfDelay: Infinity });
-  try {
-    for await (const line of lines) yield line;
-  } finally {
-    lines.close();
-  }
 }

--- a/benchmarks/swebench/src/orchestrator.ts
+++ b/benchmarks/swebench/src/orchestrator.ts
@@ -1,4 +1,4 @@
-import type { DuetArtifact } from "./packaging.js";
+import type { DuetArtifact } from "../../shared/duet-packaging.js";
 import {
   hashJson,
   hashText,
@@ -11,9 +11,9 @@ import {
   ContainerHandle,
   removeOfficialImage,
   resolveAndPullOfficialImage,
-  type CommandRunner,
   type OfficialImage,
 } from "./container.js";
+import type { CommandRunner } from "../../shared/command-runner.js";
 import {
   selectPilotInstanceIds,
   type DatasetRow,

--- a/benchmarks/swebench/src/patch.ts
+++ b/benchmarks/swebench/src/patch.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { CommandResult } from "./container.js";
+import type { CommandResult } from "../../shared/command-runner.js";
 /** Minimal container operations required by staged-index patch handling. */
 export interface PatchContainer {
   exec(

--- a/benchmarks/swebench/src/provenance.ts
+++ b/benchmarks/swebench/src/provenance.ts
@@ -3,9 +3,9 @@ import { join } from "node:path";
 
 import { hashJson, hashText } from "./artifacts.js";
 import type { CampaignConfigName } from "./config-override.js";
-import { LocalCommandRunner, type CommandRunner } from "./container.js";
+import { LocalCommandRunner, type CommandRunner } from "../../shared/command-runner.js";
 import type { CampaignSpec } from "./orchestrator.js";
-import type { DuetArtifact } from "./packaging.js";
+import type { DuetArtifact } from "../../shared/duet-packaging.js";
 
 /** Frozen campaign inputs embedded beside rollout artifacts. */
 export interface CampaignProvenance {

--- a/benchmarks/swebench/src/report.ts
+++ b/benchmarks/swebench/src/report.ts
@@ -9,7 +9,7 @@ import {
   normalizePersistedTelemetry,
   type AdvisorContextObservation,
   type RolloutTelemetry,
-} from "./telemetry.js";
+} from "../../shared/rollout-telemetry.js";
 
 export { lintPatch, type PatchLint } from "./patch-policy.js";
 

--- a/benchmarks/swebench/src/rollout.ts
+++ b/benchmarks/swebench/src/rollout.ts
@@ -11,19 +11,19 @@ import {
   type RolloutStatus,
 } from "./artifacts.js";
 import type { CampaignConfigName } from "./config-override.js";
-import type { CommandResult } from "./container.js";
+import type { CommandResult } from "../../shared/command-runner.js";
 import {
   runDuetTurn,
   type ExecTransport,
   type RolloutLimits,
   type RolloutOutcome,
-} from "./duet-client.js";
-import type { DuetArtifact } from "./packaging.js";
+} from "../../shared/duet-rpc-client.js";
+import type { DuetArtifact } from "../../shared/duet-packaging.js";
 import { capturePatchBaseline, extractPatch } from "./patch.js";
 import { lintPatch } from "./patch-policy.js";
 import { buildRolloutPrompt, SWEBENCH_SYSTEM_PROMPT } from "./prompt.js";
 import type { DatasetRow, ManifestEntry } from "./manifest.js";
-import { deriveTelemetry, type RolloutTelemetry } from "./telemetry.js";
+import { deriveTelemetry, type RolloutTelemetry } from "../../shared/rollout-telemetry.js";
 
 /** Runtime inputs for one immutable benchmark work unit. */
 export interface RunRolloutSpec {

--- a/benchmarks/swebench/src/smoke.ts
+++ b/benchmarks/swebench/src/smoke.ts
@@ -7,7 +7,7 @@ import type { DatasetRow, ManifestEntry } from "./manifest.js";
 import type { RunRolloutDependencies, RunRolloutSpec, RolloutContainer } from "./rollout.js";
 import { runRollout } from "./rollout.js";
 import { verifyPatchRoundTrip, type ExtractedPatch } from "./patch.js";
-import type { RolloutTelemetry } from "./telemetry.js";
+import type { RolloutTelemetry } from "../../shared/rollout-telemetry.js";
 
 const SMOKE_CONFIG = "glm-pure" satisfies CampaignConfigName;
 const SENTINEL_PATH = "duet-swebench-smoke.txt";

--- a/benchmarks/swebench/test/swebench-artifacts.test.ts
+++ b/benchmarks/swebench/test/swebench-artifacts.test.ts
@@ -9,7 +9,7 @@ import {
   loadRolloutAttempts,
   type RolloutArtifactSpec,
 } from "../src/artifacts.js";
-import { deriveTelemetry } from "../src/telemetry.js";
+import { deriveTelemetry } from "../../shared/rollout-telemetry.js";
 import type { TurnEvent } from "../../../src/types/protocol.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 

--- a/benchmarks/swebench/test/swebench-campaign-report.test.ts
+++ b/benchmarks/swebench/test/swebench-campaign-report.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../src/report.js";
 import type { ManifestEntry } from "../src/manifest.js";
 import { scoringModelName } from "../src/scoring-identity.js";
-import type { RolloutTelemetry } from "../src/telemetry.js";
+import type { RolloutTelemetry } from "../../shared/rollout-telemetry.js";
 
 const configs: CampaignConfigName[] = [
   "glm-pure",

--- a/benchmarks/swebench/test/swebench-container.test.ts
+++ b/benchmarks/swebench/test/swebench-container.test.ts
@@ -4,10 +4,9 @@ import {
   ContainerHandle,
   removeOfficialImage,
   resolveAndPullOfficialImage,
-  type CommandResult,
-  type CommandRunner,
 } from "../src/container.js";
-import type { ExecTransport } from "../src/duet-client.js";
+import type { ExecTransport } from "../../shared/duet-rpc-client.js";
+import type { CommandResult, CommandRunner } from "../../shared/command-runner.js";
 
 class FakeCommands implements CommandRunner {
   readonly runs: { argv: readonly string[]; stdin?: string }[] = [];

--- a/benchmarks/swebench/test/swebench-duet-client.test.ts
+++ b/benchmarks/swebench/test/swebench-duet-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { runDuetTurn, type ExecTransport } from "../src/duet-client.js";
+import { runDuetTurn, type ExecTransport } from "../../shared/duet-rpc-client.js";
 import type { RpcRunnerCommand, TurnEvent } from "../../../src/types/protocol.js";
 import { ManualRuntimeClock } from "./helpers/manual-runtime-clock.js";
 
@@ -111,7 +111,7 @@ describe("SWE-bench duet RPC client", () => {
       { type: "start", mode: "agent" },
       {
         type: "prompt",
-        requestId: "swebench-rollout-prompt",
+        requestId: "benchmark-rollout-prompt",
         message: "Fix the issue.",
         behavior: "follow_up",
       },

--- a/benchmarks/swebench/test/swebench-e2b.test.ts
+++ b/benchmarks/swebench/test/swebench-e2b.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
+import { providerEnvironment } from "../../shared/provider-environment.js";
 import type { RolloutAttempt } from "../src/artifacts.js";
 import type { InstanceManifest } from "../src/manifest.js";
 import type { CampaignSpec } from "../src/orchestrator.js";
@@ -18,7 +19,7 @@ import {
   selectE2BInstanceIds,
   selectE2BShards,
 } from "../e2b/run.js";
-import { buildE2BEnvironmentLock, e2bTemplateName, providerEnvironment } from "../e2b/support.js";
+import { buildE2BEnvironmentLock, e2bTemplateName } from "../e2b/support.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 describe("SWE-bench E2B execution", () => {

--- a/benchmarks/swebench/test/swebench-packaging.test.ts
+++ b/benchmarks/swebench/test/swebench-packaging.test.ts
@@ -3,8 +3,8 @@ import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-import type { CommandRunner } from "../src/container.js";
-import { loadPrebuiltDuetArtifact, prepareDuetArtifact } from "../src/packaging.js";
+import type { CommandRunner } from "../../shared/command-runner.js";
+import { loadPrebuiltDuetArtifact, prepareDuetArtifact } from "../../shared/duet-packaging.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 let root: string | undefined;
@@ -16,7 +16,7 @@ afterEach(async () => {
 
 describe("SWE-bench Duet packaging", () => {
   testIfDocker("carries declared dependency patches into the isolated Linux build", async () => {
-    root = await mkdtemp(join(tmpdir(), "duet-swebench-package-"));
+    root = await mkdtemp(join(tmpdir(), "duet-benchmark-package-"));
     const repoRoot = join(root, "repo");
     const outputDir = join(root, "output");
     const patchName = "@earendil-works%2Fpi-ai@0.79.10.patch";
@@ -81,7 +81,7 @@ describe("SWE-bench Duet packaging", () => {
   });
 
   testIfDocker("loads the exact prebuilt worker artifact without rebuilding it", async () => {
-    root = await mkdtemp(join(tmpdir(), "duet-swebench-package-"));
+    root = await mkdtemp(join(tmpdir(), "duet-benchmark-package-"));
     const path = join(root, "duet-linux-x64");
     await Promise.all([
       writeFile(path, "prebuilt-duet"),

--- a/benchmarks/swebench/test/swebench-patch.test.ts
+++ b/benchmarks/swebench/test/swebench-patch.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
-import { ContainerHandle, type CommandResult, type CommandRunner } from "../src/container.js";
-import type { ExecTransport } from "../src/duet-client.js";
+import { ContainerHandle } from "../src/container.js";
+import type { CommandResult, CommandRunner } from "../../shared/command-runner.js";
+import type { ExecTransport } from "../../shared/duet-rpc-client.js";
 import { capturePatchBaseline, extractPatch } from "../src/patch.js";
 
 class ScriptedCommands implements CommandRunner {

--- a/benchmarks/swebench/test/swebench-provenance.test.ts
+++ b/benchmarks/swebench/test/swebench-provenance.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { PGLITE_RUNTIME_ASSET_NAMES } from "../../../src/memory/pglite.js";
-import type { CommandResult, CommandRunner } from "../src/container.js";
-import type { ExecTransport } from "../src/duet-client.js";
+import type { CommandResult, CommandRunner } from "../../shared/command-runner.js";
+import type { ExecTransport } from "../../shared/duet-rpc-client.js";
 import type { CampaignSpec } from "../src/orchestrator.js";
 import { ensureCampaignProvenance } from "../src/provenance.js";
 import { testIfDocker } from "./helpers/docker-only.js";

--- a/benchmarks/swebench/test/swebench-rollout.test.ts
+++ b/benchmarks/swebench/test/swebench-rollout.test.ts
@@ -4,9 +4,9 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { PGLITE_RUNTIME_ASSET_NAMES } from "../../../src/memory/pglite.js";
-import type { CommandResult } from "../src/container.js";
-import type { ExecTransport } from "../src/duet-client.js";
-import type { DuetArtifact } from "../src/packaging.js";
+import type { CommandResult } from "../../shared/command-runner.js";
+import type { ExecTransport } from "../../shared/duet-rpc-client.js";
+import type { DuetArtifact } from "../../shared/duet-packaging.js";
 import { SWEBENCH_SYSTEM_PROMPT } from "../src/prompt.js";
 import { runRollout, type RolloutContainer } from "../src/rollout.js";
 import { runContainerSmoke } from "../src/smoke.js";

--- a/benchmarks/swebench/test/swebench-telemetry.test.ts
+++ b/benchmarks/swebench/test/swebench-telemetry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import { deriveTelemetry, normalizePersistedTelemetry } from "../src/telemetry.js";
+import { deriveTelemetry, normalizePersistedTelemetry } from "../../shared/rollout-telemetry.js";
 import type { TurnEvent } from "../../../src/types/protocol.js";
 
 const FIXTURES = join(import.meta.dir, "../fixtures");

--- a/evals/advisor-validates-wire-format.eval.ts
+++ b/evals/advisor-validates-wire-format.eval.ts
@@ -1,0 +1,254 @@
+import { describe, expect } from "bun:test";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { BUILT_IN_ROUTING_TABLE } from "../src/model-routing/table.js";
+import { TurnRunner } from "../src/turn-runner/turn-runner.js";
+import type { TurnEvent } from "../src/types/protocol.js";
+import { testIfDocker } from "../test/helpers/docker-only.js";
+
+const model = process.env.EVAL_MODEL ?? "kimi-k3";
+// Five runs made the unpatched prompt miss the actionable comment-prefix defect 3/5 times.
+const ITERATIONS = Number(process.env.EVAL_ITERATIONS ?? "5");
+
+class AdvisorWireFormatEvalRunner extends TurnRunner {
+  constructor(cwd: string) {
+    super({
+      cwd,
+      model: "advisor-wire-format-eval",
+      mode: "agent",
+      memoryDbPath: join(cwd, ".duet", "memory.db"),
+      skillDiscovery: { includeDefaults: false },
+    });
+  }
+
+  seedCompletionReview(): void {
+    this.requireParentAgent().state.messages.push(
+      {
+        role: "user",
+        content:
+          "Add an optional per-launcher summary to the TAP reporter. Include `Per-launcher summary` with `N tests, N pass, N fail, N skip` for each launcher.",
+        timestamp: 1,
+      },
+      assistant(
+        [
+          {
+            type: "toolCall",
+            id: "read-contract",
+            name: "read",
+            arguments: { path: "lib/reporters/tap_reporter.js" },
+          },
+        ],
+        2,
+      ),
+      {
+        role: "toolResult",
+        toolCallId: "read-contract",
+        toolName: "read",
+        content: [
+          {
+            type: "text",
+            text: [
+              "summaryDisplay() currently returns:",
+              "# tests 4",
+              "# pass  2",
+              "# skip  1",
+              "# fail  1",
+            ].join("\n"),
+          },
+        ],
+        isError: false,
+        timestamp: 3,
+      },
+      assistant(
+        [
+          {
+            type: "toolCall",
+            id: "review-diff",
+            name: "bash",
+            arguments: { command: "git diff -- lib/reporters/tap_reporter.js" },
+          },
+        ],
+        4,
+      ),
+      {
+        role: "toolResult",
+        toolCallId: "review-diff",
+        toolName: "bash",
+        content: [
+          {
+            type: "text",
+            text: [
+              "+ let lines = ['Per-launcher summary'];",
+              "+ lines.push(launcher + ': ' + s.total + ' tests, ' + s.pass + ' pass, ' + s.fail + ' fail, ' + s.skip + ' skip');",
+              "+ return lines.join('\\n');",
+            ].join("\n"),
+          },
+        ],
+        isError: false,
+        timestamp: 5,
+      },
+      assistant(
+        [
+          {
+            type: "toolCall",
+            id: "focused-tests",
+            name: "bash",
+            arguments: {
+              command: "npx mocha tests/ci/reporter_tests.js --grep launcher-summary",
+            },
+          },
+        ],
+        6,
+      ),
+      {
+        role: "toolResult",
+        toolCallId: "focused-tests",
+        toolName: "bash",
+        content: [
+          {
+            type: "text",
+            text: "7 passing. The new executor-written test expects `Per-launcher summary` and `Chrome: 3 tests, 1 pass, 1 fail, 1 skip`.",
+          },
+        ],
+        isError: false,
+        timestamp: 7,
+      },
+    );
+    // Push the relevant diff out of the raw tail, matching the long DeepSWE trace where later
+    // compatibility checks caused normal observational compaction before completion review.
+    for (let index = 0; index < 80; index += 1) {
+      const toolCallId = `adjacent-check-${index}`;
+      this.requireParentAgent().state.messages.push(
+        assistant(
+          [
+            {
+              type: "toolCall",
+              id: toolCallId,
+              name: "bash",
+              arguments: { command: `inspect-adjacent-reporter-contract ${index}` },
+            },
+          ],
+          8 + index * 2,
+        ),
+        {
+          role: "toolResult",
+          toolCallId,
+          toolName: "bash",
+          content: [
+            {
+              type: "text",
+              text:
+                `Adjacent reporter check ${index} passed without changing the TAP summary implementation.\n` +
+                "unrelated compatibility evidence ".repeat(70),
+            },
+          ],
+          isError: false,
+          timestamp: 9 + index * 2,
+        },
+      );
+    }
+    this.requireParentAgent().state.messages.push(
+      assistant(
+        [
+          {
+            type: "text",
+            text: "The implementation and focused/full tests are complete. Perform the final review before I commit.",
+          },
+          { type: "toolCall", id: "advisor-review", name: "ask_advisor", arguments: {} },
+        ],
+        168,
+      ),
+    );
+  }
+
+  advisorTool() {
+    return this.requireParentAgent().state.tools.find((tool) => tool.name === "ask_advisor");
+  }
+}
+
+describe("advisor protocol review", () => {
+  testIfDocker(
+    "rejects executor-written tests that encode invalid TAP wire syntax",
+    async () => {
+      const missed: Array<{ iteration: number; advice: string }> = [];
+      for (let iteration = 0; iteration < ITERATIONS; iteration += 1) {
+        const cwd = await mkdtemp(join(tmpdir(), "duet-advisor-wire-format-eval-"));
+        const table = structuredClone(BUILT_IN_ROUTING_TABLE);
+        table.defaultTier = "advisor-wire-format-eval";
+        table.tiers = {
+          "advisor-wire-format-eval": {
+            routes: {
+              general: {
+                description: "Review one completed repository change.",
+                target: { modelName: model, thinkingLevel: "medium" },
+              },
+            },
+            advisor: {
+              enabled: true,
+              target: { modelName: model, thinkingLevel: "high" },
+              minStepsBetween: 1,
+            },
+          },
+        };
+        await mkdir(join(cwd, ".duet"));
+        await writeFile(join(cwd, ".duet", "models.json"), JSON.stringify(table));
+        const runner = new AdvisorWireFormatEvalRunner(cwd);
+        const systemEvents: TurnEvent[] = [];
+        runner.subscribe((event) => {
+          if (event.type === "system") systemEvents.push(event);
+        });
+        try {
+          await runner.start({ type: "start", mode: "agent" });
+          runner.seedCompletionReview();
+          const advisor = runner.advisorTool();
+          if (!advisor) throw new Error("Expected ask_advisor tool");
+
+          const result = await advisor.execute("advisor-review", {});
+          const advice = result.content
+            .filter((content) => content.type === "text")
+            .map((content) => content.text)
+            .join("\n");
+          console.log(
+            JSON.stringify({ iteration, advice, details: result.details, systemEvents }, null, 2),
+          );
+          const rejectsInvalidPatch =
+            /Verdict:\s*(?:not ready|reject|do not approve|changes required)/i.test(advice);
+          const namesExactTapPrefix =
+            /`#(?: [^`]*)?`[\s\S]{0,80}(?:prefix|comment)|(?:prefix|comment)[\s\S]{0,80}`#(?: [^`]*)?`/i.test(
+              advice,
+            );
+          if (!rejectsInvalidPatch || !namesExactTapPrefix) missed.push({ iteration, advice });
+        } finally {
+          await runner.dispose();
+          await rm(cwd, { recursive: true, force: true });
+        }
+      }
+
+      expect(missed).toEqual([]);
+    },
+    600_000,
+  );
+});
+
+function assistant(content: AssistantMessage["content"], timestamp: number): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    api: "anthropic-messages",
+    provider: "duet-gateway",
+    model: "executor-model",
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "toolUse",
+    timestamp,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prepack": "bun run build",
     "test": "docker run --rm -v \"$PWD:/src:ro\" -w /work -e HOME=/tmp/home -e DUET_TEST_IN_DOCKER=1 oven/bun:1.3.11 sh -lc 'apt-get update -qq && apt-get install -y -qq git >/dev/null && cp -R /src/. /work && bun install --frozen-lockfile && bun test ./test/*.test.ts'",
     "test:swebench": "bash benchmarks/swebench/test.sh",
+    "test:deepswe": "bash benchmarks/deepswe/test.sh",
     "example": "bun examples/basic.ts",
     "example:memory-store": "bun examples/memory-store.ts",
     "example:state-machine": "bun examples/state-machine.ts",

--- a/specs/deepswe-harness/README.md
+++ b/specs/deepswe-harness/README.md
@@ -22,8 +22,10 @@ pure-resolved/advised-unresolved is a regression that remains in the result.
 
 ## Next Agent Prompt
 
-Status: six-arm tranche implementation is reviewed and green; the paid
-five-task E2B run is next, last updated 2026-07-25.
+Status: the first paid campaign was stopped after its complete five-task GLM
+pair exposed one pure-only regression. The exact trace led to a product-level
+advisor review fix that is green 5/5 on the frozen regression eval; rebuild and
+rerun the five-task campaign from a new clean commit, last updated 2026-07-25.
 
 Implement the next unchecked slice in order. Keep Pier as the sole owner of
 task containers and scoring. Preserve raw Duet RPC events before deriving
@@ -37,6 +39,20 @@ The user authorized a $1,000 campaign budget. At the chosen $10 per-rollout
 soft stop, five tasks across six arms require $900 of admission headroom.
 Decisions made while implementing the tranche are recorded in the
 [choices ledger](choices.md).
+
+The stopped campaign completed all five GLM pairs before interruption:
+
+- GLM pure: 2/5 resolved, $4.87/task, $12.18/resolved.
+- GLM + Kimi advisor: 2/5 resolved, $4.65/task, $11.63/resolved.
+- Paired outcomes: one advisor-only lift, one pure-only regression, one
+  both-resolved tie, and two neither-resolved ties.
+
+The regression was `testem-per-launcher-reports`: pure resolved, advised
+missed one of 65 new tests because it emitted bare TAP summary lines instead
+of `# `-prefixed comments. The advisor made three successful consultations but
+approved executor-written tests that encoded the same wire-format defect.
+`evals/advisor-validates-wire-format.eval.ts` reproduced the miss in 3/5 runs
+and now passes 5/5 after the generic protocol-review prompt correction.
 
 ## Ownership
 
@@ -86,6 +102,9 @@ the seed and algorithm explain how they were chosen.
   directories. Compact final result records may be committed separately.
 - Infrastructure failures may be resumed. Model or verifier failures are
   outcomes, not silently retried until they pass.
+- A pure-only advisor regression stops expansion. Preserve its traces, fix the
+  general product behavior that caused it, and start a fresh comparable
+  campaign rather than retrying the failed outcome until it passes.
 
 ## Review map
 

--- a/specs/deepswe-harness/README.md
+++ b/specs/deepswe-harness/README.md
@@ -1,0 +1,92 @@
+# DeepSWE advisor pilot
+
+## Purpose
+
+Measure whether Duet's normal advisor architecture improves long-horizon
+repository work on DeepSWE v1.1, while preserving DeepSWE's official task
+containers, pristine verifier containers, and reward files.
+
+The pilot is a paired experiment over ten frozen tasks:
+
+- GLM 5.2 pure versus GLM 5.2 with Kimi K3 advisor.
+- Kimi K3 pure versus Kimi K3 with Fable 5 advisor.
+
+Both arms in a pair use the same task, Duet commit, prompt, executor effort,
+classifier, memory behavior, vision fallback, limits, and official verifier.
+Advisor availability is the treatment. Both-resolved is a successful tie;
+pure-resolved/advised-unresolved is a regression that remains in the result.
+
+## Next Agent Prompt
+
+Status: setup complete; the paid one-task acceptance gate is next, last updated
+2026-07-25.
+
+Implement the next unchecked slice in order. Keep Pier as the sole owner of
+task containers and scoring. Preserve raw Duet RPC events before deriving
+telemetry. Before ending a pass, update this section and the checklist.
+
+- [x] [01 — Pin the official inputs](slices/01-pin-official-inputs.md)
+- [x] [02 — Bridge Duet into Pier](slices/02-pier-duet-adapter.md)
+- [ ] [03 — Execute and report the pilot](slices/03-execute-and-report.md)
+
+The pinned checkout, generated configs, compiled artifact, benchmark-local
+tests, inherited SWE-bench tests, Pier adapter seam, and official no-model
+separate-verifier smoke all pass. The paid run needs an explicit total budget;
+setup and no-model checks do not.
+
+## Ownership
+
+- DeepSWE owns task instructions, images, `pre_artifacts.sh`, held-out tests,
+  and verifier rewards.
+- Pier owns task discovery, Docker lifecycle, the separate verifier
+  environment, artifact transfer, and official result records.
+- The Duet adapter owns only installing the exact Duet artifact, driving its
+  existing RPC protocol, committing the resulting working tree for
+  `pre_artifacts.sh`, and preserving the raw event stream.
+- E2B owns only outer concurrency and result transport. Pier remains the
+  scorer inside every worker.
+
+Benchmark-wide command execution, Linux artifact packaging, RPC control, and
+wire telemetry live under `benchmarks/shared`; neither SWE-bench nor DeepSWE
+owns duplicate versions.
+
+## Frozen inputs
+
+- DeepSWE repository:
+  `https://github.com/datacurve-ai/deep-swe.git`
+- DeepSWE v1.1 commit:
+  `e016041a6ccf8da29906afc9a3f5a8df940a1f78`
+- Pier version: `0.3.0`
+- Pier source commit:
+  `fefa7475a32bb05271abdea378e8083c83eb5c35`
+- Population: ten explicit task IDs selected by sorting the 113 task IDs,
+  applying Python's MT19937 shuffle with seed `0`, and taking the first ten.
+
+Pier's built-in seeded selection is not the population contract because it
+shuffles unsorted filesystem enumeration. The committed IDs are the authority;
+the seed and algorithm explain how they were chosen.
+
+## Invariants
+
+- No benchmark-specific advisor timing, exact-call count, reroute prompt, or
+  step limit.
+- The official instruction is passed verbatim. One neutral system sentence
+  asks Duet to finish the repository task unattended.
+- Every run uses the exact clean, pushed Duet commit recorded in provenance.
+- Raw RPC NDJSON is retained even when a later event is unknown or malformed.
+- Cost comes from the final cumulative `turnUsage`; `usageByModel` remains the
+  attribution ledger. No benchmark-only product protocol fields are added.
+- DeepSWE only captures committed work, so the adapter commits all agent changes
+  without filtering paths before Pier invokes `pre_artifacts.sh`.
+- Generated jobs, runtime builds, caches, and reports live in ignored output
+  directories. Compact final result records may be committed separately.
+- Infrastructure failures may be resumed. Model or verifier failures are
+  outcomes, not silently retried until they pass.
+
+## Review map
+
+The first useful checkpoint is a no-model Pier smoke proving that the pinned
+task and separate verifier environment work. The second is one paid task across
+all four arms. Only then should all ten task shards launch.
+
+There is no visual surface or screenshot gate for this benchmark.

--- a/specs/deepswe-harness/README.md
+++ b/specs/deepswe-harness/README.md
@@ -6,10 +6,14 @@ Measure whether Duet's normal advisor architecture improves long-horizon
 repository work on DeepSWE v1.1, while preserving DeepSWE's official task
 containers, pristine verifier containers, and reward files.
 
-The pilot is a paired experiment over ten frozen tasks:
+The frozen population contains ten tasks. Its first paid tranche runs the first
+five selected tasks across two advisor pairs:
 
 - GLM 5.2 pure versus GLM 5.2 with Kimi K3 advisor.
 - Kimi K3 pure versus Kimi K3 with Fable 5 advisor.
+
+Opus 5 pure and Fable 5 pure run on those same tasks as standalone model-family
+cost and resolve-rate baselines. They do not create artificial advisor pairs.
 
 Both arms in a pair use the same task, Duet commit, prompt, executor effort,
 classifier, memory behavior, vision fallback, limits, and official verifier.
@@ -18,8 +22,8 @@ pure-resolved/advised-unresolved is a regression that remains in the result.
 
 ## Next Agent Prompt
 
-Status: setup complete; the paid one-task acceptance gate is next, last updated
-2026-07-25.
+Status: six-arm tranche implementation is reviewed and green; the paid
+five-task E2B run is next, last updated 2026-07-25.
 
 Implement the next unchecked slice in order. Keep Pier as the sole owner of
 task containers and scoring. Preserve raw Duet RPC events before deriving
@@ -29,10 +33,10 @@ telemetry. Before ending a pass, update this section and the checklist.
 - [x] [02 — Bridge Duet into Pier](slices/02-pier-duet-adapter.md)
 - [ ] [03 — Execute and report the pilot](slices/03-execute-and-report.md)
 
-The pinned checkout, generated configs, compiled artifact, benchmark-local
-tests, inherited SWE-bench tests, Pier adapter seam, and official no-model
-separate-verifier smoke all pass. The paid run needs an explicit total budget;
-setup and no-model checks do not.
+The user authorized a $1,000 campaign budget. At the chosen $10 per-rollout
+soft stop, five tasks across six arms require $900 of admission headroom.
+Decisions made while implementing the tranche are recorded in the
+[choices ledger](choices.md).
 
 ## Ownership
 
@@ -85,8 +89,8 @@ the seed and algorithm explain how they were chosen.
 
 ## Review map
 
-The first useful checkpoint is a no-model Pier smoke proving that the pinned
-task and separate verifier environment work. The second is one paid task across
-all four arms. Only then should all ten task shards launch.
+The no-model Pier smoke proved that the pinned task and separate verifier
+environment work. The next checkpoint is the first five frozen tasks across all
+six arms. The remaining five tasks stay available as an expansion tranche.
 
 There is no visual surface or screenshot gate for this benchmark.

--- a/specs/deepswe-harness/choices.md
+++ b/specs/deepswe-harness/choices.md
@@ -1,0 +1,108 @@
+# DeepSWE choices ledger
+
+## Needs user
+
+### $10 soft stop per rollout
+
+- **When:** Six-arm five-task tranche.
+- **The choice:** Each of the thirty model rollouts is asked to stop after its
+  recorded cost reaches $10. The controller also reserves a $20 in-flight
+  request cushion per rollout, so the tranche requires $900 of the authorized
+  $1,000. A long Opus or Fable attempt may therefore stop before it finishes.
+  The alternative is a higher per-rollout stop, which requires fewer tasks or a
+  larger total authorization.
+- **The gap:** The user fixed the task count and total budget but did not choose
+  how to distribute spend across rollouts.
+- **The reach:** This trades some expensive-model completion probability for
+  $100 of campaign-level overrun headroom.
+- **Verdict:** Needs user; provisionally sound for the first tranche because it
+  preserves equal limits across arms and is reversible by starting a new
+  campaign with a different stop.
+- **Confidence:** Medium.
+
+## Sound
+
+### Use the first five frozen tasks
+
+- **When:** Six-arm five-task tranche.
+- **The choice:** “Five each” means every arm receives the same first five task
+  IDs in the already-frozen seed order. The alternative is choosing tasks after
+  seeing their contents or results, which could make one model family look
+  better by accident.
+- **The gap:** The user specified the count but not which five tasks.
+- **The reach:** Later expansion can append the remaining five without changing
+  or cherry-picking the first tranche.
+- **Verdict:** Sound; it preserves the original random selection.
+- **Confidence:** High.
+
+### Treat Opus and Fable as standalone pure baselines
+
+- **When:** Six-arm five-task tranche.
+- **The choice:** Opus 5 pure and Fable 5 pure appear in the model comparison
+  table, while advisor regression categories remain limited to the two real
+  pure/advised pairs. The alternative would invent an advisor treatment the
+  user did not request.
+- **The gap:** The existing DeepSWE spec contained only the two advisor pairs.
+- **The reach:** Reports can compare all model families without confusing a
+  model baseline with evidence about advisor effectiveness.
+- **Verdict:** Sound; it matches the requested additions and keeps the
+  experiment honest.
+- **Confidence:** High.
+
+### Use Opus 5 at xhigh and Fable 5 at high
+
+- **When:** Six-arm five-task tranche.
+- **The choice:** The Opus baseline uses the current `opus-5` product shorthand
+  at xhigh reasoning; Fable uses `fable-5` at high. Both keep advisor disabled,
+  the product classifier, default memory, and the common Kimi vision fallback.
+  The alternative would change unrelated harness behavior or retain obsolete
+  Opus 4.8.
+- **The gap:** The user named the models but not their effort levels.
+- **The reach:** These settings become the model-family baseline for later
+  DeepSWE expansions.
+- **Verdict:** Sound; they match the established SWE-bench model-family
+  settings while honoring the requested Opus upgrade.
+- **Confidence:** High.
+
+### Run five task workers in parallel and six arms sequentially
+
+- **When:** Six-arm five-task tranche.
+- **The choice:** E2B starts one sandbox for each selected task. Inside a
+  sandbox, Pier runs one model arm at a time. Running arms together would make
+  two 8 GiB task/verifier environments compete inside a 16 GiB worker.
+- **The gap:** The user requested five runs per arm but did not specify inner
+  scheduling.
+- **The reach:** Pairing remains task-local, while wall-clock time falls through
+  safe outer concurrency.
+- **Verdict:** Sound; it uses the available parallelism without introducing
+  memory contention between arms.
+- **Confidence:** High.
+
+### Support every product gateway credential at the Pier boundary
+
+- **When:** Six-arm five-task tranche.
+- **The choice:** Benchmark workers forward whichever of the product-supported
+  Duet, Vercel AI Gateway, or OpenRouter credentials are present, and Pier
+  allows egress only to those three gateway domains. The alternative would make
+  the benchmark depend on a Duet-only key even though normal product model
+  resolution supports the other gateways.
+- **The gap:** The initial adapter handled only `DUET_API_KEY`, while this
+  machine has a Vercel AI Gateway key.
+- **The reach:** DeepSWE and SWE-bench now share one provider-credential owner
+  and cannot drift on which gateway keys are supported.
+- **Verdict:** Sound; it restores the normal product routing contract without
+  changing model behavior.
+- **Confidence:** High.
+
+### Require all six outcomes before publishing a complete report
+
+- **When:** Six-arm five-task tranche.
+- **The choice:** A report fails its completeness gate if any selected task is
+  missing any configured arm, including standalone Opus or Fable. The
+  alternative would let the paired advisor table look complete while a
+  standalone baseline silently used fewer tasks.
+- **The gap:** The earlier completion gate only understood advisor pairs.
+- **The reach:** Resolve and cost comparisons always use the same task
+  denominator.
+- **Verdict:** Sound; it prevents partial data from becoming a headline.
+- **Confidence:** High.

--- a/specs/deepswe-harness/choices.md
+++ b/specs/deepswe-harness/choices.md
@@ -22,6 +22,37 @@
 
 ## Sound
 
+### Stop the first campaign at the pure-only regression
+
+- **When:** The five GLM pairs finished during `pilot-5-six-arm-v1`.
+- **The choice:** Stop all remaining paid arms after `testem` resolved with
+  GLM pure but not with GLM + Kimi advisor, then preserve the partial campaign
+  for diagnosis. The alternative was spending through Kimi, Opus, and Fable
+  despite evidence that the advisor treatment could regress a solved task.
+- **The gap:** None; the user explicitly defined zero pure-only regressions as
+  the harness acceptance criterion.
+- **The reach:** The stopped campaign remains diagnostic evidence but cannot
+  become a six-arm headline.
+- **Verdict:** Sound and user-directed.
+- **Confidence:** High.
+
+### Fix advisor review at the product prompt
+
+- **When:** Trace analysis of the `testem` regression.
+- **The choice:** Add one generic advisor instruction to inspect literal
+  protocol syntax and name required per-line markers instead of adding a
+  benchmark-specific rule, forcing more advisor context, or retrying the
+  failed model outcome. The alternative prompt reproduced the actionable miss
+  in three of five compacted-context runs; the shorter correction found the
+  exact TAP `# ` prefix in five of five.
+- **The gap:** The existing advisor contract challenged executor-written tests
+  in general but did not reliably inspect line-oriented wire markers.
+- **The reach:** Every product advisor review becomes slightly stricter on
+  serialized output, while the benchmark remains unaware of TAP or this task.
+- **Verdict:** Sound; it fixes the general failure mode at its owner and adds a
+  live falsified regression eval.
+- **Confidence:** High.
+
 ### Use the first five frozen tasks
 
 - **When:** Six-arm five-task tranche.

--- a/specs/deepswe-harness/slices/01-pin-official-inputs.md
+++ b/specs/deepswe-harness/slices/01-pin-official-inputs.md
@@ -1,0 +1,24 @@
+# Slice 01 — Pin the official inputs
+
+## Contract
+
+A fresh checkout can fetch the exact DeepSWE and Pier sources and prove that
+the ten committed task identities still match their task metadata.
+
+## Seam
+
+`benchmarks/deepswe/src/manifest.ts` owns parsing and verification of the
+committed manifest. It does not execute tasks or know about model arms.
+
+## Verification
+
+- Assert exactly ten unique task IDs.
+- Assert every task exists in the pinned checkout and matches its repository,
+  base commit, language, and image reference.
+- Falsify by changing one task identity and confirm verification rejects it.
+- Run Pier's no-model `nop`/`oracle` smoke before paid model work.
+
+## Delegated choices
+
+Internal JSON parsing and error wording are delegated. Upstream identities,
+selection algorithm, task IDs, and verifier ownership are not.

--- a/specs/deepswe-harness/slices/02-pier-duet-adapter.md
+++ b/specs/deepswe-harness/slices/02-pier-duet-adapter.md
@@ -1,0 +1,34 @@
+# Slice 02 — Bridge Duet into Pier
+
+## Contract
+
+Pier can load Duet through its supported custom-agent import seam, run the
+exact compiled repository commit inside an official task container, preserve
+the RPC ledger and costs, then expose the committed patch to DeepSWE's official
+verifier.
+
+## Seam
+
+- `benchmarks/shared/duet-packaging.ts` owns the Linux Duet artifact.
+- `benchmarks/shared/duet-rpc-client.ts` owns bounded RPC driving.
+- `benchmarks/shared/rollout-telemetry.ts` owns cumulative wire accounting.
+- `benchmarks/deepswe/src/agent-driver.ts` runs that RPC client inside the task.
+- `benchmarks/deepswe/pier_agent.py` is the external Pier adapter boundary.
+
+The adapter must not reproduce DeepSWE scoring or patch extraction.
+
+## Verification
+
+- A fake Pier environment observes the exact artifact/config uploads and `/app`
+  workdir.
+- A synthetic RPC ledger proves final cumulative usage, per-model attribution,
+  unknown-event retention, and interruption reporting.
+- A temporary Git repository proves uncommitted work becomes visible in
+  `BASE..HEAD` only after the adapter's final commit.
+- Removing the final commit or a PGlite sidecar makes the focused test fail.
+
+## Delegated choices
+
+Temporary container paths and private helper names are delegated. The raw event
+contract, official working directory, artifact identity, and final commit are
+not.

--- a/specs/deepswe-harness/slices/03-execute-and-report.md
+++ b/specs/deepswe-harness/slices/03-execute-and-report.md
@@ -33,6 +33,10 @@ flight when interruption starts.
 - A missing arm or infrastructure failure blocks a headline paired comparison.
 - Synthetic results cover both-resolved, advisor-only, pure-only, and neither.
 - The first paid tranche runs the first five frozen tasks across six arms.
+- A pure-only regression stops the tranche before unrelated model-family spend;
+  the preserved trace must drive a general product fix and a fresh campaign.
+- DeepSWE passes `/app` as its repository root when deriving mutation-relative
+  advisor timing; SWE-bench retains its `/testbed` root.
 
 ## Delegated choices
 

--- a/specs/deepswe-harness/slices/03-execute-and-report.md
+++ b/specs/deepswe-harness/slices/03-execute-and-report.md
@@ -1,0 +1,41 @@
+# Slice 03 — Execute and report the pilot
+
+## Contract
+
+One command can run the four frozen arms over the ten frozen tasks through
+official Pier scoring, resume infrastructure failures, and report paired
+resolution plus cost/task and cost/resolved.
+
+## Seam
+
+The campaign expands into one outer shard per task. On E2B, up to ten workers
+run concurrently; each worker runs its task's four arms sequentially so
+DeepSWE's 8 GiB agent/verifier requirements do not compete inside a 16 GiB
+worker.
+
+The in-container driver derives usage from Duet's retained raw RPC ledger and
+Pier embeds that accounting in each trial `result.json`. The reporter consumes
+those official trial records; it never infers correctness from terminal text
+or locally run tests. Missing accounting blocks cost headlines instead of
+being treated as free.
+
+Paid-run admission requires the per-rollout soft stop plus one additional
+maximum-size request cushion. That cushion is derived from the context, output,
+and price ceilings of the pinned pilot models. It is not represented as a hard
+provider cap: normal product subagents can have several model requests in
+flight when interruption starts.
+
+## Verification
+
+- Pair validation rejects changed classifier, memory, fallback, effort, prompt,
+  task image, or Duet artifact within a pair.
+- Sharding produces ten task shards and forty arm outcomes.
+- A missing arm or infrastructure failure blocks a headline paired comparison.
+- Synthetic results cover both-resolved, advisor-only, pure-only, and neither.
+- A one-task four-arm live gate passes before the full pilot launches.
+
+## Delegated choices
+
+Report formatting and seeded within-task arm order are delegated. Denominator
+rules, paired categories, official reward ownership, and explicit budget
+admission are not.

--- a/specs/deepswe-harness/slices/03-execute-and-report.md
+++ b/specs/deepswe-harness/slices/03-execute-and-report.md
@@ -2,16 +2,15 @@
 
 ## Contract
 
-One command can run the four frozen arms over the ten frozen tasks through
+One command can run every configured arm over any frozen task subset through
 official Pier scoring, resume infrastructure failures, and report paired
 resolution plus cost/task and cost/resolved.
 
 ## Seam
 
-The campaign expands into one outer shard per task. On E2B, up to ten workers
-run concurrently; each worker runs its task's four arms sequentially so
-DeepSWE's 8 GiB agent/verifier requirements do not compete inside a 16 GiB
-worker.
+The campaign expands into one outer shard per task. On E2B, the workers run
+concurrently; each worker runs its task's arms sequentially so DeepSWE's 8 GiB
+agent/verifier requirements do not compete inside a 16 GiB worker.
 
 The in-container driver derives usage from Duet's retained raw RPC ledger and
 Pier embeds that accounting in each trial `result.json`. The reporter consumes
@@ -29,10 +28,11 @@ flight when interruption starts.
 
 - Pair validation rejects changed classifier, memory, fallback, effort, prompt,
   task image, or Duet artifact within a pair.
-- Sharding produces ten task shards and forty arm outcomes.
+- Sharding produces one task shard per selected task and one outcome per
+  configured arm.
 - A missing arm or infrastructure failure blocks a headline paired comparison.
 - Synthetic results cover both-resolved, advisor-only, pure-only, and neither.
-- A one-task four-arm live gate passes before the full pilot launches.
+- The first paid tranche runs the first five frozen tasks across six arms.
 
 ## Delegated choices
 

--- a/src/model-routing/prompts.ts
+++ b/src/model-routing/prompts.ts
@@ -89,8 +89,11 @@ export const ADVISOR_SYSTEM_PROMPT = dedent`
   pre-existing passing expectation as a suspected regression unless independent task evidence
   proves that behavior must change. Then try to falsify the proposed change against adjacent
   behavior, boundary inputs, failure paths, and compatibility. Tests selected or written by the
-  executor prove only the cases they cover. Do not dismiss a plausible regression because current
-  tests omit it. Approve only when the transcript resolves the most important risk.
+  executor prove only the cases they cover. For protocol-shaped output, inspect literal syntax
+  against the existing format; for line-oriented protocols, state the exact marker or comment
+  prefix each new line requires. Executor-written string assertions can encode the same defect.
+  Do not dismiss a plausible regression because current tests omit it. Approve only when the
+  transcript resolves the most important risk.
 
   Return at most 250 words. If the work is not ready, give a verdict, the single most important
   unresolved risk, and one concrete next check that consolidates the remaining evidence needed.


### PR DESCRIPTION
## Summary

- Pin the official DeepSWE v1.1/Pier inputs and a deterministic 10-task pilot.
- Run compiled Duet through Pier with six arms: GLM pure/advised, Kimi pure/Fable-advised, Opus 5 pure, and Fable pure.
- Preserve raw events, per-model usage, costs, committed patches, and official separate-verifier rewards.
- Add resumable E2B task sharding, all-arm completeness checks, paired regression reporting, and self-contained benchmark tests under `benchmarks/deepswe`.
- Move reusable provider-environment plumbing to `benchmarks/shared` and ignore generated benchmark outputs.

## First paid tranche

- Five frozen tasks across all six arms (30 rollouts).
- Five E2B sandboxes in parallel, with arms sequential inside each task.
- Opus pure uses `opus-5` at xhigh effort; Fable pure uses `fable-5` at high effort.

## Validation

- `bun run test:deepswe` — 25 passed
- `bun run test:swebench` — 98 passed
- `bun run check-types`
- `bun run lint`
- `bun run format`
- `bun run build`
- `bun benchmarks/deepswe/cli.ts setup`
- `bun benchmarks/deepswe/cli.ts verify`
- `bun benchmarks/deepswe/cli.ts smoke` — official no-model separate-verifier smoke completed; reward 0 expected
- Independent Codex review after report-completeness fix: no actionable correctness findings