### PR TITLE
perf: overlap turn startup initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,9 +516,9 @@ const terminal = await turnRunner.turn({
 
 ```mermaid
 flowchart TD
-  Start["start(command)"] --> Setup["hydrate memory\nload skills + agent files\nconnect MCP servers"]
-  Setup --> State["create or resume TurnState"]
-  State --> Parent["initialize parent pi agent"]
+  Start["start(command)"] --> State["create or resume TurnState"]
+  State --> Setup["hydrate concurrently:\nconnected tokens · durable memory\nskills + agent files · MCP servers\nrouting table"]
+  Setup --> Parent["initialize parent pi agent"]
   Parent --> Started["emit turn_started"]
 
   Started --> Command["turn(prompt | answer | wake)"]

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ const terminal = await turnRunner.turn({
 <details>
 <summary><b>TurnRunner lifecycle</b> — full flowchart and event model</summary>
 
-`start()` prepares a session, but it does not run agent work. It hydrates durable memory, loads skills and agent files, connects MCP servers, creates or resumes `TurnState`, initializes the parent pi agent, and emits `turn_started`. After that, every `turn()` call accepts one command: `prompt`, `answer`, or `wake`.
+`start()` prepares a session, but it does not run agent work. It prepares the initial `TurnState` and initializes independent resources concurrently, then initializes the parent pi agent and emits `turn_started` only when the first prompt can use the fully hydrated memory, skills, routing, and MCP tool set. After that, every `turn()` call accepts one command: `prompt`, `answer`, or `wake`.
 
 ```mermaid
 flowchart TD

--- a/src/turn-runner/skill-context.ts
+++ b/src/turn-runner/skill-context.ts
@@ -17,21 +17,22 @@ export class SkillContext {
   private skills: Skill[];
   private collisions: SkillCollision[] = [];
   private loaded = false;
+  /** Shared async discovery so concurrent callers never observe the unexpanded baseline. */
+  private loading?: Promise<void>;
 
   constructor(private readonly config: TurnRunnerConfig) {
-    this.skills = config.skills ? prepareExplicitSkills(config.skills) : [];
+    this.skills = config.skills ? [...config.skills] : [];
   }
 
   async ensureLoaded(): Promise<void> {
     if (this.loaded) return;
-    this.loaded = true;
-
-    const discovered = loadDiscoveredSkills(
-      this.config.skillDiscovery,
-      this.config.cwd ?? process.cwd(),
-    );
-    this.skills = mergeSkillsByName(this.skills, discovered.skills);
-    this.collisions = discovered.collisions;
+    const loading = this.loading ?? this.load();
+    this.loading = loading;
+    try {
+      await loading;
+    } finally {
+      if (this.loading === loading) this.loading = undefined;
+    }
   }
 
   /**
@@ -40,11 +41,27 @@ export class SkillContext {
    * `config.skills` is preserved; on-disk discovery is re-read.
    */
   async reload(): Promise<void> {
-    const baseline = this.config.skills ? prepareExplicitSkills(this.config.skills) : [];
-    const discovered = loadDiscoveredSkills(
-      this.config.skillDiscovery,
-      this.config.cwd ?? process.cwd(),
-    );
+    const prior = this.loading;
+    const loading = (async () => {
+      // Queue reloads so an older discovery snapshot cannot finish last and
+      // overwrite a newer one. A failed prior load must not prevent retry.
+      await prior?.catch(() => undefined);
+      this.loaded = false;
+      await this.load();
+    })();
+    this.loading = loading;
+    try {
+      await loading;
+    } finally {
+      if (this.loading === loading) this.loading = undefined;
+    }
+  }
+
+  private async load(): Promise<void> {
+    const [baseline, discovered] = await Promise.all([
+      prepareExplicitSkills(this.config.skills ?? []),
+      loadDiscoveredSkills(this.config.skillDiscovery, this.config.cwd ?? process.cwd()),
+    ]);
     this.skills = mergeSkillsByName(baseline, discovered.skills);
     this.collisions = discovered.collisions;
     this.loaded = true;

--- a/src/turn-runner/skills.ts
+++ b/src/turn-runner/skills.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, sep } from "node:path";
@@ -67,54 +67,112 @@ function uniquePaths(paths: string[]): string[] {
 }
 
 const SKILL_SHELL_EXPANSION_TIMEOUT_MS = 30_000;
+/** Overlap hung metadata commands without stampeding a resource-constrained runner host. */
+const SKILL_METADATA_EXPANSION_CONCURRENCY = 4;
+const SKILL_SHELL_EXPANSION_OPTIONS = {
+  encoding: "utf-8",
+  maxBuffer: 1024 * 1024,
+  timeout: SKILL_SHELL_EXPANSION_TIMEOUT_MS,
+} as const;
 
-function expandSkillShellCommands(content: string, cwd: string): string {
+function expandSkillShellCommandsSync(content: string, cwd: string): string {
   return content.replace(SKILL_SHELL_EXPANSION_PATTERN, (match, command: string) => {
     try {
       const output = execFileSync("bash", ["-lc", command], {
         cwd,
-        encoding: "utf-8",
-        maxBuffer: 1024 * 1024,
-        timeout: SKILL_SHELL_EXPANSION_TIMEOUT_MS,
+        ...SKILL_SHELL_EXPANSION_OPTIONS,
       });
       return output.trimEnd();
     } catch (error) {
-      // On timeout or non-zero exit, fall back to the literal token plus a
-      // brief note so the model sees what was attempted instead of failing
-      // the entire prompt. Node sets `signal` to "SIGTERM" when the
-      // timeout fires; everything else is treated as a generic failure.
-      const signal = (error as { signal?: string } | null)?.signal;
-      const note =
-        signal === "SIGTERM"
-          ? `timed out after ${SKILL_SHELL_EXPANSION_TIMEOUT_MS / 1000}s`
-          : `failed: ${(error as Error).message}`;
-      return `${match} (${note})`;
+      return failedSkillShellExpansion(match, error);
     }
   });
 }
 
-function expandSkillMetadata(skill: Skill): Skill {
+async function expandSkillShellCommands(content: string, cwd: string): Promise<string> {
+  const matches = [...content.matchAll(SKILL_SHELL_EXPANSION_PATTERN)];
+  const expansions: string[] = [];
+  // Expansions within one description retain their historical left-to-right
+  // ordering because later commands may consume side effects from earlier ones.
+  // Concurrency belongs between independent skills, not within one skill.
+  for (const match of matches) {
+    expansions.push(await runSkillShellCommand(match[0], match[1]!, cwd));
+  }
+
+  let expanded = "";
+  let offset = 0;
+  for (const [index, match] of matches.entries()) {
+    expanded += content.slice(offset, match.index) + expansions[index]!;
+    offset = match.index! + match[0].length;
+  }
+  return expanded + content.slice(offset);
+}
+
+function runSkillShellCommand(match: string, command: string, cwd: string): Promise<string> {
+  return new Promise((resolve) => {
+    execFile(
+      "bash",
+      ["-lc", command],
+      {
+        cwd,
+        ...SKILL_SHELL_EXPANSION_OPTIONS,
+      },
+      (error, stdout) => {
+        resolve(error ? failedSkillShellExpansion(match, error) : stdout.trimEnd());
+      },
+    );
+  });
+}
+
+function failedSkillShellExpansion(match: string, error: unknown): string {
+  // Keep the literal token visible on failure so the model can see what was
+  // attempted. Node reports timeout termination through the child signal.
+  const signal = (error as { signal?: string } | null)?.signal;
+  const note =
+    signal === "SIGTERM"
+      ? `timed out after ${SKILL_SHELL_EXPANSION_TIMEOUT_MS / 1000}s`
+      : `failed: ${error instanceof Error ? error.message : String(error)}`;
+  return `${match} (${note})`;
+}
+
+async function expandSkillMetadata(skill: Skill): Promise<Skill> {
   return {
     ...skill,
-    description: expandSkillShellCommands(skill.description, skill.baseDir),
+    description: await expandSkillShellCommands(skill.description, skill.baseDir),
   };
 }
 
-export function prepareExplicitSkills(skills: readonly Skill[]): Skill[] {
-  return skills.map(expandSkillMetadata);
+export function prepareExplicitSkills(skills: readonly Skill[]): Promise<Skill[]> {
+  return expandSkillMetadataConcurrently(skills);
 }
 
-export function loadDiscoveredSkills(
+export async function loadDiscoveredSkills(
   discoveryOptions: SkillDiscoveryOptions | undefined,
   cwd: string,
-): DiscoveredSkillsResult {
+): Promise<DiscoveredSkillsResult> {
   const { skills, diagnostics } = loadSkills(buildSkillDiscoveryOptions(discoveryOptions, cwd));
   // User/project skills win on name collisions, so built-ins are merged
   // last and silently dropped when shadowed.
   return {
-    skills: mergeSkillsByName(skills.map(expandSkillMetadata), listBuiltInSkills()),
+    skills: mergeSkillsByName(await expandSkillMetadataConcurrently(skills), listBuiltInSkills()),
     collisions: extractSkillCollisions(diagnostics),
   };
+}
+
+async function expandSkillMetadataConcurrently(skills: readonly Skill[]): Promise<Skill[]> {
+  const expanded: Skill[] = [];
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(SKILL_METADATA_EXPANSION_CONCURRENCY, skills.length) },
+    async () => {
+      while (nextIndex < skills.length) {
+        const index = nextIndex++;
+        expanded[index] = await expandSkillMetadata(skills[index]!);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return expanded;
 }
 
 /**
@@ -164,7 +222,7 @@ export function readSkillInstructions(skill: Skill): string {
   const builtIn = getBuiltInSkillInstructions(skill.filePath);
   if (builtIn !== undefined) return builtIn;
   const content = readFileSync(skill.filePath, "utf-8");
-  return expandSkillShellCommands(content, skill.baseDir);
+  return expandSkillShellCommandsSync(content, skill.baseDir);
 }
 
 /**

--- a/src/turn-runner/skills.ts
+++ b/src/turn-runner/skills.ts
@@ -91,21 +91,22 @@ function expandSkillShellCommandsSync(content: string, cwd: string): string {
 
 async function expandSkillShellCommands(content: string, cwd: string): Promise<string> {
   const matches = [...content.matchAll(SKILL_SHELL_EXPANSION_PATTERN)];
-  const expansions: string[] = [];
+  if (matches.length === 0) return content;
+
   // Expansions within one description retain their historical left-to-right
   // ordering because later commands may consume side effects from earlier ones.
   // Concurrency belongs between independent skills, not within one skill.
+  const expansions: string[] = [];
   for (const match of matches) {
     expansions.push(await runSkillShellCommand(match[0], match[1]!, cwd));
   }
 
-  let expanded = "";
-  let offset = 0;
-  for (const [index, match] of matches.entries()) {
-    expanded += content.slice(offset, match.index) + expansions[index]!;
-    offset = match.index! + match[0].length;
-  }
-  return expanded + content.slice(offset);
+  // `replace` re-walks the same matches in the same order, so splicing the
+  // results back in stays the sync path's mechanism rather than a second
+  // hand-rolled one. A function replacement is inserted literally, so `$&`
+  // in command output cannot be reinterpreted.
+  let next = 0;
+  return content.replace(SKILL_SHELL_EXPANSION_PATTERN, () => expansions[next++]!);
 }
 
 function runSkillShellCommand(match: string, command: string, cwd: string): Promise<string> {

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -203,6 +203,18 @@ interface TurnRunnerDependencies {
   minimumScheduledDelayMs?: number;
 }
 
+/** Startup diagnostics stay silent on healthy launches and explain timeout-scale stalls. */
+const SLOW_STARTUP_WARNING_MS = 2_000;
+const STARTUP_PHASES = [
+  "connected_tokens",
+  "memory",
+  "skills",
+  "mcp",
+  "model_router",
+  "hydration",
+] as const;
+type StartupPhase = (typeof STARTUP_PHASES)[number];
+
 interface ChildToolContext {
   /** Scope that owns tasks created by this child. */
   ownerScopeId: ScopeId;
@@ -741,10 +753,13 @@ export class TurnRunner {
    * sees available skills before typing the first prompt.
    */
   async start(command: TurnStartCommand): Promise<TurnState> {
-    await ensureFreshConnectedTokens();
-    await this.ensureMemoryLoaded();
-    await this.ensureSkillsLoaded();
-    await this.ensureMcpServersConnected(command.mcpServers);
+    const startupStartedAt = performance.now();
+    const phaseTimings: Partial<Record<StartupPhase, number>> = {};
+    const measure = async (name: StartupPhase, work: () => Promise<void>): Promise<void> => {
+      const startedAt = performance.now();
+      await work();
+      phaseTimings[name] = performance.now() - startedAt;
+    };
     const mode = command.mode ?? this.config.mode ?? "auto";
     const startOptions = command.options;
     const state = command.state
@@ -753,7 +768,23 @@ export class TurnRunner {
           options: this.resolveTurnOptions(startOptions, command.state.options),
         }
       : createInitialTurnState(mode, this.resolveTurnOptions(startOptions));
-    await this.initializeModelRouter(state.options?.model);
+    // These phases populate disjoint runner/global state: connected-provider
+    // credentials, memory persistence/cache, MCP runtime, routing table, and
+    // skill context. Parent-agent construction below is their first consumer.
+    // Start skills last because its filesystem discovery is synchronous; the
+    // async token, memory, MCP, and routing work can make progress meanwhile.
+    const startupResults = await Promise.allSettled([
+      measure("connected_tokens", () => ensureFreshConnectedTokens()),
+      measure("memory", () => this.ensureMemoryLoaded()),
+      measure("mcp", () => this.ensureMcpServersConnected(command.mcpServers)),
+      measure("model_router", () => this.initializeModelRouter(state.options?.model)),
+      measure("skills", () => this.ensureSkillsLoaded()),
+    ]);
+    const startupFailure = startupResults.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (startupFailure) throw startupFailure.reason;
+    const hydrationStartedAt = performance.now();
     this.stateMachine = state.stateMachine;
     const recovery = this.taskManager.recover(
       state.tasks ?? [],
@@ -803,6 +834,8 @@ export class TurnRunner {
     this.initializeParentAgent();
     this.started = true;
     const hydratedState = this.requireRunnerState();
+    phaseTimings.hydration = performance.now() - hydrationStartedAt;
+    warnSlowStartup(phaseTimings, performance.now() - startupStartedAt);
     this.emit({ type: "turn_started", state: hydratedState });
     return hydratedState;
   }
@@ -3518,6 +3551,14 @@ export class TurnRunner {
 }
 
 const ROUTER_STEP_TEXT_LIMIT = 2_000;
+
+function warnSlowStartup(timings: Partial<Record<StartupPhase, number>>, totalMs: number): void {
+  if (totalMs < SLOW_STARTUP_WARNING_MS) return;
+  const phases = STARTUP_PHASES.map(
+    (phase) => `${phase}=${(timings[phase] ?? 0).toFixed(1)}ms`,
+  ).join(" ");
+  console.warn(`[duet-agent] slow startup: ${phases} total=${totalMs.toFixed(1)}ms`);
+}
 
 function routerStepObservation(
   message: Extract<AgentMessage, { role: "assistant" }>,

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -745,12 +745,16 @@ export class TurnRunner {
   }
 
   /**
-   * Set up a session before any turn runs. Loads memory and skills, then
-   * emits `turn_started` with the initial state (a fresh state, or the
-   * resumed state when `command.state` is provided). No agent work runs.
+   * Set up a session before any turn runs. Resolves the initial state (a fresh
+   * state, or the resumed state when `command.state` is provided), hydrates
+   * every independent resource concurrently, builds the parent agent, then
+   * emits `turn_started`. No agent work runs.
    *
-   * Callers (CLI/TUI/session managers) call this once on launch so the user
-   * sees available skills before typing the first prompt.
+   * `turn_started` is the readiness contract: it fires only once connected
+   * tokens, durable memory, skills, MCP tools, and the routing table are all
+   * live, so the first prompt never races a half-built runtime. Callers
+   * (CLI/TUI/session managers) call this once on launch so the user sees
+   * available skills before typing the first prompt.
    */
   async start(command: TurnStartCommand): Promise<TurnState> {
     const startupStartedAt = performance.now();

--- a/test/skill-context-reload.test.ts
+++ b/test/skill-context-reload.test.ts
@@ -1,9 +1,11 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect } from "bun:test";
+import type { Skill } from "@earendil-works/pi-coding-agent";
 import { SkillContext } from "../src/turn-runner/skill-context.js";
+import type { TurnRunnerConfig } from "../src/types/config.js";
 import { testIfDocker } from "./helpers/docker-only.js";
 
 let tempDir: string;
@@ -49,4 +51,51 @@ describe("SkillContext.reload", () => {
     expect(names).toContain("alpha");
     expect(names).toContain("beta");
   });
+
+  testIfDocker("concurrent ensureLoaded() callers share one discovery", async () => {
+    const counterPath = join(tempDir, "runs");
+    writeFileSync(counterPath, "");
+    const ctx = new SkillContext({
+      skills: [explicitSkill(`Use when !\`printf x >> ${counterPath}; printf ready\`.`)],
+      skillDiscovery: { includeDefaults: false, cwd: tempDir, skillPaths: [skillsDir] },
+    });
+
+    await Promise.all([ctx.ensureLoaded(), ctx.ensureLoaded()]);
+
+    // A second load would re-run every skill's description command, so the
+    // counter — not just the merged skill list — is what proves single-flight.
+    expect(readFileSync(counterPath, "utf-8")).toBe("x");
+    expect(ctx.getSkills()[0]?.description).toBe("Use when ready.");
+  });
+
+  testIfDocker("a reload racing an in-flight load lands on the newer snapshot", async () => {
+    const config: TurnRunnerConfig = {
+      skills: [explicitSkill("Use when !`sleep 1; printf slow`.")],
+      skillDiscovery: { includeDefaults: false, cwd: tempDir, skillPaths: [skillsDir] },
+    };
+    const ctx = new SkillContext(config);
+
+    // `load()` reads config.skills synchronously, so the in-flight load is
+    // pinned to the 1s description while the reload gets the instant one.
+    // Unqueued, the reload would settle first and the older, beta-less
+    // snapshot would assign last and silently win.
+    const loading = ctx.ensureLoaded();
+    config.skills = [explicitSkill("Use when !`printf fast`.")];
+    installSkill("beta", "second skill");
+    await Promise.all([loading, ctx.reload()]);
+
+    expect(ctx.getSkills().map((s) => s.name)).toContain("beta");
+    expect(ctx.getSkills()[0]?.description).toBe("Use when fast.");
+  });
 });
+
+function explicitSkill(description: string): Skill {
+  return {
+    name: "explicit",
+    description,
+    filePath: join(tempDir, "explicit.md"),
+    baseDir: tempDir,
+    sourceInfo: {} as Skill["sourceInfo"],
+    disableModelInvocation: false,
+  };
+}

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -102,6 +102,37 @@ describe("TurnRunner skills", () => {
     expect(skill?.description).toBe("Use when description expansion.");
   });
 
+  testIfDocker("expands independent skill descriptions concurrently", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "duet-skill-"));
+    tempDir = baseDir;
+    const skills = ["first", "second"].map((name) => ({
+      name,
+      description: `Use when !\`sleep 0.4; printf '${name} ready'\`.`,
+      filePath: join(baseDir, `${name}.md`),
+      baseDir,
+      sourceInfo: {} as Skill["sourceInfo"],
+      disableModelInvocation: false,
+    }));
+
+    const startedAt = performance.now();
+    const runner = new TurnRunner({
+      model: "anthropic:claude-opus-4-7",
+      cwd: process.cwd(),
+      skillDiscovery: { includeDefaults: false },
+      skills,
+    });
+    const loaded = await runner.getSkills();
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(loaded.slice(0, 2).map((skill) => skill.description)).toEqual([
+      "Use when first ready.",
+      "Use when second ready.",
+    ]);
+    // Each command sleeps for 400ms. Serial expansion takes at least 800ms;
+    // leave 300ms of process-spawn headroom while still distinguishing overlap.
+    expect(elapsedMs).toBeLessThan(700);
+  });
+
   testIfDocker(
     "injects skill metadata only (not full instructions) into the system prompt",
     async () => {

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -128,9 +128,10 @@ describe("TurnRunner skills", () => {
       "Use when first ready.",
       "Use when second ready.",
     ]);
-    // Each command sleeps for 400ms. Serial expansion takes at least 800ms;
-    // leave 300ms of process-spawn headroom while still distinguishing overlap.
-    expect(elapsedMs).toBeLessThan(700);
+    // Each command sleeps for 400ms, so serial expansion cannot finish under
+    // 800ms. Sit just below that floor: a regression to serial still fails,
+    // but spawn overhead on a loaded CI box cannot fake one.
+    expect(elapsedMs).toBeLessThan(780);
   });
 
   testIfDocker(


### PR DESCRIPTION
## Summary

`TurnRunner.start()` ran five initialization phases serially before emitting
`turn_started`: connected-token refresh, memory hydration, skill discovery,
MCP connection, and model-router init. On a resource-constrained VM this cold
start was measured at 218s in production (staging), which forced the
gateway's `turn_started` wait timeout up twice (30s → 90s → 300s) purely in
reaction, without ever fixing the actual cost.

- The five phases populate disjoint state (provider credentials, PGlite/cache
  state, skill context, MCP runtime, routing table) — confirmed by reading
  what each one touches, not assumed — so they now run via `Promise.allSettled`
  instead of five sequential `await`s. `turn_started` still waits for every
  phase to finish; nothing here relaxes that guarantee.
- Found a second, independent bottleneck along the way: skill metadata
  expansion ran shell commands serially with a 30s timeout each
  (`execFileSync`). Independent skills now expand concurrently (capped at 4);
  commands *within* one skill's description stay strictly ordered, since later
  commands can depend on earlier side effects.
- That change surfaced a real race in `SkillContext.reload()`: two concurrent
  loads could let an older discovery snapshot finish last and silently
  overwrite a newer one. Closed with a single-flight queue — a reload now
  waits on any in-flight load before starting its own.
- Per-phase timing is logged (`console.warn`) only when total startup exceeds
  2s, so a future cold-start stall is attributable without adding noise to
  every healthy launch.

Local measurements (this machine's Docker runtime, not a staging prediction):
a fresh PGlite database showed `memory: 997.8ms` of a `998.4ms` total —
memory hydration alone was effectively the entire cold-start cost in that
case.

## Correctness hazards deliberately not touched

- `turn_started` still waits for full initialization — emitting earlier would
  let the gateway send a prompt before the parent agent, MCP tools, memory
  pack, skills, and router exist.
- Token refresh is not deferred — imminently expiring connected-provider
  credentials may be required for the first model request.
- Memory probing/migration/context-pack construction stay in the critical
  path — the current contract promises first-turn memory readiness.
- Individual MCP server handshakes remain internally serial.

## Test plan

- [x] `bun run check-types`
- [x] `bun run lint` (0 warnings/errors)
- [x] `bun run build`
- [x] `bun run test` in Docker (this repo's actual CI-equivalent convention,
      not the raw `bun test`) — 1,279 tests, 0 failures, 3,821 assertions
- [x] New regression: two independent 400ms skill-description expansions
      overlap (836ms → 412–423ms) while preserving their exact expanded
      values
- [ ] Not yet measured: real staging cold-start improvement. That requires
      publishing this version, pinning it, and rebuilding the VM image —
      deliberately left for a separate release decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dR8UvP61TyGhpJnyCbaPt