### PR TITLE
fix(memory): read hand-written memory files

### DIFF
--- a/src/memory/store/file.ts
+++ b/src/memory/store/file.ts
@@ -68,9 +68,23 @@ const KNOWN_KEY_ORDER = new Map<string, number>(KNOWN_KEYS.map((key, index) => [
 // parsed object preserves CRLF without exposing a formatting field to callers.
 const parsedLineEndings = new WeakMap<MemoryFileRecord, "\n" | "\r\n">();
 
-/** Identity a reader can supply for a file whose frontmatter names none. */
+/**
+ * Identity a reader can supply for a file whose frontmatter names none — a
+ * store derives it from the file itself (see `readEntry`). Each field is used
+ * only when the corresponding frontmatter key is absent.
+ */
 export interface DerivedMemoryIdentity {
+  /**
+   * Record id to adopt when the header has no `id`. Must satisfy the safe
+   * path-segment rule (`[A-Za-z0-9_-]+`) because ids name private archive
+   * directories; the store's derivation (`mem_` + a digest) always does.
+   */
   id: string;
+  /**
+   * Unix epoch milliseconds to adopt when the header has no `createdAt`;
+   * drives newest-first ordering and the observed date, so a store passes
+   * the file's own birth time.
+   */
   createdAt: number;
 }
 
@@ -105,6 +119,7 @@ export function parseMemoryFile(
   assertContent(content);
 
   const values = new Map<string, MemoryFrontmatterValue>();
+  const seenKeys = new Set<string>();
   for (const line of header.split(lineEnding)) {
     if (line.trim().length === 0 || line.trimStart().startsWith("#")) continue;
     const match = /^([^:]+):(?:\s+(.*))?$/.exec(line);
@@ -112,7 +127,8 @@ export function parseMemoryFile(
     const key = match[1]!.trim();
     const rawValue = (match[2] ?? "").trim();
     if (!KEY_PATTERN.test(key)) throw new Error(`Invalid frontmatter key: ${key}`);
-    if (values.has(key)) throw new Error(`Duplicate frontmatter key: ${key}`);
+    if (seenKeys.has(key)) throw new Error(`Duplicate frontmatter key: ${key}`);
+    seenKeys.add(key);
     if (key === "sourceFolder") {
       throw new Error("sourceFolder is private archive metadata and cannot enter a memory file");
     }
@@ -231,7 +247,15 @@ function splitInlineList(inner: string): string[] {
   const items: string[] = [];
   let current = "";
   let quote: '"' | "'" | undefined;
-  for (const char of inner) {
+  for (let index = 0; index < inner.length; index += 1) {
+    const char = inner[index]!;
+    // A backslash inside double quotes escapes the next character (JSON
+    // rules), so an escaped quote neither closes the string nor splits it.
+    if (quote === '"' && char === "\\") {
+      current += char + (inner[index + 1] ?? "");
+      index += 1;
+      continue;
+    }
     if (quote === undefined && (char === '"' || char === "'")) quote = char;
     else if (quote === char) quote = undefined;
     if (char === "," && quote === undefined) {

--- a/src/memory/store/file.ts
+++ b/src/memory/store/file.ts
@@ -68,15 +68,27 @@ const KNOWN_KEY_ORDER = new Map<string, number>(KNOWN_KEYS.map((key, index) => [
 // parsed object preserves CRLF without exposing a formatting field to callers.
 const parsedLineEndings = new WeakMap<MemoryFileRecord, "\n" | "\r\n">();
 
+/** Identity a reader can supply for a file whose frontmatter names none. */
+export interface DerivedMemoryIdentity {
+  id: string;
+  createdAt: number;
+}
+
 /**
- * Parse the canonical YAML-compatible subset used by memory files.
+ * Parse a memory file's frontmatter.
  *
- * Values are canonical JSON strings, finite decimal numbers, or inline
- * arrays of canonical JSON strings. Known keys stay in the order emitted by
- * {@link serializeMemoryFile}; unknown keys may follow them and use the same
- * scalar grammar.
+ * The grammar is deliberately loose on the way in and strict on the way out:
+ * agents write these files by hand as often as through `duet memory add`, so
+ * plain YAML scalars (`kind: note`), single or double quotes, inline arrays of
+ * plain items, blank and `#` lines, and any key order are all read. `version`
+ * defaults to 1 and `kind` to `note`; `id` and `createdAt` fall back to
+ * `derived` when the caller can name them from the file itself. Serializing
+ * always emits the one canonical form, so a rewritten file needs no leniency.
  */
-export function parseMemoryFile(text: string): MemoryFileRecord {
+export function parseMemoryFile(
+  text: string,
+  options: { derived?: DerivedMemoryIdentity } = {},
+): MemoryFileRecord {
   const lineEnding = text.startsWith("---\r\n")
     ? "\r\n"
     : text.startsWith("---\n")
@@ -93,37 +105,30 @@ export function parseMemoryFile(text: string): MemoryFileRecord {
   assertContent(content);
 
   const values = new Map<string, MemoryFrontmatterValue>();
-  let lastKnownIndex = -1;
-  let sawUnknown = false;
   for (const line of header.split(lineEnding)) {
-    const separator = line.indexOf(": ");
-    if (separator <= 0) throw new Error(`Invalid frontmatter line: ${line}`);
-    const key = line.slice(0, separator);
-    const rawValue = line.slice(separator + 2);
+    if (line.trim().length === 0 || line.trimStart().startsWith("#")) continue;
+    const match = /^([^:]+):(?:\s+(.*))?$/.exec(line);
+    if (!match) throw new Error(`Invalid frontmatter line: ${line}`);
+    const key = match[1]!.trim();
+    const rawValue = (match[2] ?? "").trim();
     if (!KEY_PATTERN.test(key)) throw new Error(`Invalid frontmatter key: ${key}`);
     if (values.has(key)) throw new Error(`Duplicate frontmatter key: ${key}`);
     if (key === "sourceFolder") {
       throw new Error("sourceFolder is private archive metadata and cannot enter a memory file");
     }
-
-    const knownIndex = KNOWN_KEY_ORDER.get(key);
-    if (knownIndex === undefined) {
-      sawUnknown = true;
-    } else {
-      if (sawUnknown || knownIndex <= lastKnownIndex) {
-        throw new Error(`Frontmatter key is out of canonical order: ${key}`);
-      }
-      lastKnownIndex = knownIndex;
-    }
+    if (rawValue.length === 0) continue;
     values.set(key, parseScalar(rawValue));
   }
 
-  const version = requireNumber(values, "version");
+  const version = optionalNumber(values, "version") ?? 1;
   if (version !== 1) throw new Error(`Unsupported memory file version: ${version}`);
-  const kind = requireString(values, "kind");
+  const kind = optionalString(values, "kind") ?? "note";
   if (kind !== "train" && kind !== "note") throw new Error(`Invalid memory kind: ${kind}`);
 
-  const createdAt = requireNumber(values, "createdAt");
+  const id = values.has("id") ? requireIdSegment(values, "id") : options.derived?.id;
+  if (id === undefined) throw new Error("Frontmatter id must be a string");
+  const createdAt = optionalNumber(values, "createdAt") ?? options.derived?.createdAt;
+  if (createdAt === undefined) throw new Error("Frontmatter createdAt must be a number");
   if (!Number.isSafeInteger(createdAt) || createdAt < 0) {
     throw new Error("createdAt must be a non-negative integer");
   }
@@ -134,7 +139,7 @@ export function parseMemoryFile(text: string): MemoryFileRecord {
 
   const record: MemoryFileRecord = {
     version: 1,
-    id: requireIdSegment(values, "id"),
+    id,
     kind,
     createdAt,
     ...optionalStringProperty(values, "headline"),
@@ -194,20 +199,50 @@ function parseScalar(rawValue: string): MemoryFrontmatterValue {
     const value = Number(rawValue);
     if (Number.isFinite(value) && String(value) === rawValue) return value;
   }
-  try {
-    const value: unknown = JSON.parse(rawValue);
-    if (typeof value === "string" && JSON.stringify(value) === rawValue) return value;
-    if (
-      Array.isArray(value) &&
-      value.every((item): item is string => typeof item === "string") &&
-      `[${value.map((item) => JSON.stringify(item)).join(", ")}]` === rawValue
-    ) {
-      return value;
-    }
-  } catch {
-    // The grammar error below is more useful than JSON's parser diagnostic.
+  const quoted = unquote(rawValue);
+  if (quoted !== undefined) return quoted;
+  if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+    const inner = rawValue.slice(1, -1).trim();
+    if (inner.length === 0) return [];
+    return splitInlineList(inner).map((item) => unquote(item) ?? item);
   }
-  throw new Error(`Unsupported frontmatter scalar: ${rawValue}`);
+  // Anything else is a plain YAML scalar: read it as the text it is.
+  return rawValue;
+}
+
+function unquote(value: string): string | undefined {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      // Not valid JSON: fall through to the literal text between the quotes.
+    }
+    return value.slice(1, -1);
+  }
+  if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replaceAll("''", "'");
+  }
+  return undefined;
+}
+
+/** Split `a, "b, c", 'd'` on the commas that sit outside quotes. */
+function splitInlineList(inner: string): string[] {
+  const items: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+  for (const char of inner) {
+    if (quote === undefined && (char === '"' || char === "'")) quote = char;
+    else if (quote === char) quote = undefined;
+    if (char === "," && quote === undefined) {
+      items.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  items.push(current.trim());
+  return items.filter((item) => item.length > 0);
 }
 
 function serializeScalar(value: MemoryFrontmatterValue): string {
@@ -224,12 +259,6 @@ function serializeScalar(value: MemoryFrontmatterValue): string {
   throw new Error("Frontmatter values must be strings, numbers, or string arrays");
 }
 
-function requireNumber(values: Map<string, MemoryFrontmatterValue>, key: string): number {
-  const value = values.get(key);
-  if (typeof value !== "number") throw new Error(`Frontmatter ${key} must be a number`);
-  return value;
-}
-
 function optionalNumber(
   values: Map<string, MemoryFrontmatterValue>,
   key: string,
@@ -240,9 +269,21 @@ function optionalNumber(
   return value;
 }
 
-function requireString(values: Map<string, MemoryFrontmatterValue>, key: string): string {
+function optionalString(
+  values: Map<string, MemoryFrontmatterValue>,
+  key: string,
+): string | undefined {
   const value = values.get(key);
+  if (value === undefined) return undefined;
+  // A number written where text is expected reads as its text.
+  if (typeof value === "number") return String(value);
   if (typeof value !== "string") throw new Error(`Frontmatter ${key} must be a string`);
+  return value;
+}
+
+function requireString(values: Map<string, MemoryFrontmatterValue>, key: string): string {
+  const value = optionalString(values, key);
+  if (value === undefined) throw new Error(`Frontmatter ${key} must be a string`);
   return value;
 }
 
@@ -283,8 +324,10 @@ function optionalStringArrayProperty(
   values: Map<string, MemoryFrontmatterValue>,
   key: "tags",
 ): Partial<Pick<MemoryFileRecord, "tags">> {
-  const value = values.get(key);
-  if (value === undefined) return {};
+  const raw = values.get(key);
+  if (raw === undefined) return {};
+  // A single plain scalar is a one-item list.
+  const value = typeof raw === "string" ? [raw] : raw;
   if (!Array.isArray(value) || value.some((item) => item.trim().length === 0)) {
     throw new Error(`Frontmatter ${key} must be a string array without blank items`);
   }

--- a/src/memory/store/index.ts
+++ b/src/memory/store/index.ts
@@ -19,6 +19,7 @@ export {
 export {
   deleteEntry,
   listStore,
+  listStoreTolerant,
   readEntry,
   updateEntry,
   writeEntry,

--- a/src/memory/store/store.ts
+++ b/src/memory/store/store.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import * as fileSystem from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
@@ -157,8 +157,25 @@ async function readParsedEntry(
   if (!status.isFile()) throw new Error(`Memory entry is not a regular file: ${path}`);
   const handle = await fileSystem.open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
   const text = await handle.readFile("utf8").finally(() => handle.close());
-  const record = parseMemoryFile(text);
+  const record = parseMemoryFile(text, { derived: derivedIdentity(storeDir, slug, status) });
   return { stored: toStoredMemory(storeDir, slug, record), record };
+}
+
+// A hand-written file names no id or creation time. Its identity is then a
+// function of where it lives: stable across reads, distinct across stores that
+// share a slug, and written into the file the first time it is re-serialized.
+function derivedIdentity(
+  storeDir: string,
+  slug: string,
+  status: { birthtimeMs: number; mtimeMs: number },
+) {
+  const digest = createHash("sha256")
+    .update(`${resolve(storeDir)}\n${slug}`)
+    .digest("base64url");
+  return {
+    id: `mem_${digest.slice(0, 12)}`,
+    createdAt: Math.round(status.birthtimeMs > 0 ? status.birthtimeMs : status.mtimeMs),
+  };
 }
 
 function toStoredMemory(storeDir: string, slug: string, record: MemoryFileRecord): StoredMemory {

--- a/test/fixtures/memory-store/hand-written-by-agent.md
+++ b/test/fixtures/memory-store/hand-written-by-agent.md
@@ -1,0 +1,9 @@
+---
+version: 1
+kind: note
+priority: high
+source: imported-family-records
+---
+# Family domain boundaries
+
+- This folder holds the family records; the agent answers only from them.

--- a/test/memory-store-filesystem.test.ts
+++ b/test/memory-store-filesystem.test.ts
@@ -206,3 +206,42 @@ function storedView(storeDir: string, input: MemoryEntryInput) {
     content: input.content,
   };
 }
+
+describe("hand-written memory files in a store", () => {
+  // The verbatim shape an agent wrote on a production VM (2026-08-28). The
+  // store must read it as-is, give it a stable identity, and make that
+  // identity durable the first time it rewrites the file.
+  testIfDocker("reads the file unchanged and pins its identity on first rewrite", async () => {
+    const root = await fileSystem.mkdtemp(join(tmpdir(), "duet-memory-store-hand-written-"));
+    const storeDir = join(root, "memories");
+    try {
+      await fileSystem.mkdir(storeDir);
+      await fileSystem.copyFile(
+        join(fixtures, "hand-written-by-agent.md"),
+        join(storeDir, "family-domain-boundaries.md"),
+      );
+
+      const first = await readEntry(storeDir, "family-domain-boundaries");
+      const second = await readEntry(storeDir, "family-domain-boundaries");
+
+      expect(first).toMatchObject({
+        slug: "family-domain-boundaries",
+        kind: "note",
+        content:
+          "# Family domain boundaries\n\n- This folder holds the family records; the agent answers only from them.\n",
+      });
+      expect(first.id).toMatch(/^mem_[A-Za-z0-9_-]{12}$/);
+      expect(first.createdAt).toBeGreaterThan(0);
+      expect(second).toEqual(first);
+      expect((await listStore(storeDir)).map((entry) => entry.id)).toEqual([first.id]);
+
+      await updateEntry(storeDir, "family-domain-boundaries", "Rewritten body.\n");
+      const raw = await fileSystem.readFile(join(storeDir, "family-domain-boundaries.md"), "utf8");
+      expect(raw.startsWith(`---\nversion: 1\nid: "${first.id}"\nkind: "note"\n`)).toBe(true);
+      expect(raw).toContain('priority: "high"\nsource: "imported-family-records"\n');
+      expect((await readEntry(storeDir, "family-domain-boundaries")).id).toBe(first.id);
+    } finally {
+      await fileSystem.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/memory-store.test.ts
+++ b/test/memory-store.test.ts
@@ -127,3 +127,78 @@ describe("memory identifier containment", () => {
     );
   });
 });
+
+describe("hand-written memory files", () => {
+  // What an agent writes with a heredoc instead of `duet memory add`: plain
+  // YAML scalars, keys in whatever order came to mind, no id, no createdAt.
+  const handWritten = [
+    "---",
+    "kind: note",
+    "priority: high",
+    "source: imported-paige-channel",
+    "tags: [reading, books]",
+    "version: 1",
+    "---",
+    "# Paige domain facts\n",
+  ].join("\n");
+
+  test("accepts plain scalars in any key order, deriving id and createdAt from the file", () => {
+    const record = parseMemoryFile(handWritten, {
+      derived: { id: "mem_paige-domain-facts", createdAt: 1_787_934_002_586 },
+    });
+
+    expect(record).toEqual({
+      version: 1,
+      id: "mem_paige-domain-facts",
+      kind: "note",
+      createdAt: 1_787_934_002_586,
+      priority: "high",
+      source: "imported-paige-channel",
+      tags: ["reading", "books"],
+      content: "# Paige domain facts\n",
+    });
+    // Re-serializing writes the canonical form, so the next reader needs no derivation.
+    expect(serializeMemoryFile(record)).toBe(
+      [
+        "---",
+        "version: 1",
+        'id: "mem_paige-domain-facts"',
+        'kind: "note"',
+        "createdAt: 1787934002586",
+        'priority: "high"',
+        'source: "imported-paige-channel"',
+        'tags: ["reading", "books"]',
+        "---",
+        "# Paige domain facts\n",
+      ].join("\n"),
+    );
+  });
+
+  test("defaults version and kind, and keeps quoted and plain scalars equivalent", () => {
+    const record = parseMemoryFile(
+      "---\nheadline: 'Single quoted'\nnote: plain text with: colon\n---\nbody\n",
+      {
+        derived: { id: "mem_x", createdAt: 5 },
+      },
+    );
+    expect(record).toMatchObject({
+      version: 1,
+      kind: "note",
+      headline: "Single quoted",
+      extra: { note: "plain text with: colon" },
+    });
+  });
+
+  test("still refuses a file with no frontmatter at all, and one that names an unknown kind", () => {
+    expect(() =>
+      parseMemoryFile("# just markdown\n", { derived: { id: "mem_x", createdAt: 5 } }),
+    ).toThrow("frontmatter delimiter");
+    expect(() =>
+      parseMemoryFile("---\nkind: dream\n---\nbody\n", { derived: { id: "mem_x", createdAt: 5 } }),
+    ).toThrow("Invalid memory kind: dream");
+  });
+
+  test("without a derivation source, id and createdAt remain required", () => {
+    expect(() => parseMemoryFile("---\nkind: note\n---\nbody\n")).toThrow("Frontmatter id");
+  });
+});

--- a/test/memory-store.test.ts
+++ b/test/memory-store.test.ts
@@ -202,3 +202,46 @@ describe("hand-written memory files", () => {
     expect(() => parseMemoryFile("---\nkind: note\n---\nbody\n")).toThrow("Frontmatter id");
   });
 });
+
+describe("the memory file that broke a workspace", () => {
+  // Verbatim shape of the files an agent wrote by hand on a production VM on
+  // 2026-08-28: plain scalars, no id, no createdAt. It must parse as-is.
+  test("parses without any edits once the store supplies an identity", async () => {
+    const text = await readFile(fixturePath("hand-written-by-agent.md"), "utf8");
+
+    const record = parseMemoryFile(text, { derived: { id: "mem_derived", createdAt: 7 } });
+
+    expect(record).toEqual({
+      version: 1,
+      id: "mem_derived",
+      kind: "note",
+      createdAt: 7,
+      priority: "high",
+      source: "imported-family-records",
+      content:
+        "# Family domain boundaries\n\n- This folder holds the family records; the agent answers only from them.\n",
+    });
+  });
+});
+
+describe("frontmatter edge cases", () => {
+  test("round-trips an escaped quote inside an inline array", () => {
+    const record = parseMemoryFile(
+      serializeMemoryFile({
+        version: 1,
+        id: "mem_q",
+        kind: "note",
+        createdAt: 1,
+        tags: ['a"b', "c, d"],
+        content: "body\n",
+      }),
+    );
+    expect(record.tags).toEqual(['a"b', "c, d"]);
+  });
+
+  test("a blank-valued key still counts toward the duplicate check", () => {
+    expect(() =>
+      parseMemoryFile("---\nkind:\nkind: train\nid: mem_x\ncreatedAt: 1\n---\nbody\n"),
+    ).toThrow("Duplicate frontmatter key: kind");
+  });
+});


### PR DESCRIPTION
## Why

A Duet agent wrote 14 memory files by hand (`kind: note`, `priority: high`, no `id`/`createdAt`). `parseMemoryFile` threw `Unsupported frontmatter scalar: note`; on the VM the gateway's strict store listing turned that into a failed sync cycle every 5 minutes and an "unhealthy" workspace whose Files pane and apps refused to open (prod `dan-test`, 2026-08-30). The gateway side is fixed separately (quarantine + sync isolation, duet `staging`); this makes the parser itself tolerant.

## What

- Plain YAML scalars, single/double quotes, inline arrays of plain items, blank and `#` lines, any key order.
- `version` defaults to 1, `kind` to `note`; a number where text is expected reads as its text; a bare `tags` scalar is a one-item list.
- `id`/`createdAt` fall back to a `derived` identity the store computes from the file (sha256 of store path + slug; file birth time), written into the file on first re-serialize. Without a derivation source both stay required, so `memory add` output is validated as before.
- Serialization is unchanged: still one canonical form.

## Tests

`test/memory-store.test.ts` — 4 new cases (plain scalars in any order with derivation; defaults + quoting; still refuses no-frontmatter and unknown kind; strict without derivation). Memory-store, filesystem, and cli-memory-add suites green locally; `check-types`, `lint`, `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxQrMnWjQRiAZGkmgQZZer