### PR TITLE
feat(routing): expose tier closures, stamp x-duet-tier, accept per-prompt tier

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
       "types": "./dist/src/memory/store/index.d.ts",
       "import": "./dist/src/memory-store.js"
     },
+    "./routing-manifest": {
+      "types": "./dist/src/routing-manifest.d.ts",
+      "import": "./dist/src/routing-manifest.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/src/cli/rpc.ts
+++ b/src/cli/rpc.ts
@@ -5,12 +5,13 @@ import {
   PROVIDER_SHORTHANDS,
   resolveProviderShorthand,
 } from "../model-resolution/catalog.js";
-import { TurnRunner } from "../turn-runner/turn-runner.js";
+import { isDuetModelTier } from "../model-routing/active-tier.js";
 import {
   SystemRuntimeClock,
   type CancelScheduled,
   type RuntimeClock,
 } from "../turn-runner/runtime-clock.js";
+import { TurnRunner } from "../turn-runner/turn-runner.js";
 import type {
   RpcCommandAcceptedEvent,
   RpcEvent,
@@ -185,6 +186,8 @@ export interface RpcRunner {
   interrupt(command: TurnInterruptCommand): void;
   editFollowUpQueue(command: TurnEditFollowUpQueueCommand): void;
   compact(command: TurnCompactCommand): void | Promise<void>;
+  /** Retarget subsequent work before an RPC prompt carrying `tier` is dispatched. */
+  setModel(modelName: string): { routed: boolean };
 }
 
 /**
@@ -534,7 +537,15 @@ export async function driveRpcLoop(
         // join it via the runner's own queueing. turn() returns the same
         // activeTurnPromise for the whole chain, so we only track the
         // first promise and let the runner serialize everything else.
-        const { requestId, ...runnerCommand } = command;
+        const { requestId, ...correlatedCommand } = command;
+        let runnerCommand: Extract<TurnRunnerCommand, { type: "prompt" | "answer" | "wake" }>;
+        if (correlatedCommand.type === "prompt") {
+          const { tier, ...promptCommand } = correlatedCommand;
+          if (tier) runner.setModel(tier);
+          runnerCommand = promptCommand;
+        } else {
+          runnerCommand = correlatedCommand;
+        }
         const promise = runner.turn(runnerCommand, () => {
           emit({ type: "command_accepted", requestId, commandType: command.type });
         });
@@ -639,6 +650,17 @@ export function parseRpcCommandLine(rawLine: string): ParseRpcCommandLineResult 
     return {
       kind: "error",
       message: `RPC command "${commandType}" requires a non-empty string "requestId".`,
+    };
+  }
+  if (
+    commandType === "prompt" &&
+    (parsed as { tier?: unknown }).tier !== undefined &&
+    (typeof (parsed as { tier?: unknown }).tier !== "string" ||
+      !isDuetModelTier((parsed as { tier: string }).tier))
+  ) {
+    return {
+      kind: "error",
+      message: 'RPC command "prompt" tier must be one of "frontier", "balanced", or "economy".',
     };
   }
   return { kind: "command", command: parsed as RpcRunnerCommand };

--- a/src/memory/embedding.ts
+++ b/src/memory/embedding.ts
@@ -1,4 +1,8 @@
+import { activeDuetTier } from "../model-routing/active-tier.js";
 import { getDuetGatewayBaseUrl } from "../model-resolution/duet-gateway.js";
+import { DEFAULT_DUET_EMBEDDING_MODEL } from "../model-resolution/internal-models.js";
+
+export { DEFAULT_DUET_EMBEDDING_MODEL } from "../model-resolution/internal-models.js";
 
 /**
  * Client for Duet gateway embeddings.
@@ -29,8 +33,6 @@ import { getDuetGatewayBaseUrl } from "../model-resolution/duet-gateway.js";
 export const EMBEDDING_DIMENSIONS = 3072;
 /** Maximum input strings sent in a single embedding request. */
 export const EMBEDDING_BATCH_LIMIT = 100;
-/** Current Duet embedding default; matches the 3072-dim pgvector table. */
-export const DEFAULT_DUET_EMBEDDING_MODEL = "google/gemini-embedding-2";
 export const DUET_EMBEDDING_MODEL_ENV = "DUET_EMBEDDING_MODEL";
 
 const ENDPOINT_PATH = "/v1/embeddings";
@@ -144,11 +146,13 @@ async function postBatch(options: PostBatchOptions): Promise<EmbedResult> {
   let lastError: unknown;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
+      const tier = activeDuetTier();
       const response = await options.fetchImpl(options.url, {
         method: "POST",
         headers: {
           authorization: `Bearer ${options.apiKey}`,
           "content-type": "application/json",
+          ...(tier ? { "x-duet-tier": tier } : {}),
         },
         body: JSON.stringify({ model: options.model, input: options.inputs }),
       });

--- a/src/model-resolution/catalog.ts
+++ b/src/model-resolution/catalog.ts
@@ -1,4 +1,4 @@
-import { DUET_GATEWAY_API_KEY_ENV } from "./duet-gateway.js";
+import { DUET_GATEWAY_API_KEY_ENV } from "./duet-gateway-config.js";
 import type { ConnectedProviderId } from "../connected-providers/store.js";
 
 /** Metered providers considered by the router when resolving an unpinned model. */

--- a/src/model-resolution/duet-gateway-config.ts
+++ b/src/model-resolution/duet-gateway-config.ts
@@ -1,0 +1,5 @@
+/** Environment variable containing the organization-scoped Duet gateway token. */
+export const DUET_GATEWAY_API_KEY_ENV = "DUET_API_KEY";
+
+/** Environment variable overriding the Duet gateway origin. */
+export const DUET_GATEWAY_BASE_URL_ENV = "DUET_GATEWAY_BASE_URL";

--- a/src/model-resolution/duet-gateway.ts
+++ b/src/model-resolution/duet-gateway.ts
@@ -1,9 +1,14 @@
 import { getEnvApiKey, getModel, type Model } from "@earendil-works/pi-ai";
 import { isConnectedProviderId } from "../connected-providers/store.js";
+import { activeDuetTier } from "../model-routing/active-tier.js";
+import { BUILT_IN_DUET_GATEWAY_TIER_CLOSURES } from "../routing-manifest.js";
+import { DUET_GATEWAY_API_KEY_ENV, DUET_GATEWAY_BASE_URL_ENV } from "./duet-gateway-config.js";
 import {
   connectedProviderApiKey,
   refreshConnectedTokenInBackground,
 } from "../connected-providers/tokens.js";
+
+export { DUET_GATEWAY_API_KEY_ENV, DUET_GATEWAY_BASE_URL_ENV } from "./duet-gateway-config.js";
 
 const DEFAULT_DUET_GATEWAY_BASE_URL = "https://gateway.duet.so";
 const OPENAI_MODEL_PREFIX = "openai/";
@@ -84,9 +89,6 @@ const SONNET_5_COST = {
  * startup so users only need to set the duet token.
  */
 
-export const DUET_GATEWAY_API_KEY_ENV = "DUET_API_KEY";
-export const DUET_GATEWAY_BASE_URL_ENV = "DUET_GATEWAY_BASE_URL";
-
 export function getDuetGatewayBaseUrl(): string {
   const override = process.env[DUET_GATEWAY_BASE_URL_ENV]?.trim();
   if (override) return stripTrailingSlash(override);
@@ -109,6 +111,12 @@ export function getDuetGatewayBaseUrl(): string {
  * set for explicit `vercel-ai-gateway:*` pins.
  */
 export function resolveDuetGatewayModel(modelId: string): Model<any> {
+  const tier = activeDuetTier();
+  if (tier && !BUILT_IN_DUET_GATEWAY_TIER_CLOSURES[tier].includes(modelId)) {
+    throw new Error(
+      `Duet gateway model "${modelId}" is outside the built-in "${tier}" tier closure.`,
+    );
+  }
   const upstream = resolveDuetGatewayUpstream(modelId);
 
   return {
@@ -116,6 +124,7 @@ export function resolveDuetGatewayModel(modelId: string): Model<any> {
     provider: "duet-gateway",
     id: modelId,
     baseUrl: getDuetGatewayBaseUrlForModel(upstream),
+    ...(tier ? { headers: { ...upstream.headers, "x-duet-tier": tier } } : {}),
   };
 }
 

--- a/src/model-resolution/internal-models.ts
+++ b/src/model-resolution/internal-models.ts
@@ -1,0 +1,2 @@
+/** Current Duet embedding model; matches the memory store's 3072-dimension vectors. */
+export const DEFAULT_DUET_EMBEDDING_MODEL = "google/gemini-embedding-2";

--- a/src/model-routing/active-tier.ts
+++ b/src/model-routing/active-tier.ts
@@ -1,0 +1,27 @@
+/** Built-in virtual tiers accepted by the product-facing routing contract. */
+export const DUET_MODEL_TIERS = ["frontier", "balanced", "economy"] as const;
+
+/** Product-facing virtual tier whose gateway calls carry billing attribution. */
+export type DuetModelTier = (typeof DUET_MODEL_TIERS)[number];
+
+let activeTier: DuetModelTier | undefined;
+
+/** Current process-scoped tier, absent whenever the process is concretely pinned. */
+export function activeDuetTier(): DuetModelTier | undefined {
+  return activeTier;
+}
+
+/** True only for the three product-owned virtual tier ids. */
+export function isDuetModelTier(value: string | undefined): value is DuetModelTier {
+  return DUET_MODEL_TIERS.some((tier) => tier === value);
+}
+
+/**
+ * Update gateway attribution from the effective model selection.
+ *
+ * Concrete pins and non-routing commands clear the holder so a long-lived
+ * process cannot inherit a prior routed tier.
+ */
+export function setActiveDuetTierFromModelSelection(modelName: string | undefined): void {
+  activeTier = isDuetModelTier(modelName) ? modelName : undefined;
+}

--- a/src/routing-manifest.ts
+++ b/src/routing-manifest.ts
@@ -1,0 +1,74 @@
+import { walkVirtualRoute } from "./model-routing/resolve.js";
+import { DUET_MODEL_TIERS, type DuetModelTier } from "./model-routing/active-tier.js";
+import {
+  BUILT_IN_ROUTING_TABLE,
+  isVirtualModel,
+  type RoutingTable,
+} from "./model-routing/table.js";
+import { DEFAULT_CLI_MEMORY_MODEL, transportModelId } from "./model-resolution/catalog.js";
+import { DEFAULT_DUET_EMBEDDING_MODEL } from "./model-resolution/internal-models.js";
+
+export { DUET_MODEL_TIERS, type DuetModelTier } from "./model-routing/active-tier.js";
+
+/** Machine-readable tier-to-gateway-model closure used by product drift checks. */
+export type DuetGatewayTierClosures = Readonly<Record<DuetModelTier, readonly string[]>>;
+
+function gatewayModelId(modelName: string): string {
+  const modelId = transportModelId("duet-gateway", modelName);
+  if (!modelId) {
+    throw new Error(`Routing target "${modelName}" has no duet-gateway model id.`);
+  }
+  return modelId;
+}
+
+function concreteRouteTarget(table: RoutingTable, tier: string, route: string): string {
+  const walked = walkVirtualRoute(table, tier, route);
+  if (walked.cycle) {
+    throw new Error(`Virtual model cycle: ${walked.cycle.join(" -> ")}.`);
+  }
+  if (!walked.target) {
+    throw new Error(`Tier "${tier}" has no concrete target for route "${route}".`);
+  }
+  return walked.target.modelName;
+}
+
+/**
+ * Project the callable duet-gateway model ids for each built-in tier.
+ *
+ * Route targets and configured vision fallbacks are followed through virtual
+ * references. Advisors contribute only when enabled. The shared classifier,
+ * observational-memory actor, and embedding model belong to every tier.
+ */
+export function projectDuetGatewayTierClosures(table: RoutingTable): DuetGatewayTierClosures {
+  const closures = Object.fromEntries(
+    DUET_MODEL_TIERS.map((tier) => {
+      const definition = table.tiers[tier];
+      if (!definition) {
+        throw new Error(`Routing table is missing built-in tier "${tier}".`);
+      }
+
+      const modelIds = new Set<string>();
+      for (const [route, rule] of Object.entries(definition.routes)) {
+        modelIds.add(gatewayModelId(concreteRouteTarget(table, tier, route)));
+        if (rule.visionFallbackModelName) {
+          const fallback = isVirtualModel(rule.visionFallbackModelName, table)
+            ? concreteRouteTarget(table, rule.visionFallbackModelName, route)
+            : rule.visionFallbackModelName;
+          modelIds.add(gatewayModelId(fallback));
+        }
+      }
+      if (definition.advisor.enabled) {
+        modelIds.add(gatewayModelId(definition.advisor.target.modelName));
+      }
+      modelIds.add(gatewayModelId(table.classifier.target.modelName));
+      modelIds.add(gatewayModelId(DEFAULT_CLI_MEMORY_MODEL));
+      modelIds.add(DEFAULT_DUET_EMBEDDING_MODEL);
+      return [tier, Object.freeze([...modelIds])] as const;
+    }),
+  );
+  return Object.freeze(closures) as DuetGatewayTierClosures;
+}
+
+/** Built-in billing closures projected from the router's own source table. */
+export const BUILT_IN_DUET_GATEWAY_TIER_CLOSURES =
+  projectDuetGatewayTierClosures(BUILT_IN_ROUTING_TABLE);

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -27,6 +27,7 @@ import dedent from "dedent";
 import { stripSystemReminders, systemReminder } from "../lib/system-reminder.js";
 
 import { assistantText } from "../core/serializer.js";
+import { setActiveDuetTierFromModelSelection } from "../model-routing/active-tier.js";
 import { classifyRoute } from "../model-routing/classifier.js";
 import type { ClassifyRouteOptions } from "../model-routing/classifier.js";
 import { loadRoutingTable } from "../model-routing/loader.js";
@@ -585,6 +586,7 @@ export class TurnRunner {
     this.memoryPersistence = undefined;
     await this.mcpRuntime?.dispose();
     this.mcpRuntime = undefined;
+    setActiveDuetTierFromModelSelection(undefined);
   }
 
   subscribe(handler: TurnEventHandler): () => void {
@@ -739,6 +741,9 @@ export class TurnRunner {
    * sees available skills before typing the first prompt.
    */
   async start(command: TurnStartCommand): Promise<TurnState> {
+    setActiveDuetTierFromModelSelection(
+      command.options?.model ?? command.state?.options?.model ?? this.config.model,
+    );
     await ensureFreshConnectedTokens();
     await this.ensureMemoryLoaded();
     await this.ensureSkillsLoaded();
@@ -3442,6 +3447,7 @@ export class TurnRunner {
     const selection = this.pendingModelSelection;
     if (!selection) return;
     this.pendingModelSelection = undefined;
+    setActiveDuetTierFromModelSelection(selection);
     if (!this.isVirtualModelSelection(selection)) {
       this.modelRouter?.pin();
       this.advisorPolicy = undefined;

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,5 +1,6 @@
 import type { ImageContent, TextContent, ThinkingLevel, Usage } from "@earendil-works/pi-ai";
 import type { RouterSwitch } from "../model-routing/router.js";
+import type { DuetModelTier } from "../model-routing/active-tier.js";
 import type { TransportName } from "../model-resolution/catalog.js";
 import type { TaskDescriptor, TaskId, TaskSettlement } from "../tasks/types.js";
 
@@ -587,8 +588,20 @@ export type TurnRunnerCommand =
   | TurnEditFollowUpQueueCommand
   | TurnCompactCommand;
 
-/** RPC transport envelope for commands whose delivery must be correlated. */
-export type RpcTurnCommand = TurnCommand & { requestId: string };
+/** RPC prompt envelope whose tier, when present, is applied before prompt dispatch. */
+export type RpcPromptCommand = TurnPromptCommand & {
+  requestId: string;
+  /**
+   * Virtual tier selected atomically before this prompt reaches the runner.
+   * Optional so the new agent remains wire-compatible with pre-tier gateways.
+   */
+  tier?: DuetModelTier;
+};
+
+/** RPC transport envelope for correlated answer and wake commands. */
+export type RpcTurnCommand =
+  | RpcPromptCommand
+  | ((TurnAnswerCommand | TurnWakeCommand) & { requestId: string });
 
 /** Commands accepted by the newline-delimited RPC transport. */
 export type RpcRunnerCommand =

--- a/test/cli-rpc.test.ts
+++ b/test/cli-rpc.test.ts
@@ -69,6 +69,7 @@ interface RecordedRunner extends RpcRunner {
   interrupts: TurnInterruptCommand[];
   editQueues: TurnEditFollowUpQueueCommand[];
   compacts: TurnCompactCommand[];
+  actions: string[];
   acceptNextTurn: () => void;
   resolveTurn: (terminal: TurnTerminalEvent) => void;
 }
@@ -109,6 +110,7 @@ function buildRunner(): RecordedRunner {
     interrupts: [],
     editQueues: [],
     compacts: [],
+    actions: [],
     acceptNextTurn() {
       pendingAcceptances.shift()?.();
     },
@@ -117,6 +119,7 @@ function buildRunner(): RecordedRunner {
       runner.starts.push(command);
     },
     async turn(command, onAccepted) {
+      runner.actions.push(`turn:${command.type}`);
       runner.turns.push(command);
       if (onAccepted) pendingAcceptances.push(onAccepted);
       return turnPromise;
@@ -129,6 +132,10 @@ function buildRunner(): RecordedRunner {
     },
     compact(command) {
       runner.compacts.push(command);
+    },
+    setModel(modelName) {
+      runner.actions.push(`tier:${modelName}`);
+      return { routed: true };
     },
   };
   return runner;
@@ -575,6 +582,17 @@ describe("parseRpcCommandLine", () => {
       expect(result.message).toMatch(/requestId/);
     }
   });
+
+  test("rejects prompt tiers outside the product tier contract", () => {
+    const result = parseRpcCommandLine(
+      '{"type":"prompt","requestId":"req","tier":"premium","message":"hello","behavior":"steer"}',
+    );
+
+    expect(result).toEqual({
+      kind: "error",
+      message: 'RPC command "prompt" tier must be one of "frontier", "balanced", or "economy".',
+    });
+  });
 });
 
 describe("RpcEventWriter", () => {
@@ -786,6 +804,36 @@ describe("driveRpcLoop", () => {
     await loop;
     expect(runner.starts).toEqual([{ type: "start" }]);
     expect(runner.turns).toEqual([{ type: "prompt", message: "hi", behavior: "follow_up" }]);
+  });
+
+  test("applies an optional prompt tier atomically before handing the prompt to the runner", async () => {
+    const runner = buildRunner();
+    const terminal: TurnTerminalEvent = {
+      type: "complete",
+      status: "completed",
+      state: {} as never,
+    };
+    const loop = driveRpcLoop(
+      runner,
+      commandStream([
+        { type: "start" },
+        {
+          type: "prompt",
+          requestId: "request-tier",
+          tier: "balanced",
+          message: "use the new tier",
+          behavior: "follow_up",
+        },
+      ]),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    runner.resolveTurn(terminal);
+    await loop;
+
+    expect(runner.actions).toEqual(["tier:balanced", "turn:prompt"]);
+    expect(runner.turns).toEqual([
+      { type: "prompt", message: "use the new tier", behavior: "follow_up" },
+    ]);
   });
 
   test("emits a soft error and keeps waiting when the first command is not start", async () => {

--- a/test/model-routing-clamp.test.ts
+++ b/test/model-routing-clamp.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { setActiveDuetTierFromModelSelection } from "../src/model-routing/active-tier.js";
+import { resolveRoute } from "../src/model-routing/resolve.js";
+import { BUILT_IN_ROUTING_TABLE } from "../src/model-routing/table.js";
+import { transportModelId } from "../src/model-resolution/catalog.js";
+import { resolveDuetGatewayModel } from "../src/model-resolution/duet-gateway.js";
+import { routingCatalogAdapter } from "../src/model-resolution/resolver.js";
+
+afterEach(() => {
+  setActiveDuetTierFromModelSelection(undefined);
+});
+
+describe("duet-gateway routing override clamp", () => {
+  test("rejects an override target outside the active built-in tier closure", () => {
+    const table = structuredClone(BUILT_IN_ROUTING_TABLE);
+    table.tiers.economy.routes.implement.target.modelName = "sol";
+    const target = resolveRoute(
+      table,
+      "economy",
+      "implement",
+      { hasImages: false },
+      routingCatalogAdapter,
+    );
+    const gatewayModelId = transportModelId("duet-gateway", target.modelName);
+    if (!gatewayModelId) throw new Error("test target needs a duet-gateway id");
+
+    setActiveDuetTierFromModelSelection("economy");
+
+    expect(() => resolveDuetGatewayModel(gatewayModelId)).toThrow(
+      /openai\/gpt-5\.6-sol.*outside.*economy/i,
+    );
+  });
+
+  test("allows narrowing and reordering when every target remains in closure", () => {
+    const table = structuredClone(BUILT_IN_ROUTING_TABLE);
+    table.tiers.economy.routes = {
+      general: table.tiers.economy.routes.general,
+      implement: {
+        ...table.tiers.economy.routes.implement,
+        target: { modelName: "luna", thinkingLevel: "low" },
+      },
+    };
+    const target = resolveRoute(
+      table,
+      "economy",
+      "implement",
+      { hasImages: false },
+      routingCatalogAdapter,
+    );
+    const gatewayModelId = transportModelId("duet-gateway", target.modelName);
+    if (!gatewayModelId) throw new Error("test target needs a duet-gateway id");
+
+    setActiveDuetTierFromModelSelection("economy");
+
+    expect(resolveDuetGatewayModel(gatewayModelId)).toMatchObject({
+      id: "openai/gpt-5.6-luna",
+      headers: { "x-duet-tier": "economy" },
+    });
+  });
+
+  test("does not clamp concrete pins or non-duet-gateway transports", () => {
+    setActiveDuetTierFromModelSelection("duet:openai/gpt-5.6-sol");
+    expect(() => resolveDuetGatewayModel("openai/gpt-5.6-sol")).not.toThrow();
+
+    setActiveDuetTierFromModelSelection("economy");
+    expect(() =>
+      routingCatalogAdapter.modelAcceptsImages("vercel-ai-gateway:openai/gpt-5.6-sol"),
+    ).not.toThrow();
+  });
+});

--- a/test/routing-manifest.test.ts
+++ b/test/routing-manifest.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BUILT_IN_DUET_GATEWAY_TIER_CLOSURES,
+  projectDuetGatewayTierClosures,
+} from "../src/routing-manifest.js";
+import { BUILT_IN_ROUTING_TABLE } from "../src/model-routing/table.js";
+
+describe("duet-gateway routing manifest", () => {
+  test("projects routes, vision fallbacks, enabled advisors, and shared internal models", () => {
+    expect(projectDuetGatewayTierClosures(BUILT_IN_ROUTING_TABLE)).toEqual({
+      frontier: [
+        "moonshotai/kimi-k3",
+        "anthropic/claude-fable-5",
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-opus-5",
+        "openai/gpt-5.6-luna",
+        "google/gemini-embedding-2",
+      ],
+      balanced: [
+        "moonshotai/kimi-k3",
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-terra",
+        "anthropic/claude-sonnet-5",
+        "anthropic/claude-fable-5",
+        "openai/gpt-5.6-luna",
+        "google/gemini-embedding-2",
+      ],
+      economy: ["openai/gpt-5.6-luna", "zai/glm-5.2", "google/gemini-embedding-2"],
+    });
+    expect(BUILT_IN_DUET_GATEWAY_TIER_CLOSURES).toEqual(
+      projectDuetGatewayTierClosures(BUILT_IN_ROUTING_TABLE),
+    );
+
+    // Economy's disabled Terra advisor is configuration documentation only,
+    // not callable traffic and therefore not part of its billing closure.
+    expect(BUILT_IN_DUET_GATEWAY_TIER_CLOSURES.economy).not.toContain("openai/gpt-5.6-terra");
+  });
+
+  test("follows a distinct configured vision fallback and ignores a disabled advisor target", () => {
+    const table = structuredClone(BUILT_IN_ROUTING_TABLE);
+    table.tiers.economy.routes.implement.visionFallbackModelName = "kimi";
+    table.tiers.economy.advisor.target.modelName = "sol";
+
+    const projected = projectDuetGatewayTierClosures(table);
+
+    expect(projected.economy).toContain("moonshotai/kimi-k3");
+    expect(projected.economy).not.toContain("openai/gpt-5.6-sol");
+  });
+});

--- a/test/tier-header.test.ts
+++ b/test/tier-header.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createEmbeddingClient } from "../src/memory/embedding.js";
+import {
+  activeDuetTier,
+  setActiveDuetTierFromModelSelection,
+} from "../src/model-routing/active-tier.js";
+import { resolveDuetGatewayModel } from "../src/model-resolution/duet-gateway.js";
+import { resolveModelName } from "../src/model-resolution/resolver.js";
+import type { DuetModelTier } from "../src/routing-manifest.js";
+import { TurnRunner } from "../src/turn-runner/turn-runner.js";
+
+afterEach(() => {
+  setActiveDuetTierFromModelSelection(undefined);
+});
+
+const callSites: Record<DuetModelTier, ReadonlyArray<[string, string]>> = {
+  frontier: [
+    ["actor", "openai/gpt-5.6-sol"],
+    ["classifier", "openai/gpt-5.6-luna"],
+    ["advisor", "anthropic/claude-fable-5"],
+    ["vision-fallback", "moonshotai/kimi-k3"],
+    ["subagent", "openai/gpt-5.6-sol"],
+    ["memory", "openai/gpt-5.6-luna"],
+  ],
+  balanced: [
+    ["actor", "openai/gpt-5.6-terra"],
+    ["classifier", "openai/gpt-5.6-luna"],
+    ["advisor", "anthropic/claude-fable-5"],
+    ["vision-fallback", "moonshotai/kimi-k3"],
+    ["subagent", "openai/gpt-5.6-sol"],
+    ["memory", "openai/gpt-5.6-luna"],
+  ],
+  economy: [
+    ["actor", "openai/gpt-5.6-luna"],
+    ["classifier", "openai/gpt-5.6-luna"],
+    ["vision-fallback", "openai/gpt-5.6-luna"],
+    ["subagent", "zai/glm-5.2"],
+    ["memory", "openai/gpt-5.6-luna"],
+  ],
+};
+
+describe("x-duet-tier model headers", () => {
+  test("covers every routed duet-gateway call site and never leaks from a concrete pin", () => {
+    for (const [tier, sites] of Object.entries(callSites) as Array<
+      [DuetModelTier, ReadonlyArray<[string, string]>]
+    >) {
+      setActiveDuetTierFromModelSelection(tier);
+      expect(activeDuetTier(), tier).toBe(tier);
+      for (const [site, modelId] of sites) {
+        expect(resolveDuetGatewayModel(modelId).headers?.["x-duet-tier"], `${tier} ${site}`).toBe(
+          tier,
+        );
+      }
+
+      setActiveDuetTierFromModelSelection("duet:anthropic/claude-opus-5");
+      expect(activeDuetTier(), `${tier} concrete pin`).toBeUndefined();
+      for (const [site, modelId] of sites) {
+        expect(
+          resolveDuetGatewayModel(modelId).headers?.["x-duet-tier"],
+          `pin after ${tier} ${site}`,
+        ).toBeUndefined();
+      }
+    }
+  });
+
+  test("does not stamp non-duet-gateway transports", () => {
+    setActiveDuetTierFromModelSelection("frontier");
+
+    expect(
+      resolveModelName("vercel-ai-gateway:openai/gpt-5.6-sol").headers?.["x-duet-tier"],
+    ).toBeUndefined();
+    expect(
+      resolveModelName("openrouter:openai/gpt-5.6-sol").headers?.["x-duet-tier"],
+    ).toBeUndefined();
+  });
+
+  test("stamps embeddings only while a routed tier is active", async () => {
+    const captured: Array<Headers> = [];
+    const embed = createEmbeddingClient({
+      apiKey: "test-key",
+      baseUrl: "https://example.test",
+      fetch: (async (_input: string | URL | Request, init?: RequestInit) => {
+        captured.push(new Headers(init?.headers));
+        return new Response(
+          JSON.stringify({
+            data: [{ embedding: [1] }],
+            model: "google/gemini-embedding-2",
+          }),
+        );
+      }) as typeof fetch,
+    });
+
+    setActiveDuetTierFromModelSelection("economy");
+    await embed(["routed"]);
+    setActiveDuetTierFromModelSelection("duet:openai/gpt-5.6-luna");
+    await embed(["pinned"]);
+
+    expect(captured.map((headers) => headers.get("x-duet-tier"))).toEqual(["economy", null]);
+  });
+
+  test("boot and tier flips retarget actor and auxiliary gateway calls together", async () => {
+    const previousKey = process.env.DUET_API_KEY;
+    process.env.DUET_API_KEY = "tier-flip-test-key";
+    const runner = new TurnRunner({
+      model: "economy",
+      mode: "agent",
+      memoryDbPath: false,
+      memoryStores: false,
+      skillDiscovery: { includeDefaults: false },
+    });
+
+    try {
+      await runner.start({ type: "start", mode: "agent" });
+      expect(activeDuetTier()).toBe("economy");
+      expect(runner.routeStatus()?.modelName).toBe("luna");
+      expect(
+        resolveDuetGatewayModel("openai/gpt-5.6-luna").headers?.["x-duet-tier"],
+        "classifier before flip",
+      ).toBe("economy");
+
+      expect(runner.setModel("frontier")).toEqual({ routed: true });
+      expect(activeDuetTier()).toBe("frontier");
+      expect(runner.getState()?.options?.model).toBe("frontier");
+      expect(
+        resolveDuetGatewayModel("anthropic/claude-fable-5").headers?.["x-duet-tier"],
+        "advisor after flip",
+      ).toBe("frontier");
+      expect(
+        resolveDuetGatewayModel("openai/gpt-5.6-luna").headers?.["x-duet-tier"],
+        "memory after flip",
+      ).toBe("frontier");
+
+      runner.setModel("duet:anthropic/claude-opus-5");
+      expect(activeDuetTier()).toBeUndefined();
+      expect(
+        resolveDuetGatewayModel("openai/gpt-5.6-luna").headers?.["x-duet-tier"],
+        "memory after concrete pin",
+      ).toBeUndefined();
+    } finally {
+      await runner.dispose();
+      if (previousKey === undefined) delete process.env.DUET_API_KEY;
+      else process.env.DUET_API_KEY = previousKey;
+    }
+  });
+});

--- a/test/turn-runner-router.test.ts
+++ b/test/turn-runner-router.test.ts
@@ -778,7 +778,10 @@ describe("TurnRunner virtual-model adapter", () => {
       // haiku-4.5's real 200k window is the smallest in the catalog — luna
       // previously served this role only because its synthesized spec
       // under-reported 256k; its true window is 1.05M.
-      planTarget: { modelName: "haiku-4.5", thinkingLevel: "low" },
+      planTarget: {
+        modelName: "vercel-ai-gateway:anthropic/claude-haiku-4.5",
+        thinkingLevel: "low",
+      },
       effectiveContext: 2_000_000,
     });
     await startRunner(runner, []);


### PR DESCRIPTION
Agent-side half of duet's **virtual model tiers** feature (slice 02 of
`specs/virtual-model-tiers/` in the duet repo). The product is moving from
"pick a concrete model" to three virtual tiers — `frontier | balanced |
economy`, shown to users as Max / Standard / Lite — with flat per-tier token
billing. This PR gives the product the seams it needs to do that.

**The version is deliberately still 0.3.5.** Publishing is a separate,
human-owned step; duet's slices 03 (pin bump + drift test) and 04 (VM image
rebuild) are blocked on it.

## What's in it

**1. `./routing-manifest` export** — projects each virtual tier's closure of
gateway model ids from the router table, importable without pulling in CLI
runtime. The product needs this to validate billing claims and to disclose
"what does Max actually use?" in its picker.

Closure rule: direct route targets + vision fallbacks + **enabled** advisor
targets + the shared classifier + internal memory/embedding models. Economy's
advisor is disabled, so its target is excluded — otherwise a Lite session could
bill Standard-class traffic at Lite rates.

**2. `x-duet-tier` on gateway calls** — a process-scoped active-tier holder,
set at boot from the resolved `--model` and updated on every tier flip, stamped
from the single duet-gateway model construction point. It covers actor,
classifier, advisor, vision-fallback, subagent, memory **and** embedding calls
(embedding uses its own direct fetch, so it's stamped there too).

Deliberately headerless: concrete pins (`duet:<id>`), non-routed contexts
(train, `duet model`, memory-only CLI), and non-duet-gateway transports
(connected-provider, Vercel, OpenRouter). A test asserts a concrete pin never
leaks a tier header, so the product can fail closed on unattributed traffic.

**3. Optional per-prompt `tier` on the RPC prompt command** — applied
atomically before the prompt reaches the turn runner, so a running agent
switches tier on the next turn instead of only on relaunch. Optional on the
wire on purpose: a 0.4.0 agent still runs under a pre-cutover gateway.

**4. Override clamp** — a local `.duet/models.json` may narrow or reorder a
tier's routes but cannot target a model outside that tier's built-in closure
while running a virtual tier against duet-gateway. Without this, a local file
could silently widen the billing/security closure.

## Verification

- 44 new tests: header matrix (call-site × tier × pin/no-pin), tier-flip
  propagation to auxiliary calls, closure projection incl. the disabled-advisor
  exclusion, RPC ordering, and clamp behavior.
- `check-types`, `lint`, `format:check`, `build` all pass; existing routing and
  concrete-pin suites stay green.
- One existing synthetic router fixture was repinned to Vercel so it keeps
  testing context-window behavior without violating the new closure rule.

## Note for the reviewer

The manifest orders each closure route-first; duet's `MODEL_TIERS` sorts the
same ids alphabetically. Same membership, different order — the drift test on
the duet side must compare **sets**, not arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SmJorRXHJmsZcSzE3AidL
