### PR TITLE
fix(turn-runner): never spin on settlements held behind a foreground wait

### DIFF
--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -450,9 +450,9 @@ export class TurnRunner {
   private readonly parentInputWaiters = new Set<() => void>();
   /** Settlements already folded into the ledger during replacement/interrupt. */
   private readonly ignoredTaskSettlements = new Set<TaskId>();
-  /** Delivery posture for task-backed foreground bash calls. */
   /** Settled tasks taken off the task manager but not yet queued for the parent. */
   private readonly heldSettlements: TaskSettlement[] = [];
+  /** Delivery posture for task-backed foreground bash calls. */
   private readonly taskSettlementDelivery = new Map<
     TaskId,
     "foreground_pending" | "deliver" | "suppress"
@@ -1147,13 +1147,14 @@ export class TurnRunner {
     }
   }
 
-  private enqueueAvailableSettlements(): void {
-    // Always take settlements off the task manager, even while they are
-    // being held: a queue left non-empty reads as activity to
-    // `waitForSettlement`, and a parent loop idling behind a foreground
-    // wait then re-runs on every microtask without ever yielding to I/O —
-    // which is the only thing that could end the foreground wait. That
-    // starved a production runner for ten hours at 100% CPU.
+  /**
+   * Move every settlement off the task manager into the held buffer. The
+   * manager's queue must never keep a settlement the loop has already seen:
+   * `waitForSettlement` reads a non-empty queue as fresh activity, and a
+   * loop holding settlements behind a foreground wait would then re-run on
+   * every microtask without ever yielding to the I/O that ends the wait.
+   */
+  private holdSettledTasks(): void {
     for (
       let settlement = this.taskManager.nextSettled();
       settlement;
@@ -1161,6 +1162,10 @@ export class TurnRunner {
     ) {
       this.heldSettlements.push(settlement);
     }
+  }
+
+  private enqueueAvailableSettlements(): void {
+    this.holdSettledTasks();
     if ([...this.taskSettlementDelivery.values()].includes("foreground_pending")) return;
     const settlements: TaskSettlement[] = [];
     for (const settlement of this.heldSettlements.splice(0)) {
@@ -1214,13 +1219,7 @@ export class TurnRunner {
   }
 
   private discardStaleTaskSettlements(): void {
-    for (
-      let settlement = this.taskManager.nextSettled();
-      settlement;
-      settlement = this.taskManager.nextSettled()
-    ) {
-      this.heldSettlements.push(settlement);
-    }
+    this.holdSettledTasks();
     for (const settlement of this.heldSettlements.splice(0)) {
       this.stateTasks.delete(settlement.id);
       this.ignoredTaskSettlements.delete(settlement.id);

--- a/src/turn-runner/turn-runner.ts
+++ b/src/turn-runner/turn-runner.ts
@@ -451,6 +451,8 @@ export class TurnRunner {
   /** Settlements already folded into the ledger during replacement/interrupt. */
   private readonly ignoredTaskSettlements = new Set<TaskId>();
   /** Delivery posture for task-backed foreground bash calls. */
+  /** Settled tasks taken off the task manager but not yet queued for the parent. */
+  private readonly heldSettlements: TaskSettlement[] = [];
   private readonly taskSettlementDelivery = new Map<
     TaskId,
     "foreground_pending" | "deliver" | "suppress"
@@ -960,11 +962,7 @@ export class TurnRunner {
             if (this.queueParkNudgeIfDue(completion.status, pendingBeforeInput)) continue;
             break;
           }
-          if (this.parentInputs.length > 0) {
-            await this.taskManager.waitForSettlement();
-          } else {
-            await this.waitForLoopActivity();
-          }
+          await this.waitForLoopActivity();
           continue;
         }
 
@@ -1129,8 +1127,14 @@ export class TurnRunner {
     this.parentInputWaiters.clear();
   }
 
+  /**
+   * Block until something the loop has not seen yet arrives: a parent input
+   * or a task settlement. Only called once the loop has found nothing
+   * runnable, so whatever is already queued must not count as activity —
+   * `enqueueAvailableSettlements` keeps the task manager's queue drained for
+   * exactly that reason.
+   */
   private async waitForLoopActivity(): Promise<void> {
-    if (this.parentInputs.length > 0) return;
     let wake!: () => void;
     const parentInput = new Promise<void>((resolve) => {
       wake = resolve;
@@ -1144,13 +1148,22 @@ export class TurnRunner {
   }
 
   private enqueueAvailableSettlements(): void {
-    if ([...this.taskSettlementDelivery.values()].includes("foreground_pending")) return;
-    const settlements: TaskSettlement[] = [];
+    // Always take settlements off the task manager, even while they are
+    // being held: a queue left non-empty reads as activity to
+    // `waitForSettlement`, and a parent loop idling behind a foreground
+    // wait then re-runs on every microtask without ever yielding to I/O —
+    // which is the only thing that could end the foreground wait. That
+    // starved a production runner for ten hours at 100% CPU.
     for (
       let settlement = this.taskManager.nextSettled();
       settlement;
       settlement = this.taskManager.nextSettled()
     ) {
+      this.heldSettlements.push(settlement);
+    }
+    if ([...this.taskSettlementDelivery.values()].includes("foreground_pending")) return;
+    const settlements: TaskSettlement[] = [];
+    for (const settlement of this.heldSettlements.splice(0)) {
       const delivery = this.taskSettlementDelivery.get(settlement.id);
       this.taskSettlementDelivery.delete(settlement.id);
       if (delivery !== "suppress") settlements.push(settlement);
@@ -1206,6 +1219,9 @@ export class TurnRunner {
       settlement;
       settlement = this.taskManager.nextSettled()
     ) {
+      this.heldSettlements.push(settlement);
+    }
+    for (const settlement of this.heldSettlements.splice(0)) {
       this.stateTasks.delete(settlement.id);
       this.ignoredTaskSettlements.delete(settlement.id);
       this.taskSettlementDelivery.delete(settlement.id);

--- a/test/turn-runner-held-settlement.test.ts
+++ b/test/turn-runner-held-settlement.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import {
+  TurnRunner,
+  type AgentWorkerInput,
+  type AgentWorkerResult,
+} from "../src/turn-runner/turn-runner.js";
+import type { SubagentRun } from "../src/turn-runner/subagent.js";
+import type { TurnEvent } from "../src/types/protocol.js";
+import { createOutreachStateMachine } from "./helpers/turn-runner-protocol.js";
+
+/**
+ * A state-machine state runs as a task, so the parent loop idles waiting for
+ * activity while the state's agent works. Inside the state, the agent starts
+ * a slow command that outlives its foreground budget (it moves to the
+ * background) and then waits on another command in the foreground. The
+ * background one settles first, while the foreground wait is still open.
+ */
+class HeldSettlementRunner extends TurnRunner {
+  private workerCalls = 0;
+  foregroundResult?: AgentToolResult<unknown>;
+
+  constructor() {
+    super({
+      model: "anthropic:claude-opus-4-7",
+      memoryDbPath: false,
+      skillDiscovery: { includeDefaults: false },
+    });
+  }
+
+  protected override async runAgentWorker(input: AgentWorkerInput): Promise<AgentWorkerResult> {
+    this.workerCalls += 1;
+    if (this.workerCalls === 1) {
+      return {
+        control: { type: "select_state_machine_state", decision: { state: "research_prospect" } },
+        outcome: {
+          type: "complete",
+          status: "completed",
+          result: "Selected research state.",
+          state: { ...input.state, status: "completed" },
+        },
+      };
+    }
+    return {
+      control: { type: "none" },
+      outcome: {
+        type: "complete",
+        status: "completed",
+        result: "Parent done.",
+        state: {
+          ...input.state,
+          status: "completed",
+          agent: { ...input.state.agent, status: "completed" },
+        },
+      },
+    };
+  }
+
+  protected override createStateSubagentRun(): SubagentRun {
+    return {
+      prompt: async () => {
+        const bash = this.createTools("agent").tools.find((tool) => tool.name === "bash");
+        if (!bash) throw new Error("bash tool missing");
+        // Outlives its 50ms budget, so it converts to a background task and
+        // settles ~200ms later — while the next call is still waiting.
+        await bash.execute("bg", { command: "sleep 0.25 && printf bg-done", timeout: 0.05 });
+        this.foregroundResult = await bash.execute("fg", {
+          command: "sleep 0.5 && printf fg-done",
+          timeout: 5,
+        });
+        return { type: "complete", result: "State done." };
+      },
+      interrupt: () => undefined,
+      interruptedReason: () => undefined,
+      partialAssistantText: () => undefined,
+    };
+  }
+}
+
+describe("settlements held behind a foreground wait", () => {
+  test(
+    "a background settlement during a state's foreground wait does not stall the turn",
+    async () => {
+      const runner = new HeldSettlementRunner();
+      const events: TurnEvent[] = [];
+      runner.subscribe((event) => events.push(event));
+      await runner.start({ type: "start", mode: createOutreachStateMachine() });
+
+      const terminal = await runner.turn({
+        type: "prompt",
+        message: "Continue.",
+        behavior: "follow_up",
+      });
+
+      expect(terminal.type).toBe("complete");
+      expect(runner.foregroundResult?.content[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining("fg-done"),
+      });
+      const settled = events.filter((event) => event.type === "task_settled");
+      expect(settled.map((event) => event.settlement.status)).toEqual([
+        "completed",
+        "completed",
+        "completed",
+      ]);
+      await runner.dispose();
+    },
+    { timeout: 10_000 },
+  );
+});


### PR DESCRIPTION
## What broke

Prod session `jn754pgywqsmzc3rss8zv68fx98dbksn` (2026-08-28) sat in `running` for 10 hours with no events. The runner was alive the whole time, pinned at 100% of a core (leftover cgroup `cpu.stat`: 10.66h user time), until the gateway's interrupt timeout SIGKILLed it. It never read the steering prompt or the interrupt.

## Why

Four pieces of `turn-runner.ts` interact:

1. A state-machine state runs as a **task** (`startSubagentTask`), so the parent loop idles in `waitForLoopActivity()`.
2. The state's tools share `taskSettlementDelivery`; every foreground bash is `foreground_pending` for its wait budget.
3. A backgrounded bash settled while another bash was `foreground_pending`. `enqueueAvailableSettlements()` held it — by design — but returned **without draining** the task manager's `settlements` queue.
4. `waitForLoopActivity()` raced `taskManager.waitForSettlement()`, which returns immediately while that queue is non-empty. Wake → hold → wait → resolve → … forever, on the microtask queue. No I/O, timers, or child-exit callbacks ever ran, so the foreground could never clear and stdin RPC was never read.

The trigger — "start a slow command, it moves to the background, run another command in the foreground while it finishes" — is an ordinary model pattern; any state-machine session can hit it.

## Fix

- `enqueueAvailableSettlements` always drains the task manager into a runner-side `heldSettlements` buffer; the hold is on the runner, so the task manager's queue only ever means "not yet observed".
- The loop's two idle waits (`waitForSettlement()` when non-runnable inputs are queued, `waitForLoopActivity()` otherwise) become one wait that wakes on a parent input **or** a new settlement. The old `waitForSettlement()`-only branch also could not be woken by a steer command.
- `discardStaleTaskSettlements` clears the held buffer too.

## Test

`test/turn-runner-held-settlement.test.ts` — state runs a bash that outlives a 50ms budget (→ background), then a foreground bash; the background one settles during the foreground wait. On the unfixed code this hangs the entire `bun test` process (the spin starves Bun's own test timeout); fixed, it completes in ~1s.

Runner suites (60 tests across 8 files), `tsc --noEmit`, and `oxfmt --check` are green.

## Rollout

Needs a release + catalog bump in duet + fleet self-update. Companion gateway PR in `duet` makes the gateway reap a runner that never acks its input instead of returning 503 and leaving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdKxZiMCLsQXu7Zftvs1w4
